### PR TITLE
fix(jira-comment): support stdin input via "-" argument

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -56,6 +56,7 @@ uv run scripts/core/jira-issue.py update PROJ-123 --fields-json '{"description":
 
 # Comment (add/edit/list — edit needs comment ID from list)
 uv run scripts/workflow/jira-comment.py add PROJ-123 "Comment text"
+cat comment.txt | uv run scripts/workflow/jira-comment.py add PROJ-123 -  # stdin for multiline
 uv run scripts/workflow/jira-comment.py --json list PROJ-123
 uv run scripts/workflow/jira-comment.py edit PROJ-123 COMMENT_ID "Updated text"
 uv run scripts/workflow/jira-comment.py delete PROJ-123 COMMENT_ID

--- a/skills/jira-communication/evals/evals.json
+++ b/skills/jira-communication/evals/evals.json
@@ -78,16 +78,20 @@
   },
   {
     "name": "add_multiline_comment_via_stdin",
-    "prompt": "Add this comment to PROJ-789:\n\nh2. Status Update\n\n* Deployment completed\n* Tests passing\n\nPlease write it to a temp file and pipe it to jira-comment.",
+    "prompt": "Add this comment to PROJ-789:\n\nh2. Status Update\n\n* Deployment completed\n* Tests passing\n\nThis is multiline Jira wiki markup — use stdin piping to preserve formatting.",
     "assertions": [
       {
         "type": "tool_use",
         "tool": "Bash",
-        "pattern": "jira-comment\\.py.*add.*PROJ-789.*-"
+        "pattern": "jira-comment\\.py.*add\\s+PROJ-789\\s+-"
       },
       {
         "type": "content",
-        "pattern": "(cat|pipe|stdin|<)"
+        "pattern": "(\\bcat\\b|\\|.*jira-comment|\\bstdin\\b|<<)"
+      },
+      {
+        "type": "content",
+        "pattern": "Status Update"
       }
     ]
   },
@@ -98,7 +102,7 @@
       {
         "type": "tool_use",
         "tool": "Bash",
-        "pattern": "jira-comment\\.py.*add.*PROJ-100"
+        "pattern": "jira-comment\\.py.*add.*PROJ-100.*Fixed in commit"
       },
       {
         "type": "content",

--- a/skills/jira-communication/scripts/workflow/jira-comment.py
+++ b/skills/jira-communication/scripts/workflow/jira-comment.py
@@ -79,9 +79,37 @@ def add(ctx, issue_key: str, comment_text: str):
 
     # Read from stdin if "-" is passed as comment text
     if comment_text == "-":
-        comment_text = sys.stdin.read().rstrip("\n")
+        if sys.stdin.isatty():
+            error(
+                "'-' requires piped input but stdin is a terminal",
+                suggestion="Usage: cat comment.txt | jira-comment add PROJ-123 -",
+            )
+            sys.exit(1)
+
+        max_size = 256 * 1024  # 256KB, above Jira's comment limit
+        try:
+            comment_text = sys.stdin.read(max_size + 1)
+        except UnicodeDecodeError:
+            error(
+                "stdin contains invalid text encoding (expected UTF-8)",
+                suggestion="Ensure the piped file is valid UTF-8 text, not binary data.",
+            )
+            sys.exit(1)
+
+        if len(comment_text) > max_size:
+            error(
+                f"stdin input exceeds maximum size ({max_size // 1024}KB)",
+                suggestion="Jira comments have size limits. Consider attaching the content as a file.",
+            )
+            sys.exit(1)
+
+        comment_text = comment_text.rstrip("\n")
+
         if not comment_text.strip():
-            error("No input received from stdin")
+            error(
+                "No input received from stdin (empty or whitespace-only)",
+                suggestion="Verify your piped command produces non-empty output.",
+            )
             sys.exit(1)
 
     try:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -271,6 +271,7 @@ class TestMockedCommands:
         mc.issue_add_comment.assert_called_once()
         actual_body = mc.issue_add_comment.call_args[0][1]
         assert "h2. Test" in actual_body
+        assert "\n\n" in actual_body
         assert "Body text" in actual_body
 
     def test_comment_add_stdin_preserves_whitespace(self):
@@ -281,17 +282,59 @@ class TestMockedCommands:
         result, mc = self._run_comment_cmd(["add", "PROJ-123", "-"], mock_client=mc, input=body)
         assert result.exit_code == 0, result.output
         actual_body = mc.issue_add_comment.call_args[0][1]
-        assert actual_body.startswith("  indented")
+        assert actual_body == "  indented line\n\n  another indented"
+
+    def test_comment_add_stdin_strips_trailing_newlines_only(self):
+        """Trailing newlines stripped; leading whitespace and internal newlines preserved."""
+        mc = self._make_mock_client()
+        mc.issue_add_comment.return_value = {"id": "100"}
+        result, mc = self._run_comment_cmd(["add", "PROJ-123", "-"], mock_client=mc, input="  leading\nline2\n\n")
+        assert result.exit_code == 0, result.output
+        actual = mc.issue_add_comment.call_args[0][1]
+        assert actual == "  leading\nline2"
 
     def test_comment_add_stdin_empty_fails(self):
         """jira-comment add PROJ-123 - with empty stdin must fail."""
         result, _ = self._run_comment_cmd(["add", "PROJ-123", "-"], input="")
         assert result.exit_code == 1
+        assert "stdin" in result.output.lower()
 
     def test_comment_add_stdin_whitespace_only_fails(self):
         """jira-comment add PROJ-123 - with whitespace-only stdin must fail."""
         result, _ = self._run_comment_cmd(["add", "PROJ-123", "-"], input="   \n\n  ")
         assert result.exit_code == 1
+        assert "stdin" in result.output.lower()
+
+    def test_comment_add_stdin_tty_guard_exists(self):
+        """The add command must check sys.stdin.isatty() before reading stdin.
+
+        Click's CliRunner replaces sys.stdin during invoke(), making it impossible
+        to test the isatty guard through the CLI. We verify at the source level
+        that the guard exists and is correctly placed before sys.stdin.read().
+        """
+        import inspect
+
+        source = inspect.getsource(_comment_mod.add.callback)
+        isatty_pos = source.find("isatty()")
+        read_pos = source.find("stdin.read(")
+        assert isatty_pos != -1, "isatty() guard missing from add command"
+        assert read_pos != -1, "stdin.read() missing from add command"
+        assert isatty_pos < read_pos, "isatty() guard must come before stdin.read()"
+
+    def test_comment_add_stdin_oversized_fails(self):
+        """stdin input exceeding size limit must fail."""
+        big_input = "x" * (256 * 1024 + 100)
+        result, _ = self._run_comment_cmd(["add", "PROJ-123", "-"], input=big_input)
+        assert result.exit_code == 1
+        assert "size" in result.output.lower()
+
+    def test_comment_add_stdin_quiet(self):
+        """jira-comment --quiet add PROJ-123 - must output only the comment ID."""
+        mc = self._make_mock_client()
+        mc.issue_add_comment.return_value = {"id": "88888"}
+        result, mc = self._run_comment_cmd(["--quiet", "add", "PROJ-123", "-"], mock_client=mc, input="text")
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == "88888"
 
     def test_comment_add_literal_text(self):
         """jira-comment add PROJ-123 'text' must pass text directly, not read stdin."""


### PR DESCRIPTION
## Summary

- `jira-comment add PROJ-123 -` now reads comment body from stdin
- Previously `-` was passed as literal text, resulting in comments containing only a dash

## Test plan

- [ ] `echo "test comment" | uv run scripts/workflow/jira-comment.py add PROJ-123 -` creates comment with "test comment"
- [ ] `cat multiline.txt | uv run scripts/workflow/jira-comment.py add PROJ-123 -` creates comment with file contents
- [ ] `uv run scripts/workflow/jira-comment.py add PROJ-123 "normal text"` still works as before
- [ ] Empty stdin (`echo "" | ... add PROJ-123 -`) shows error and exits