### PR TITLE
feat(attachment): add upload command

### DIFF
--- a/evals/comprehensive-evals.json
+++ b/evals/comprehensive-evals.json
@@ -85,6 +85,13 @@
       "prompt": "Search for Jira users matching 'doreen'",
       "expected_output": "Agent runs jira-user.py search doreen and shows matching users",
       "ideal_tools": 1
+    },
+    {
+      "id": 13,
+      "name": "upload-attachment",
+      "prompt": "Attach the file /tmp/eval-attachment-test.txt to TEST-135",
+      "expected_output": "Agent runs jira-attachment.py add TEST-135 /tmp/eval-attachment-test.txt",
+      "ideal_tools": 1
     }
   ]
 }

--- a/evals/comprehensive-workspace/baseline/eval-13/outputs/output.txt
+++ b/evals/comprehensive-workspace/baseline/eval-13/outputs/output.txt
@@ -1,0 +1,15 @@
+Eval 13: upload-attachment (BASELINE)
+Prompt: "Attach the file /tmp/eval-attachment-test.txt to TEST-135"
+
+No 'add' subcommand exists on jira-attachment.py.
+
+Command:
+uv run scripts/core/jira-attachment.py add TEST-135 /tmp/eval-attachment-test.txt
+
+Output:
+Error: No such command 'add'.
+EXIT: 2
+
+Actual tool calls needed: N/A (impossible without --fields-json workaround or manual API call)
+Ideal tool calls: 1
+Result: FAIL — no upload capability exists

--- a/evals/comprehensive-workspace/iteration-4/eval-13/outputs/output.txt
+++ b/evals/comprehensive-workspace/iteration-4/eval-13/outputs/output.txt
@@ -1,0 +1,14 @@
+Eval 13: upload-attachment (ITERATION 4)
+Prompt: "Attach the file /tmp/eval-attachment-test.txt to TEST-135"
+
+SKILL.md documents jira-attachment.py add subcommand. Agent uses it directly.
+
+Command:
+uv run scripts/core/jira-attachment.py add TEST-135 /tmp/eval-attachment-test.txt
+
+Output:
+✓ Attached eval-attachment-test.txt (18 bytes) to TEST-135
+
+Actual tool calls needed: 1
+Ideal tool calls: 1
+Result: PASS — single command, file uploaded successfully

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -20,7 +20,7 @@ On Jira URL or issue key (PROJ-123) → run `jira-issue.py get`. Auth issues →
 
 ## Scripts
 
-**Core**: `jira-issue.py` (get/update/delete), `jira-search.py` (JQL), `jira-worklog.py`, `jira-attachment.py`, `jira-setup.py`, `jira-validate.py`
+**Core**: `jira-issue.py` (get/update/delete), `jira-search.py` (JQL), `jira-worklog.py`, `jira-attachment.py` (add/download), `jira-setup.py`, `jira-validate.py`
 **Workflow**: `jira-create.py`, `jira-transition.py`, `jira-comment.py` (add/edit/delete/list), `jira-move.py`, `jira-sprint.py`, `jira-board.py`
 **Utility**: `jira-user.py` (get/search/me), `jira-fields.py` (search/types), `jira-link.py`, `jira-weblink.py` (web link CRUD), `jira-worklog-query.py`
 
@@ -78,6 +78,10 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-weblink.py add PROJ-123 --url ht
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-weblink.py list PROJ-123
 
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-fields.py types PROJ
+
+# Attachments
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screenshot.png
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 /tmp/report.pdf --dry-run
 ```
 
 `--assignee me` resolves to the authenticated user.

--- a/skills/jira-communication/scripts/core/jira-attachment.py
+++ b/skills/jira-communication/scripts/core/jira-attachment.py
@@ -7,7 +7,7 @@
 #     "requests>=2.31.0,<3",
 # ]
 # ///
-"""Jira attachment operations - download attachments."""
+"""Jira attachment operations - download and upload attachments."""
 
 import json
 import sys
@@ -24,8 +24,9 @@ if _lib_path.exists():
 
 import click
 import requests
+from lib.client import CaptchaError, LazyJiraClient, _sanitize_error
 from lib.config import load_config, normalize_netloc
-from lib.output import error, success
+from lib.output import error, success, warning
 
 # Chunk size for streaming large file downloads (1 MB)
 CHUNK_SIZE = 1048576
@@ -96,7 +97,7 @@ def validate_output_path(output_file: str, working_dir: str) -> Path | None:
 def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str | None, debug: bool):
     """Jira attachment operations.
 
-    Download attachments from Jira issues.
+    Download and upload Jira issue attachments.
     """
     ctx.ensure_object(dict)
     ctx.obj["json"] = output_json
@@ -104,6 +105,7 @@ def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str 
     ctx.obj["env_file"] = env_file
     ctx.obj["profile"] = profile
     ctx.obj["debug"] = debug
+    ctx.obj["client"] = LazyJiraClient(env_file=env_file, profile=profile)
 
 
 @cli.command()
@@ -234,6 +236,58 @@ def download(ctx, attachment_url: str, output_file: str):
         if ctx.obj["debug"]:
             raise
         error(f"Failed to download attachment: {e}")
+        sys.exit(1)
+
+
+@cli.command("add")
+@click.argument("issue_key")
+@click.argument("file_path", type=click.Path(exists=True, dir_okay=False, readable=True))
+@click.option("--dry-run", is_flag=True, help="Validate file without uploading")
+@click.pass_context
+def add(ctx, issue_key: str, file_path: str, dry_run: bool):
+    """Upload an attachment to a Jira issue.
+
+    ISSUE_KEY: The Jira issue key (e.g., PROJ-123)
+
+    FILE_PATH: Path to the file to attach
+
+    Examples:
+
+      jira-attachment add PROJ-123 screenshot.png
+
+      jira-attachment add PROJ-123 /tmp/report.pdf --dry-run
+    """
+    client = ctx.obj["client"]
+    client.with_context(issue_key=issue_key)
+
+    path = Path(file_path)
+    file_size = path.stat().st_size
+
+    if dry_run:
+        warning("DRY RUN — would upload:")
+        print(f"  File: {path.name} ({file_size:,} bytes)")
+        print(f"  Issue: {issue_key}")
+        return
+
+    try:
+        result = client.add_attachment(issue_key, str(path))
+
+        if ctx.obj["quiet"]:
+            if isinstance(result, list) and result and isinstance(result[0], dict):
+                print(result[0].get("id", ""))
+            else:
+                print("")
+        elif ctx.obj["json"]:
+            print(json.dumps(result if isinstance(result, list) else [result], indent=2))
+        else:
+            success(f"Attached {path.name} ({file_size:,} bytes) to {issue_key}")
+
+    except CaptchaError:
+        raise
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to upload attachment: {_sanitize_error(str(e))}")
         sys.exit(1)
 
 

--- a/skills/jira-communication/scripts/utility/jira-user.py
+++ b/skills/jira-communication/scripts/utility/jira-user.py
@@ -249,7 +249,7 @@ def search(ctx, query: str, limit: int):
 
         if not users:
             if api_errors:
-                error(f"User search failed — all API attempts errored:\n  " + "\n  ".join(api_errors))
+                error("User search failed — all API attempts errored:\n  " + "\n  ".join(api_errors))
             else:
                 error(f"No users found matching: {query}")
             sys.exit(1)


### PR DESCRIPTION
## Summary

- Add `add` subcommand to `jira-attachment.py` for uploading files as Jira issue attachments
- Uses `LazyJiraClient` + `atlassian-python-api` `add_attachment()` method
- Supports `--dry-run`, `--json`, `--quiet`, and default output modes
- Enables the Matrix-to-Jira media pipeline (download image from chat → attach to issue)

## Test plan

- [x] Baseline eval: `jira-attachment.py add` fails before changes ("No such command")
- [x] Iteration eval: single tool call, file uploaded successfully to TEST-135
- [x] All output modes tested: dry-run, default, JSON, quiet
- [x] Regression: existing `download` command unaffected
- [x] `CaptchaError` re-raised, other errors sanitized via `_sanitize_error()`