### PR TITLE
fix: use set_issue_status for Jira Server/DC compatibility

### DIFF
--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -189,7 +189,18 @@ def do_transition(ctx, issue_key: str, status_name: str,
         # Perform transition - API uses target status name (not transition name/ID)
         # set_issue_status handles the transition ID lookup internally
         target_status = _get_to_status(matching)
-        client.set_issue_status(issue_key, target_status, fields=fields if fields else None)
+
+        # Build update dict for comment if provided
+        update = None
+        if comment:
+            update = {"comment": [{"add": {"body": comment}}]}
+
+        client.set_issue_status(
+            issue_key,
+            target_status,
+            fields=fields if fields else None,
+            update=update
+        )
 
         if ctx.obj['quiet']:
             print(issue_key)


### PR DESCRIPTION
## Summary
- Fix transition script failing on Jira Server/DC with `issue_transition() got an unexpected keyword argument 'fields'`
- Replace `issue_transition()` call with `set_issue_status()` which properly handles the API differences between Jira Cloud and Server/DC
- The `set_issue_status()` method internally looks up the transition ID from the target status name

## Problem
The `jira-transition.py` script was calling:
```python
client.issue_transition(issue_key, matching['id'], fields=..., comment=...)
```

But the `atlassian-python-api` library's `issue_transition()` method has signature `(self, issue_key: str, status: str)` and doesn't accept `fields` or `comment` kwargs.

## Solution
Use `set_issue_status()` instead, which accepts `fields` and `update` parameters and handles the transition correctly.

## Test plan
- [x] Tested transition on Jira Server/DC instance (DHLGW-1470)
- [ ] Test on Jira Cloud instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)