### PR TITLE
ci: migrate Python CI to shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,63 +6,22 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  bandit:
-    name: Bandit Security Scan
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
-        with:
-          enable-cache: true
-
-      - name: Bandit security scan
-        run: >
-          uv run --with bandit
-          bandit -r
-          skills/jira-communication/scripts/
-          scripts/
-          -c pyproject.toml
-          --severity-level medium
-
-  test:
-    name: Test (Python ${{ matrix.python }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
-        with:
-          enable-cache: true
-
-      - name: Run tests (Python ${{ matrix.python }})
-        run: >
-          uv run
-          --python ${{ matrix.python }}
-          --with pytest
-          --with atlassian-python-api
-          --with click
-          --with requests
-          python -m pytest tests/ -v
+  ci:
+    uses: netresearch/skill-repo-skill/.github/workflows/ci-python.yml@main
+    permissions:
+      contents: read
+    with:
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      test-command: >
+        uv run
+        --python "$PYTHON_VERSION"
+        --with pytest
+        --with atlassian-python-api
+        --with click
+        --with requests
+        python -m pytest tests/ -v
+      run-bandit: true
+      bandit-args: '-r skills/jira-communication/scripts/ scripts/ -c pyproject.toml --severity-level medium'


### PR DESCRIPTION
## Summary
- Replace local Python CI workflow (Bandit + pytest matrix) with shared `ci-python.yml` caller from skill-repo-skill
- Preserves Python version matrix (3.10-3.14), Bandit security scanning, and test dependencies
- `dependency-audit.yml` kept as-is (repo-specific, action pins are current)

## Dependencies
This PR depends on `ci-python.yml` being merged in netresearch/skill-repo-skill first. The caller references `@main` which will resolve once that shared workflow lands.

## Test plan
- [ ] Merge ci-python.yml in skill-repo-skill first
- [ ] Verify CI triggers on push to main and PRs
- [ ] Verify Bandit scan runs with correct args
- [ ] Verify pytest runs across all Python versions