### PR TITLE
fix: remove duplicate hooks declaration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-integration",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",
@@ -20,6 +20,5 @@
   "skills": [
     "./skills/jira-communication",
     "./skills/jira-syntax"
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }


### PR DESCRIPTION
## Summary
- Remove explicit hooks declaration from plugin.json
- Bump version to 3.2.1

## Problem
Claude Code now auto-loads `hooks/hooks.json` when the file exists in the plugin directory. Having it also declared in plugin.json causes a duplicate hooks file error:
```
Error: Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file
```

## Solution
Remove the `hooks` field from plugin.json since hooks are auto-discovered.

## Test plan
- [ ] Reinstall plugin and verify no duplicate hooks error in logs