### PR TITLE
chore: release v3.10.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.10.1] - 2026-04-16
+
+### Fixed
+
+- Windows: ensure UTF-8 stdout/stderr to prevent `charmap` codec errors that caused duplicate Jira operations (issues, comments, transitions) when Unicode status symbols failed to print after successful API calls ([#61](https://github.com/netresearch/jira-skill/pull/61))
+- DRY up Windows UTF-8 stream configuration — `config.py` now reuses `output._ensure_utf8_streams()` instead of duplicating the logic
+- Fix ruff F541 lint error (f-string without placeholders) in `jira-user.py`
+
 ## [3.10.0] - 2026-04-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -497,7 +497,20 @@ First stable release providing comprehensive Jira integration through Claude Cod
 - [Claude Code Marketplace](https://github.com/netresearch/claude-code-marketplace)
 - [Jira Wiki Markup Reference](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
 
-[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.3.5...HEAD
+[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.10.1...HEAD
+[3.10.1]: https://github.com/netresearch/jira-skill/compare/v3.10.0...v3.10.1
+[3.10.0]: https://github.com/netresearch/jira-skill/compare/v3.9.0...v3.10.0
+[3.9.0]: https://github.com/netresearch/jira-skill/compare/v3.8.0...v3.9.0
+[3.8.0]: https://github.com/netresearch/jira-skill/compare/v3.7.0...v3.8.0
+[3.7.0]: https://github.com/netresearch/jira-skill/compare/v3.6.3...v3.7.0
+[3.6.3]: https://github.com/netresearch/jira-skill/compare/v3.6.2...v3.6.3
+[3.6.2]: https://github.com/netresearch/jira-skill/compare/v3.6.1...v3.6.2
+[3.6.1]: https://github.com/netresearch/jira-skill/compare/v3.6.0...v3.6.1
+[3.6.0]: https://github.com/netresearch/jira-skill/compare/v3.5.0...v3.6.0
+[3.5.0]: https://github.com/netresearch/jira-skill/compare/v3.4.0...v3.5.0
+[3.4.0]: https://github.com/netresearch/jira-skill/compare/v3.3.7...v3.4.0
+[3.3.7]: https://github.com/netresearch/jira-skill/compare/v3.3.6...v3.3.7
+[3.3.6]: https://github.com/netresearch/jira-skill/compare/v3.3.5...v3.3.6
 [3.3.5]: https://github.com/netresearch/jira-skill/compare/v3.3.4...v3.3.5
 [3.3.4]: https://github.com/netresearch/jira-skill/compare/v3.3.3...v3.3.4
 [3.3.3]: https://github.com/netresearch/jira-skill/compare/v3.3.2...v3.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -502,15 +502,11 @@ First stable release providing comprehensive Jira integration through Claude Cod
 [3.10.0]: https://github.com/netresearch/jira-skill/compare/v3.9.0...v3.10.0
 [3.9.0]: https://github.com/netresearch/jira-skill/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/netresearch/jira-skill/compare/v3.7.0...v3.8.0
-[3.7.0]: https://github.com/netresearch/jira-skill/compare/v3.6.3...v3.7.0
-[3.6.3]: https://github.com/netresearch/jira-skill/compare/v3.6.2...v3.6.3
-[3.6.2]: https://github.com/netresearch/jira-skill/compare/v3.6.1...v3.6.2
+[3.7.0]: https://github.com/netresearch/jira-skill/compare/v3.6.1...v3.7.0
 [3.6.1]: https://github.com/netresearch/jira-skill/compare/v3.6.0...v3.6.1
 [3.6.0]: https://github.com/netresearch/jira-skill/compare/v3.5.0...v3.6.0
 [3.5.0]: https://github.com/netresearch/jira-skill/compare/v3.4.0...v3.5.0
-[3.4.0]: https://github.com/netresearch/jira-skill/compare/v3.3.7...v3.4.0
-[3.3.7]: https://github.com/netresearch/jira-skill/compare/v3.3.6...v3.3.7
-[3.3.6]: https://github.com/netresearch/jira-skill/compare/v3.3.5...v3.3.6
+[3.4.0]: https://github.com/netresearch/jira-skill/compare/v3.3.5...v3.4.0
 [3.3.5]: https://github.com/netresearch/jira-skill/compare/v3.3.4...v3.3.5
 [3.3.4]: https://github.com/netresearch/jira-skill/compare/v3.3.3...v3.3.4
 [3.3.3]: https://github.com/netresearch/jira-skill/compare/v3.3.2...v3.3.3

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv, curl. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.10.0"
+  version: "3.10.1"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Bash(curl:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.10.0"
+  version: "3.10.1"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
## Summary

- Bump version to 3.10.1 in `plugin.json` and both `SKILL.md` files
- Add CHANGELOG entry for v3.10.1

### Changes in this release

- **fix**: Ensure UTF-8 stdout/stderr on Windows to prevent duplicate Jira operations caused by `charmap` codec errors on Unicode status symbols (#61)
- **refactor**: DRY up Windows UTF-8 config — `config.py` reuses `output._ensure_utf8_streams()`
- **fix**: Remove extraneous f-prefix (ruff F541) in `jira-user.py`