### PR TITLE
fix(jira-link): use correct API format for create_issue_link

### DIFF
--- a/skills/jira-communication/scripts/utility/jira-link.py
+++ b/skills/jira-communication/scripts/utility/jira-link.py
@@ -80,11 +80,11 @@ def create(ctx, from_key: str, to_key: str, link_type: str, dry_run: bool):
         return
 
     try:
-        client.create_issue_link(
-            type=link_type,
-            inwardIssue=to_key,
-            outwardIssue=from_key
-        )
+        client.create_issue_link({
+            "type": {"name": link_type},
+            "inwardIssue": {"key": to_key},
+            "outwardIssue": {"key": from_key}
+        })
 
         if ctx.obj['json']:
             format_output({


### PR DESCRIPTION
## Summary

- Fix `jira-link.py create` command which was failing with `Jira.create_issue_link() got an unexpected keyword argument 'type'`

## Root Cause

The `atlassian-python-api` library's `create_issue_link` method expects a single dictionary parameter with nested objects, not keyword arguments.

## Changes

```python
# Before (broken)
client.create_issue_link(
    type=link_type,
    inwardIssue=to_key,
    outwardIssue=from_key
)

# After (fixed)
client.create_issue_link({
    "type": {"name": link_type},
    "inwardIssue": {"key": to_key},
    "outwardIssue": {"key": from_key}
})
```

## Test Plan

- [x] Tested locally: `jira-link.py create PROJ-123 PROJ-456 -t "Cause"` now works