### PR TITLE
fix: ensure UTF-8 stdout/stderr on Windows to prevent duplicate Jira operations

### DIFF
--- a/skills/jira-communication/scripts/lib/config.py
+++ b/skills/jira-communication/scripts/lib/config.py
@@ -9,6 +9,13 @@ from urllib.parse import urlparse
 
 # === INLINE_START: config ===
 
+# Ensure UTF-8 output on Windows (see output.py for full rationale).
+if sys.platform == "win32":
+    for _stream in ("stdout", "stderr"):
+        _s = getattr(sys, _stream)
+        if hasattr(_s, "reconfigure"):
+            _s.reconfigure(encoding="utf-8", errors="replace")
+
 
 def normalize_netloc(url: str) -> str:
     """Normalize a URL's netloc by lowercasing and stripping default ports."""

--- a/skills/jira-communication/scripts/lib/config.py
+++ b/skills/jira-communication/scripts/lib/config.py
@@ -9,12 +9,12 @@ from urllib.parse import urlparse
 
 # === INLINE_START: config ===
 
-# Ensure UTF-8 output on Windows (see output.py for full rationale).
+# Ensure UTF-8 output on Windows — reuse the shared helper so behavior
+# stays in sync (see output.py for the full rationale).
 if sys.platform == "win32":
-    for _stream in ("stdout", "stderr"):
-        _s = getattr(sys, _stream)
-        if hasattr(_s, "reconfigure"):
-            _s.reconfigure(encoding="utf-8", errors="replace")
+    from .output import _ensure_utf8_streams
+
+    _ensure_utf8_streams()
 
 
 def normalize_netloc(url: str) -> str:

--- a/skills/jira-communication/scripts/lib/output.py
+++ b/skills/jira-communication/scripts/lib/output.py
@@ -1,6 +1,5 @@
 """Output formatting utilities for Jira CLI scripts."""
 
-import io
 import json
 import sys
 from typing import Any
@@ -25,12 +24,6 @@ def _ensure_utf8_streams() -> None:
             stream = getattr(sys, stream_name)
             if hasattr(stream, "reconfigure"):
                 stream.reconfigure(encoding="utf-8", errors="replace")
-            elif hasattr(stream, "buffer"):
-                setattr(
-                    sys,
-                    stream_name,
-                    io.TextIOWrapper(stream.buffer, encoding="utf-8", errors="replace"),
-                )
 
 
 _ensure_utf8_streams()

--- a/skills/jira-communication/scripts/lib/output.py
+++ b/skills/jira-communication/scripts/lib/output.py
@@ -1,10 +1,39 @@
 """Output formatting utilities for Jira CLI scripts."""
 
+import io
 import json
 import sys
 from typing import Any
 
 # === INLINE_START: output ===
+
+
+def _ensure_utf8_streams() -> None:
+    """Reconfigure stdout/stderr to UTF-8 on Windows.
+
+    Windows consoles default to a locale-specific encoding (e.g. cp1252)
+    that cannot represent Unicode symbols used in status messages (✓, ✗, ⚠).
+    This causes 'charmap' codec errors *after* a Jira API call has already
+    succeeded, making the script exit non-zero and tempting callers to retry
+    — which creates duplicate issues/comments.
+
+    Called once at module import so every script that imports output.py
+    benefits automatically.
+    """
+    if sys.platform == "win32":
+        for stream_name in ("stdout", "stderr"):
+            stream = getattr(sys, stream_name)
+            if hasattr(stream, "reconfigure"):
+                stream.reconfigure(encoding="utf-8", errors="replace")
+            elif hasattr(stream, "buffer"):
+                setattr(
+                    sys,
+                    stream_name,
+                    io.TextIOWrapper(stream.buffer, encoding="utf-8", errors="replace"),
+                )
+
+
+_ensure_utf8_streams()
 
 
 def format_json(data: Any, indent: int = 2) -> str:


### PR DESCRIPTION
## Problem

On Windows, Python defaults to `cp1252` for console output. Unicode status symbols (`✓`, `✗`, `⚠`) used in `success()`, `error()`, and `warning()` cause `'charmap' codec can't encode character` errors.

**The critical issue:** Jira API calls succeed *before* the status message is printed. When `print()` fails on the Unicode symbol, the script exits non-zero. Callers (e.g. Claude Code) interpret this as operation failure and retry — **creating duplicate issues, comments, and transitions**.

## Fix

Reconfigure `stdout`/`stderr` to UTF-8 at module import time using `reconfigure()` (available since Python 3.7, project requires ≥3.10):

- **`output.py`** — `_ensure_utf8_streams()` called at import. Since every script imports `output.py`, this covers all CLI commands automatically.
- **`config.py`** — Calls `_ensure_utf8_streams()` from `output.py` for code paths that load config before output (e.g. profile resolution warnings with `⚠`).

No-op on non-Windows platforms (`sys.platform == "win32"` guard).

## Changes

- `output.py`: +`_ensure_utf8_streams()` function, called once at module load
- `config.py`: Import and call shared `_ensure_utf8_streams()` from output.py
- `jira-user.py`: Fix ruff F541 lint (f-string without placeholders)

## Test plan

- [x] Verified `jira-create.py` no longer crashes on Windows with Unicode output
- [x] All 20 scripts import `lib.output` → fix propagates automatically
- [x] `config.py` covered independently for early-load paths
- [x] All 323 tests pass
- [ ] Linux/macOS: no behavioral change (guard skips non-Windows)