### PR TITLE
docs(jira-communication): add subtask type naming and assign-to-me guidance

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -72,10 +72,10 @@ Never derive the Jira username from a display name or email address — they oft
 
 ```bash
 # Get current user's username
-uv run scripts/utility/jira-user.py --json me   # → use the "name" field
+uv run scripts/utility/jira-user.py --quiet me   # → returns username or account ID
 
 # Assign an issue to yourself
-ME=$(uv run scripts/utility/jira-user.py --json me | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])")
+ME=$(uv run scripts/utility/jira-user.py --quiet me)
 uv run scripts/core/jira-issue.py update PROJ-123 --assignee "$ME"
 ```
 


### PR DESCRIPTION
## Summary

- **Subtask types on Jira Server/DC**: Subtask issue types are prefixed with `Sub: ` (e.g. `Sub: Task`, `Sub: Bug`). Using plain `Task` or `Sub-task` with `--parent` causes a hard failure (`Issue type is not a sub-task` / `Invalid issue type`). Added a dedicated section with correct and incorrect examples.
- **Assign to me**: Never derive the Jira username from a display name or email — they frequently differ (e.g. display name `Axel Seemann` → actual username `axel.kummer`). Added a pattern that uses `jira-user.py me` to resolve the authenticated user's username before passing it to `--assignee`.

Both patterns were discovered from real command failures and are already handled correctly by the existing scripts — this PR just makes the guidance explicit in SKILL.md so the agent doesn't have to learn it the hard way again.

## Test plan

- [ ] Verify `jira-user.py me` returns a `name` field on both Cloud and Server profiles
- [ ] Verify `--type "Sub: Task" --parent PROJ-X` creates a subtask successfully on a Server instance
- [ ] Review SKILL.md rendering looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)