### PR TITLE
fix(release): add workflow to build Claude Desktop compatible skill packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Build full plugin package
+        run: |
+          mkdir -p dist
+          zip -r "dist/jira-integration-plugin-${{ steps.version.outputs.VERSION }}.zip" . \
+            -x ".git/*" \
+            -x ".github/*" \
+            -x "dist/*" \
+            -x "*.pyc" \
+            -x "__pycache__/*" \
+            -x ".DS_Store"
+
+      - name: Build jira-communication skill package
+        run: |
+          SKILL_DIR="skills/jira-communication"
+          TEMP_DIR=$(mktemp -d)
+
+          # Copy skill contents to temp dir (flat structure for Claude Desktop)
+          cp "$SKILL_DIR/SKILL.md" "$TEMP_DIR/"
+          cp -r "$SKILL_DIR/scripts" "$TEMP_DIR/"
+          cp -r "$SKILL_DIR/references" "$TEMP_DIR/"
+          cp LICENSE "$TEMP_DIR/"
+
+          # Create ZIP from temp dir
+          cd "$TEMP_DIR"
+          zip -r "$GITHUB_WORKSPACE/dist/jira-communication-skill-${{ steps.version.outputs.VERSION }}.zip" .
+          cd -
+          rm -rf "$TEMP_DIR"
+
+      - name: Build jira-syntax skill package
+        run: |
+          SKILL_DIR="skills/jira-syntax"
+          TEMP_DIR=$(mktemp -d)
+
+          # Copy skill contents to temp dir (flat structure for Claude Desktop)
+          cp "$SKILL_DIR/SKILL.md" "$TEMP_DIR/"
+          cp -r "$SKILL_DIR/scripts" "$TEMP_DIR/"
+          cp -r "$SKILL_DIR/templates" "$TEMP_DIR/"
+          cp -r "$SKILL_DIR/references" "$TEMP_DIR/"
+          cp LICENSE "$TEMP_DIR/"
+
+          # Create ZIP from temp dir
+          cd "$TEMP_DIR"
+          zip -r "$GITHUB_WORKSPACE/dist/jira-syntax-skill-${{ steps.version.outputs.VERSION }}.zip" .
+          cd -
+          rm -rf "$TEMP_DIR"
+
+      - name: List packages
+        run: ls -la dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/jira-integration-plugin-${{ steps.version.outputs.VERSION }}.zip
+            dist/jira-communication-skill-${{ steps.version.outputs.VERSION }}.zip
+            dist/jira-syntax-skill-${{ steps.version.outputs.VERSION }}.zip
+          generate_release_notes: true
+          body: |
+            ## Downloads
+
+            | Package | Description |
+            |---------|-------------|
+            | `jira-integration-plugin-${{ steps.version.outputs.VERSION }}.zip` | Full plugin with both skills (for multi-skill compatible tools) |
+            | `jira-communication-skill-${{ steps.version.outputs.VERSION }}.zip` | Jira API operations skill (Claude Desktop compatible) |
+            | `jira-syntax-skill-${{ steps.version.outputs.VERSION }}.zip` | Jira wiki markup syntax skill (Claude Desktop compatible) |
+
+            **Claude Desktop users**: Download the individual skill packages (`jira-communication-skill` or `jira-syntax-skill`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-14 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-22 -->
 
 # AGENTS.md (root)
 
@@ -24,6 +24,15 @@ uv run skills/jira-communication/scripts/core/jira-validate.py --help
 
 ## Release workflow
 
+Releases are automated via GitHub Actions (`.github/workflows/release.yml`). On tag push, it creates 3 packages:
+
+| Package | Description |
+|---------|-------------|
+| `jira-integration-plugin-vX.X.X.zip` | Full plugin (multi-skill compatible tools) |
+| `jira-communication-skill-vX.X.X.zip` | Standalone skill (Claude Desktop compatible) |
+| `jira-syntax-skill-vX.X.X.zip` | Standalone skill (Claude Desktop compatible) |
+
+**Steps:**
 1. Check commits since last release: `git log --oneline v<last>..HEAD`
 2. Backfill any missing CHANGELOG entries
 3. Update CHANGELOG.md with new version entry
@@ -31,7 +40,8 @@ uv run skills/jira-communication/scripts/core/jira-validate.py --help
 5. Commit: `git commit -m "chore: release v<version>"`
 6. Tag: `git tag v<version>`
 7. Push: `git push origin main --tags`
-8. Create GitHub release: `gh release create v<version>` (notes from CHANGELOG)
+
+The GitHub Action automatically creates the release with all 3 download packages.
 
 ## Index of scoped AGENTS.md
 


### PR DESCRIPTION
Addresses #11: Claude Desktop requires exactly one SKILL.md per ZIP.

The new release workflow creates 3 packages:
- jira-integration: Full plugin (for multi-skill compatible tools)
- jira-communication: Standalone skill (Claude Desktop compatible)
- jira-syntax: Standalone skill (Claude Desktop compatible)