### PR TITLE
fix: add working directory note and fix script tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This is an **Agent Skill** following the [open standard](https://agentskills.io)
 
 ## Quick Start
 
+> **Note:** Run commands from `skills/jira-communication/`, or prefix paths with `skills/jira-communication/` from the repo root.
+
 ```bash
 # Search issues
 uv run scripts/core/jira-search.py query "project = PROJ AND status = 'In Progress'"
@@ -69,10 +71,12 @@ uv run scripts/workflow/jira-create.py issue PROJ "Fix bug" --type Bug --priorit
 
 | Script | Commands | Usage |
 |--------|----------|-------|
+| `jira-setup.py` | (default) | Interactive credential setup |
 | `jira-validate.py` | (default) | Validate environment setup |
 | `jira-issue.py` | get, update | Get and update issues |
 | `jira-search.py` | query | JQL search |
 | `jira-worklog.py` | add, list | Time tracking |
+| `jira-attachment.py` | download | Download issue attachments |
 
 ### Workflow Operations (scripts/workflow/)
 
@@ -208,10 +212,6 @@ uv run scripts/utility/jira-link.py create PROJ-123 PROJ-456 --type "Blocks" --d
 ## Related Skills
 
 - **jira-syntax** - Jira wiki markup validation and templates (unchanged)
-
-## Migration
-
-Migrating from v2.x (MCP-based)? See [Migration Guide](skills/jira-communication/references/migration-guide.md).
 
 ## Troubleshooting
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,6 +7,8 @@ description: "Agent Skill: Comprehensive Jira integration through lightweight Py
 
 Comprehensive Jira integration through lightweight Python CLI scripts.
 
+> **Note:** Run scripts from `skills/jira-communication/`, or use full paths from repo root.
+
 ## Auto-Trigger Patterns
 
 **AUTOMATICALLY ACTIVATE** when user mentions:
@@ -39,13 +41,14 @@ Comprehensive Jira integration through lightweight Python CLI scripts.
 | `jira-issue.py` | Get/update issue details |
 | `jira-search.py` | Search with JQL |
 | `jira-worklog.py` | Time tracking |
-| `jira-comment.py` | Comments |
+| `jira-attachment.py` | Download attachments |
 
 ### Workflow Operations
 | Script | Purpose |
 |--------|---------|
 | `jira-create.py` | Create issues |
 | `jira-transition.py` | Change status |
+| `jira-comment.py` | Comments |
 | `jira-link.py` | Issue links |
 | `jira-sprint.py` | Sprint management |
 | `jira-board.py` | Board operations |


### PR DESCRIPTION
- Add note about running from skills/jira-communication/ directory
- Add missing jira-setup.py and jira-attachment.py to tables
- Move jira-comment.py to correct category (workflow)
- Remove outdated migration section from README

Noticed Claude was having a hard time finding the scripts