### PR TITLE
fix: clean frontmatter and fix description

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: jira-communication
 description: "Use when interacting with Jira issues - searching, creating, updating, transitioning, commenting, logging work, downloading attachments, managing sprints, boards, issue links, fields, or users. Auto-triggers on Jira URLs and issue keys (PROJ-123)."
-allowed-tools: Bash(uv run scripts/*:*) Read
 ---
 
 # Jira Communication

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: jira-syntax
 description: "Use when writing Jira descriptions or comments, converting Markdown to Jira wiki markup, using templates (bug reports, feature requests), or validating Jira syntax before submission."
-allowed-tools: Bash(scripts/validate-jira-syntax.sh:*) Read
 ---
 
 # Jira Syntax Validation Skill


### PR DESCRIPTION
## Summary
- Clean SKILL.md frontmatter (remove `allowed-tools` field from both skills)

## Context
Per writing-skills standards, SKILL.md frontmatter should only contain `name` and `description`.