### PR TITLE
feat: add UserPromptSubmit hook for Jira issue detection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira-integration",
-  "version": "3.1.6",
-  "description": "Comprehensive Jira integration with script-based architecture",
+  "version": "3.2.0",
+  "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",
   "author": {
@@ -20,5 +20,6 @@
   "skills": [
     "./skills/jira-communication",
     "./skills/jira-syntax"
-  ]
+  ],
+  "hooks": "./hooks/hooks.json"
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Jira integration hooks for automatic issue detection and context",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/detect_jira_issues.py",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/detect_jira_issues.py
+++ b/scripts/detect_jira_issues.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook to detect Jira issue keys in user messages.
+Provides context about detected issues and suggests using the jira skill.
+"""
+
+import sys
+import re
+import json
+
+# Jira issue key pattern: PROJECT-123
+# Common project prefixes for Netresearch
+ISSUE_KEY_PATTERN = r"\b([A-Z][A-Z0-9_]+-\d+)\b"
+
+# Jira URL patterns
+JIRA_URL_PATTERNS = [
+    r"https?://jira\.[^/]+/browse/([A-Z][A-Z0-9_]+-\d+)",
+    r"https?://[^/]+\.atlassian\.net/browse/([A-Z][A-Z0-9_]+-\d+)",
+]
+
+
+def extract_issue_keys(text: str) -> list[str]:
+    """Extract unique Jira issue keys from text."""
+    keys = set()
+
+    # Direct issue keys
+    for match in re.finditer(ISSUE_KEY_PATTERN, text):
+        keys.add(match.group(1))
+
+    # Issue keys from URLs
+    for pattern in JIRA_URL_PATTERNS:
+        for match in re.finditer(pattern, text):
+            keys.add(match.group(1))
+
+    return sorted(keys)
+
+
+def main():
+    try:
+        input_data = sys.stdin.read()
+    except Exception:
+        return
+
+    if not input_data:
+        return
+
+    # Parse user prompt
+    try:
+        data = json.loads(input_data)
+        prompt = data.get("prompt", "") or data.get("content", "") or data.get("message", "")
+    except (json.JSONDecodeError, TypeError):
+        prompt = input_data
+
+    if not prompt:
+        return
+
+    # Extract issue keys
+    issue_keys = extract_issue_keys(prompt)
+
+    if issue_keys:
+        keys_str = ", ".join(issue_keys)
+        print(f"""<system-reminder>
+Detected Jira issue reference(s): {keys_str}
+
+The jira-integration skill can help:
+- Fetch issue details with jira_get_issue
+- Search related issues with jira_search
+- Update issue status/comments
+- Use Jira wiki markup for formatting
+
+Use the mcp-atlassian MCP server for API operations if available.
+</system-reminder>""")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds UserPromptSubmit hook that detects Jira issue keys in user messages
- Auto-detects both direct keys (PROJ-123) and Jira URLs
- Provides context about available jira-integration features

## Changes

- `hooks/hooks.json`: UserPromptSubmit hook configuration
- `scripts/detect_jira_issues.py`: Issue key detection script
- `.claude-plugin/plugin.json`: Added hooks, bumped to v3.2.0

## Test Plan

- [ ] Type a message containing "PROJ-123" and verify detection
- [ ] Test with Jira URL and verify key extraction
- [ ] Verify system-reminder provides helpful context