### PR TITLE
fix: align SKILL.md description with quality standard

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jira-communication
-description: "Use when interacting with Jira issues - searching, creating, updating, transitioning, commenting, logging work, or downloading attachments. Auto-triggers on Jira URLs and issue keys (PROJ-123)."
+description: "Use when interacting with Jira issues - searching, creating, updating, transitioning, commenting, logging work, downloading attachments, managing sprints, boards, issue links, fields, or users. Auto-triggers on Jira URLs and issue keys (PROJ-123)."
 allowed-tools: Bash(uv run scripts/*:*) Read
 ---
 

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jira-syntax
-description: "Use when writing Jira descriptions or comments, converting Markdown to Jira wiki markup, or validating Jira syntax before submission."
+description: "Use when writing Jira descriptions or comments, converting Markdown to Jira wiki markup, using templates (bug reports, feature requests), or validating Jira syntax before submission."
 allowed-tools: Bash(scripts/validate-jira-syntax.sh:*) Read
 ---
 


### PR DESCRIPTION
## Summary
- Fix SKILL.md description to use "Use when..." trigger format
- Remove "Agent Skill:" prefix and "By Netresearch." suffix
- Remove workflow summaries from description

Addresses netresearch/claude-code-marketplace#32