### PR TITLE
refactor(ci): delegate dependency-audit to skill-repo-skill

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,48 +1,15 @@
 name: Dependency Audit
 
 on:
-    schedule:
-        - cron: '0 8 * * 1'  # Weekly Monday 08:00 UTC
-    workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * 1'  # Weekly Monday 08:00 UTC
+  workflow_dispatch:
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
-    audit:
-        runs-on: ubuntu-latest
-
-        steps:
-            - id: checkout
-              name: Checkout
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-            - id: setup_uv
-              name: Install uv
-              uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
-              with:
-                  enable-cache: true
-
-            - id: audit
-              name: Audit PEP 723 inline dependencies
-              run: |
-                  # Collect unique dependencies from PEP 723 inline script metadata
-                  python3 -c "
-                  import re, pathlib, json
-                  deps = set()
-                  for f in pathlib.Path('skills/jira-communication/scripts').rglob('*.py'):
-                      content = f.read_text()
-                      # Match PEP 723 dependencies block
-                      m = re.search(r'# dependencies = \[(.+?)\]', content, re.DOTALL)
-                      if m:
-                          for dm in re.finditer(r'\"([^\"]+)\"', m.group(1)):
-                              deps.add(dm.group(1))
-                  # Write as requirements format (one per line)
-                  pathlib.Path('/tmp/requirements-audit.txt').write_text(
-                      '\n'.join(sorted(deps)) + '\n'
-                  )
-                  print('Dependencies to audit:')
-                  for d in sorted(deps):
-                      print(f'  {d}')
-                  "
-                  uv run --with pip-audit pip-audit -r /tmp/requirements-audit.txt --desc
+  audit:
+    uses: netresearch/skill-repo-skill/.github/workflows/dependency-audit.yml@main
+    with:
+      scripts-paths: '["skills/jira-communication/scripts"]'


### PR DESCRIPTION
## Summary

Converts the per-repo direct-actions `dependency-audit.yml` scheduler into a thin caller that delegates to the new reusable workflow in [`netresearch/skill-repo-skill`](https://github.com/netresearch/skill-repo-skill).

Action pins (`actions/checkout`, `astral-sh/setup-uv`) move to one source of truth, so Renovate bumps (cf. #66) no longer land as per-skill PRs.

## Diff

- **Before:** 48 lines, direct `actions/checkout` + `astral-sh/setup-uv@v8.0.0` + inline Python scanner
- **After:** 15 lines, `uses: netresearch/skill-repo-skill/.github/workflows/dependency-audit.yml@main` with `scripts-paths: '["skills/jira-communication/scripts"]'`

## Dependency

- Blocked by https://github.com/netresearch/skill-repo-skill/pull/64 — merge that first, then this one can merge
- Once merged, close https://github.com/netresearch/jira-skill/pull/66 (Renovate setup-uv bump for the inline workflow, now obsolete)

## Test plan

- [ ] `netresearch/skill-repo-skill#64` merged
- [ ] Manually trigger this workflow via `workflow_dispatch` on the PR branch to verify delegation works
- [ ] CI green on this PR