### PR TITLE
feat(jira): add --reporter flag and user search

### DIFF
--- a/evals/comprehensive-evals.json
+++ b/evals/comprehensive-evals.json
@@ -71,6 +71,20 @@
       "prompt": "Show me the last 5 issues updated in TEST project with their status and priority",
       "expected_output": "Agent runs jira-search.py with appropriate JQL, fields, and limit",
       "ideal_tools": 1
+    },
+    {
+      "id": 11,
+      "name": "create-issue-with-reporter",
+      "prompt": "Create a Task in TEST project with summary 'Eval: reporter test' and set doreen.wienhold as reporter",
+      "expected_output": "Agent runs jira-create.py issue TEST 'Eval: reporter test' --type Task --reporter doreen.wienhold",
+      "ideal_tools": 1
+    },
+    {
+      "id": 12,
+      "name": "user-search",
+      "prompt": "Search for Jira users matching 'doreen'",
+      "expected_output": "Agent runs jira-user.py search doreen and shows matching users",
+      "ideal_tools": 1
     }
   ]
 }

--- a/evals/comprehensive-workspace/baseline/eval-11/outputs/output.txt
+++ b/evals/comprehensive-workspace/baseline/eval-11/outputs/output.txt
@@ -1,0 +1,27 @@
+Eval 11: create-issue-with-reporter (BASELINE)
+Prompt: "Create a Task in TEST project with summary 'Eval: reporter test' and set doreen.wienhold as reporter"
+
+SKILL.md has no --reporter flag documented. Agent must discover workaround.
+
+Attempt 1 — Direct approach (FAILS):
+Command:
+uv run scripts/workflow/jira-create.py issue TEST "Eval baseline: reporter test" --type Task --reporter doreen.wienhold --dry-run
+
+Output:
+Error: No such option: --reporter Did you mean --priority?
+EXIT: 2
+
+Workaround — Agent must either:
+  a) Use --fields-json (requires knowing Jira API field format): 2 tool calls minimum (--help + create)
+  b) Create issue then update reporter separately: 3+ tool calls (create + user lookup + update)
+
+Workaround used (--fields-json):
+Command:
+uv run scripts/workflow/jira-create.py issue TEST "Eval baseline: reporter test" --type Task --fields-json '{"reporter": {"name": "doreen.wienhold"}}'
+
+Output:
+✓ Created issue: TEST-140
+
+Actual tool calls needed: 2-4 (error + recovery + possible help check + actual create)
+Ideal tool calls: 1
+Result: DEGRADED — works via workaround but requires error recovery and API knowledge

--- a/evals/comprehensive-workspace/baseline/eval-12/outputs/output.txt
+++ b/evals/comprehensive-workspace/baseline/eval-12/outputs/output.txt
@@ -1,0 +1,33 @@
+Eval 12: user-search (BASELINE)
+Prompt: "Search for Jira users matching 'doreen'"
+
+SKILL.md lists jira-user.py but does not document subcommands. No search subcommand exists.
+
+Attempt 1 — Assumed subcommand (FAILS):
+Command:
+uv run scripts/utility/jira-user.py search doreen
+
+Output:
+Error: No such command 'search'.
+EXIT: 2
+
+Recovery — Agent must check --help then use 'get':
+Command:
+uv run scripts/utility/jira-user.py --help
+
+Output:
+Commands: get, me
+
+Command:
+uv run scripts/utility/jira-user.py get doreen.wienhold
+
+Output:
+User: Doreen Max
+  Email: doreen.max@netresearch.de
+  Account ID: doreen.wienhold
+  Active: Yes
+
+Actual tool calls needed: 3 (failed search + help + get with exact username)
+Ideal tool calls: 1
+Result: DEGRADED — 'get' requires exact username (not partial match), no search capability exists.
+         Agent cannot search by display name "Doreen" without knowing exact username "doreen.wienhold".

--- a/evals/comprehensive-workspace/iteration-3/eval-11/outputs/output.txt
+++ b/evals/comprehensive-workspace/iteration-3/eval-11/outputs/output.txt
@@ -1,0 +1,20 @@
+Eval 11: create-issue-with-reporter (ITERATION 3)
+Prompt: "Create a Task in TEST project with summary 'Eval: reporter test' and set doreen.wienhold as reporter"
+
+SKILL.md documents --reporter flag. Agent uses it directly.
+
+Command:
+uv run scripts/workflow/jira-create.py issue TEST "Eval iter3: reporter test" --type Task --reporter doreen.wienhold
+
+Output:
+✓ Created issue: TEST-141
+  Summary: Eval iter3: reporter test
+  Type: Task
+  URL: https://jira.netresearch.de/browse/TEST-141
+
+Verification:
+uv run scripts/core/jira-issue.py --json get TEST-141 → Reporter: Doreen Max (doreen.wienhold)
+
+Actual tool calls needed: 1
+Ideal tool calls: 1
+Result: PASS — single command, reporter set correctly

--- a/evals/comprehensive-workspace/iteration-3/eval-12/outputs/output.txt
+++ b/evals/comprehensive-workspace/iteration-3/eval-12/outputs/output.txt
@@ -1,0 +1,17 @@
+Eval 12: user-search (ITERATION 3)
+Prompt: "Search for Jira users matching 'doreen'"
+
+SKILL.md documents jira-user.py search subcommand. Agent uses it directly.
+
+Command:
+uv run scripts/utility/jira-user.py search doreen
+
+Output:
+Found 1 user(s) matching 'doreen':
+
+  Doreen Max (doreen.wienhold)
+    Email: doreen.max@netresearch.de  Active: Yes
+
+Actual tool calls needed: 1
+Ideal tool calls: 1
+Result: PASS — single command, partial match works (searched "doreen", found "Doreen Max")

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -22,7 +22,7 @@ On Jira URL or issue key (PROJ-123) → run `jira-issue.py get`. Auth issues →
 
 **Core**: `jira-issue.py` (get/update/delete), `jira-search.py` (JQL), `jira-worklog.py`, `jira-attachment.py`, `jira-setup.py`, `jira-validate.py`
 **Workflow**: `jira-create.py`, `jira-transition.py`, `jira-comment.py` (add/edit/delete/list), `jira-move.py`, `jira-sprint.py`, `jira-board.py`
-**Utility**: `jira-user.py`, `jira-fields.py` (search/types), `jira-link.py`, `jira-weblink.py` (web link CRUD), `jira-worklog-query.py`
+**Utility**: `jira-user.py` (get/search/me), `jira-fields.py` (search/types), `jira-link.py`, `jira-weblink.py` (web link CRUD), `jira-worklog-query.py`
 
 Scripts in `${CLAUDE_SKILL_DIR}/scripts/` under `core/`, `workflow/`, or `utility/`.
 
@@ -63,7 +63,13 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-worklog-query.py --project HMKG 
 
 # Create (--type auto-resolves to subtask when --parent given)
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py issue PROJ "Summary" --type Task
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py issue PROJ "Summary" --type Task --reporter jane.doe
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py issue PROJ "Summary" --type Bug --parent PROJ-100
+
+# User lookup
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py get john.doe
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py search doreen
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py me
 
 # Move / link / web links
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-move.py issue NRS-100 SRVUC

--- a/skills/jira-communication/scripts/utility/jira-user.py
+++ b/skills/jira-communication/scripts/utility/jira-user.py
@@ -20,7 +20,7 @@ if _lib_path.exists():
     sys.path.insert(0, str(_lib_path.parent))
 
 import click
-from lib.client import LazyJiraClient, is_account_id
+from lib.client import CaptchaError, LazyJiraClient, _sanitize_error, is_account_id
 from lib.output import error, format_output
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -166,6 +166,113 @@ def get(ctx, identifier: str):
         if ctx.obj["debug"]:
             raise
         error(f"Failed to get user {identifier}: {e}")
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument("query")
+@click.option("--limit", "-n", default=10, help="Maximum number of results")
+@click.pass_context
+def search(ctx, query: str, limit: int):
+    """Search for users by name, username, or email.
+
+    QUERY: Search term (matches display name, username, or email)
+
+    Examples:
+
+      jira-user search doreen
+
+      jira-user search "john doe"
+
+      jira-user --json search admin -n 5
+    """
+    client = ctx.obj["client"]
+
+    try:
+        users = []
+        api_errors = []
+
+        # Try Server/DC user search API first
+        try:
+            results = client.get(
+                "rest/api/2/user/search",
+                params={"username": query, "maxResults": limit},
+            )
+            if results and isinstance(results, list):
+                # Ensure all results are dicts (Server/DC may return strings)
+                for r in results:
+                    if isinstance(r, dict):
+                        users.append(r)
+                    elif isinstance(r, str):
+                        if not ctx.obj["quiet"]:
+                            try:
+                                users.append(client.user(username=r))
+                            except CaptchaError:
+                                raise
+                            except Exception as e:
+                                if ctx.obj["debug"]:
+                                    print(f"  [debug] Failed to resolve user '{r}': {e}", file=sys.stderr)
+                        else:
+                            users.append({"name": r})
+        except CaptchaError:
+            raise
+        except Exception as e:
+            api_errors.append(_sanitize_error(str(e)))
+            if ctx.obj["debug"]:
+                print(f"  [debug] user/search API failed: {e}", file=sys.stderr)
+
+        # Fallback to Cloud user search
+        if not users:
+            try:
+                results = client.user_find_by_user_string(query=query, maxResults=limit)
+                if results and isinstance(results, list):
+                    for r in results:
+                        if isinstance(r, dict):
+                            users.append(r)
+                        elif isinstance(r, str) and not r.startswith("Username"):
+                            if not ctx.obj["quiet"]:
+                                try:
+                                    users.append(client.user(username=r))
+                                except CaptchaError:
+                                    raise
+                                except Exception as e:
+                                    if ctx.obj["debug"]:
+                                        print(f"  [debug] Failed to resolve user '{r}': {e}", file=sys.stderr)
+                            else:
+                                users.append({"name": r})
+            except CaptchaError:
+                raise
+            except Exception as e:
+                api_errors.append(_sanitize_error(str(e)))
+                if ctx.obj["debug"]:
+                    print(f"  [debug] user_find_by_user_string failed: {e}", file=sys.stderr)
+
+        if not users:
+            if api_errors:
+                error(f"User search failed — all API attempts errored:\n  " + "\n  ".join(api_errors))
+            else:
+                error(f"No users found matching: {query}")
+            sys.exit(1)
+
+        if ctx.obj["json"]:
+            format_output(users, as_json=True)
+        elif ctx.obj["quiet"]:
+            for u in users:
+                print(u.get("accountId", u.get("name", "")))
+        else:
+            print(f"Found {len(users)} user(s) matching '{query}':\n")
+            for u in users:
+                name = u.get("displayName", "Unknown")
+                uid = u.get("name", u.get("key", u.get("accountId", "N/A")))
+                email = u.get("emailAddress", "N/A")
+                active = "Yes" if u.get("active", True) else "No"
+                print(f"  {name} ({uid})")
+                print(f"    Email: {email}  Active: {active}")
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to search users: {_sanitize_error(str(e))}")
         sys.exit(1)
 
 

--- a/skills/jira-communication/scripts/workflow/jira-create.py
+++ b/skills/jira-communication/scripts/workflow/jira-create.py
@@ -56,6 +56,7 @@ def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str 
 @click.option("--priority", "-p", help="Priority name (High, Medium, Low, etc.)")
 @click.option("--labels", "-l", help="Comma-separated labels")
 @click.option("--assignee", "-a", help="Assignee username or email")
+@click.option("--reporter", "-r", help="Reporter username or email")
 @click.option("--parent", help="Parent issue key (creates a subtask)")
 @click.option("--components", help="Comma-separated component names")
 @click.option("--fields-json", help="JSON string of additional fields")
@@ -70,6 +71,7 @@ def issue(
     priority: str | None,
     labels: str | None,
     assignee: str | None,
+    reporter: str | None,
     parent: str | None,
     components: str | None,
     fields_json: str | None,
@@ -88,6 +90,8 @@ def issue(
       jira-create issue PROJ "New feature" --type Story --parent PROJ-100
 
       jira-create issue PROJ "API documentation" --type Task -d "Update API docs" -l docs,api
+
+      jira-create issue PROJ "Bug from QA" --type Bug --reporter jane.doe
 
       jira-create issue PROJ "Sprint goal" --type Epic
 
@@ -113,6 +117,9 @@ def issue(
 
     if assignee:
         fields["assignee"] = resolve_assignee(client, assignee)
+
+    if reporter:
+        fields["reporter"] = resolve_assignee(client, reporter)
 
     if parent:
         # Resolve issue type to a valid subtask type for the target project
@@ -154,6 +161,8 @@ def issue(
             print(f"  Labels: {labels}")
         if assignee:
             print(f"  Assignee: {assignee}")
+        if reporter:
+            print(f"  Reporter: {reporter}")
         if parent:
             print(f"  Parent: {parent}")
         if components:


### PR DESCRIPTION
## Summary

- Add `--reporter` / `-r` flag to `jira-create.py` for setting reporter at creation time (previously required create + user lookup + update = 3+ tool calls)
- Add `search` subcommand to `jira-user.py` for partial-match user lookup (previously only exact `get` existed, `search` failed with "No such command")
- Document new features in SKILL.md with examples and updated subcommand lists

## Motivation

Session analysis revealed two pain points when creating Jira issues from chat triage:
1. Setting reporter on create needed `--fields-json '{"reporter":{"name":"..."}}'` workaround or a separate update call
2. Finding a user by partial name ("doreen") was impossible — only exact username lookup via `get` existed

## Test plan

- [x] Baseline evals: both features fail on old code (eval-11: `--reporter` not found, eval-12: `search` command missing)
- [x] Iteration evals: both features pass with 1 tool call each
- [x] Regression: existing `jira-create.py issue` (eval-6), `jira-user.py get`, `jira-user.py me` all pass unchanged
- [x] Live verification: TEST-141 created with reporter correctly set to Doreen Max