### PR TITLE
feat(jira-link): add list and delete subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- SKILL.md now documents the full CRUD surface for both `jira-link` and `jira-weblink`. The web-link `update` and `delete` subcommands existed previously but were undocumented, causing agents to fall back to raw REST API calls.
+- SKILL.md: add examples for the new `jira-link list`/`delete` subcommands and the previously-undocumented `jira-weblink delete`. Full CRUD for both scripts is still discoverable via `--help`; SKILL.md shows the operations most relevant to the new delete workflow within the 500-word cap.
 
 ## [3.10.1] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`jira-link.py list`**: List all issue links on an issue with IDs, link type, direction, and related issue key/summary/status. Supports `--json` and `--quiet` output modes.
+- **`jira-link.py delete`**: Remove an issue link by `--id` or by the combination of `--to`/`--type`. Detects ambiguous matches and requires `--id` to disambiguate. Supports `--dry-run` preview.
+
+### Changed
+
+- SKILL.md now documents the full CRUD surface for both `jira-link` and `jira-weblink`. The web-link `update` and `delete` subcommands existed previously but were undocumented, causing agents to fall back to raw REST API calls.
+
 ## [3.10.1] - 2026-04-16
 
 ### Fixed

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -71,19 +71,11 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py get john.doe
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py search doreen
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py me
 
-# Move
+# Move / link / web links
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-move.py issue NRS-100 SRVUC
-
-# Issue links (issue <-> issue)
-uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-link.py create PROJ-123 PROJ-456 --type "Blocks"
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-link.py create PROJ-123 PROJ-456 --type Blocks
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-link.py list PROJ-123
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-link.py delete PROJ-123 --id 10042
-uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-link.py delete PROJ-123 --to PROJ-456 --type "Blocks" --dry-run
-
-# Web links (external URLs on an issue)
-uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-weblink.py add PROJ-123 --url https://example.com/doc --title "Design Doc"
-uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-weblink.py list PROJ-123
-uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-weblink.py update PROJ-123 --id 42 --title "Renamed"
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-weblink.py delete PROJ-123 --id 42
 
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-fields.py types PROJ

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -71,11 +71,20 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py get john.doe
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py search doreen
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py me
 
-# Move / link / web links
+# Move
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-move.py issue NRS-100 SRVUC
+
+# Issue links (issue <-> issue)
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-link.py create PROJ-123 PROJ-456 --type "Blocks"
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-link.py list PROJ-123
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-link.py delete PROJ-123 --id 10042
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-link.py delete PROJ-123 --to PROJ-456 --type "Blocks" --dry-run
+
+# Web links (external URLs on an issue)
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-weblink.py add PROJ-123 --url https://example.com/doc --title "Design Doc"
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-weblink.py list PROJ-123
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-weblink.py update PROJ-123 --id 42 --title "Renamed"
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-weblink.py delete PROJ-123 --id 42
 
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-fields.py types PROJ
 

--- a/skills/jira-communication/scripts/utility/jira-link.py
+++ b/skills/jira-communication/scripts/utility/jira-link.py
@@ -131,5 +131,193 @@ def list_types(ctx):
         sys.exit(1)
 
 
+@cli.command("list")
+@click.argument("issue_key")
+@click.pass_context
+def list_cmd(ctx, issue_key: str):
+    """List all issue links on an issue.
+
+    ISSUE_KEY: The Jira issue key (e.g. PROJ-123)
+
+    Shows link ID, direction, link type, and the other issue's key and summary.
+
+    Example:
+
+      jira-link list PROJ-123
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+
+    try:
+        issue = client.issue(issue_key, fields="issuelinks")
+        raw_links = (issue.get("fields") or {}).get("issuelinks") or []
+
+        links = []
+        for link in raw_links:
+            link_id = link.get("id", "")
+            type_obj = link.get("type") or {}
+            type_name = type_obj.get("name", "")
+            if "outwardIssue" in link:
+                other = link["outwardIssue"]
+                direction = "outward"
+                relation = type_obj.get("outward", "")
+            elif "inwardIssue" in link:
+                other = link["inwardIssue"]
+                direction = "inward"
+                relation = type_obj.get("inward", "")
+            else:
+                other = {}
+                direction = ""
+                relation = ""
+            other_key = other.get("key", "")
+            other_summary = ((other.get("fields") or {}).get("summary")) or ""
+            other_status = (((other.get("fields") or {}).get("status")) or {}).get("name", "")
+            links.append(
+                {
+                    "id": link_id,
+                    "type": type_name,
+                    "direction": direction,
+                    "relation": relation,
+                    "other_key": other_key,
+                    "other_summary": other_summary,
+                    "other_status": other_status,
+                }
+            )
+
+        if ctx.obj["json"]:
+            format_output(links, as_json=True)
+        elif ctx.obj["quiet"]:
+            for link_entry in links:
+                print(
+                    f"{link_entry['id']} {link_entry['type']} {link_entry['direction']} {link_entry['other_key']}"
+                )
+        else:
+            if not links:
+                print(f"No issue links on {issue_key}")
+                return
+            rows = [
+                {
+                    "ID": link_entry["id"],
+                    "Type": link_entry["type"],
+                    "Direction": link_entry["direction"],
+                    "Other": link_entry["other_key"],
+                    "Summary": link_entry["other_summary"][:60],
+                    "Status": link_entry["other_status"],
+                }
+                for link_entry in links
+            ]
+            print(format_table(rows, ["ID", "Type", "Direction", "Other", "Summary", "Status"]))
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to list issue links for {issue_key}: {e}")
+        sys.exit(1)
+
+
+def _link_matches(link: dict, to_key: str, link_type: str) -> bool:
+    """Return True if an issue link targets to_key with link_type (case-insensitive)."""
+    type_name = (link.get("type") or {}).get("name", "")
+    if type_name.lower() != link_type.lower():
+        return False
+    other = link.get("outwardIssue") or link.get("inwardIssue") or {}
+    return other.get("key") == to_key
+
+
+def _format_link_display(link: dict) -> str:
+    """Format an issue link for human-readable output (e.g. 'blocks TEST-2')."""
+    type_obj = link.get("type") or {}
+    type_name = type_obj.get("name", "")
+    if "outwardIssue" in link:
+        other = link["outwardIssue"].get("key", "?")
+        relation = type_obj.get("outward", type_name)
+        return f"{relation} {other}"
+    if "inwardIssue" in link:
+        other = link["inwardIssue"].get("key", "?")
+        relation = type_obj.get("inward", type_name)
+        return f"{relation} {other}"
+    return type_name
+
+
+@cli.command()
+@click.argument("issue_key")
+@click.option("--id", "link_id", type=str, help="Issue link ID (from `jira-link list`)")
+@click.option("--to", "to_key", help="Other issue key to identify the link by")
+@click.option("--type", "-t", "link_type", help="Link type name (used with --to)")
+@click.option("--dry-run", is_flag=True, help="Show what would be deleted")
+@click.pass_context
+def delete(
+    ctx,
+    issue_key: str,
+    link_id: str | None,
+    to_key: str | None,
+    link_type: str | None,
+    dry_run: bool,
+):
+    """Delete an issue link.
+
+    ISSUE_KEY: The Jira issue key that owns the link (e.g. PROJ-123)
+
+    Identify the link by either --id or the combination of --to and --type.
+
+    Examples:
+
+      jira-link delete PROJ-123 --id 10042
+
+      jira-link delete PROJ-123 --to PROJ-456 --type "Blocks" --dry-run
+    """
+    if link_id is None and not (to_key and link_type):
+        error("Provide --id, or both --to and --type, to identify the link")
+        sys.exit(1)
+    if link_id is not None and (to_key or link_type):
+        error("Use --id OR (--to and --type), not both")
+        sys.exit(1)
+
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+
+    try:
+        # Resolve to a single link_id + display string
+        if link_id is not None:
+            link = client.get_issue_link(link_id)
+            display = _format_link_display(link)
+        else:
+            issue = client.issue(issue_key, fields="issuelinks")
+            raw_links = (issue.get("fields") or {}).get("issuelinks") or []
+            matches = [lnk for lnk in raw_links if _link_matches(lnk, to_key, link_type)]
+            if not matches:
+                error(f"No {link_type!r} link from {issue_key} to {to_key}")
+                sys.exit(1)
+            if len(matches) > 1:
+                ids = ", ".join(m.get("id", "?") for m in matches)
+                error(f"Multiple matching links (ids: {ids}); use --id to disambiguate")
+                sys.exit(1)
+            link = matches[0]
+            link_id = link.get("id")
+            display = _format_link_display(link)
+
+        if dry_run:
+            warning("DRY RUN - No link will be deleted")
+            print(f"Would delete [{link_id}] {display}")
+            return
+
+        client.remove_issue_link(link_id)
+
+        if ctx.obj["json"]:
+            format_output({"key": issue_key, "id": link_id, "deleted": True}, as_json=True)
+        elif ctx.obj["quiet"]:
+            print("ok")
+        else:
+            success(f"Deleted link [{link_id}] {display}")
+
+    except SystemExit:
+        raise
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to delete issue link: {e}")
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     cli()

--- a/skills/jira-communication/scripts/utility/jira-link.py
+++ b/skills/jira-communication/scripts/utility/jira-link.py
@@ -234,9 +234,10 @@ def _format_link_display(link: dict, context_key: str | None = None) -> str:
     type_name = type_obj.get("name", "")
     outward = link.get("outwardIssue") or {}
     inward = link.get("inwardIssue") or {}
-    if context_key and outward.get("key") == context_key and inward:
+    ctx_cf = context_key.casefold() if context_key else None
+    if ctx_cf and outward.get("key", "").casefold() == ctx_cf and inward:
         return f"{type_obj.get('outward', type_name)} {inward.get('key', '?')}"
-    if context_key and inward.get("key") == context_key and outward:
+    if ctx_cf and inward.get("key", "").casefold() == ctx_cf and outward:
         return f"{type_obj.get('inward', type_name)} {outward.get('key', '?')}"
     if outward:
         return f"{type_obj.get('outward', type_name)} {outward.get('key', '?')}"

--- a/skills/jira-communication/scripts/utility/jira-link.py
+++ b/skills/jira-communication/scripts/utility/jira-link.py
@@ -20,7 +20,7 @@ if _lib_path.exists():
     sys.path.insert(0, str(_lib_path.parent))
 
 import click
-from lib.client import LazyJiraClient
+from lib.client import LazyJiraClient, _sanitize_error
 from lib.output import error, format_output, format_table, success, warning
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -211,7 +211,7 @@ def list_cmd(ctx, issue_key: str):
     except Exception as e:
         if ctx.obj["debug"]:
             raise
-        error(f"Failed to list issue links for {issue_key}: {e}")
+        error(f"Failed to list issue links for {issue_key}: {_sanitize_error(str(e))}")
         sys.exit(1)
 
 
@@ -221,21 +221,29 @@ def _link_matches(link: dict, to_key: str, link_type: str) -> bool:
     if type_name.lower() != link_type.lower():
         return False
     other = link.get("outwardIssue") or link.get("inwardIssue") or {}
-    return other.get("key") == to_key
+    other_key = other.get("key", "")
+    return other_key.casefold() == to_key.casefold()
 
 
-def _format_link_display(link: dict) -> str:
-    """Format an issue link for human-readable output (e.g. 'blocks TEST-2')."""
+def _format_link_display(link: dict, context_key: str | None = None) -> str:
+    """Format an issue link for human-readable output (e.g. 'blocks TEST-2').
+
+    When context_key is provided, describe the link from that issue's
+    perspective — matters when both inward and outward are populated
+    (e.g. results from client.get_issue_link(id)).
+    """
     type_obj = link.get("type") or {}
     type_name = type_obj.get("name", "")
-    if "outwardIssue" in link:
-        other = link["outwardIssue"].get("key", "?")
-        relation = type_obj.get("outward", type_name)
-        return f"{relation} {other}"
-    if "inwardIssue" in link:
-        other = link["inwardIssue"].get("key", "?")
-        relation = type_obj.get("inward", type_name)
-        return f"{relation} {other}"
+    outward = link.get("outwardIssue") or {}
+    inward = link.get("inwardIssue") or {}
+    if context_key and outward.get("key") == context_key and inward:
+        return f"{type_obj.get('outward', type_name)} {inward.get('key', '?')}"
+    if context_key and inward.get("key") == context_key and outward:
+        return f"{type_obj.get('inward', type_name)} {outward.get('key', '?')}"
+    if outward:
+        return f"{type_obj.get('outward', type_name)} {outward.get('key', '?')}"
+    if inward:
+        return f"{type_obj.get('inward', type_name)} {inward.get('key', '?')}"
     return type_name
 
 
@@ -280,7 +288,12 @@ def delete(
         # Resolve to a single link_id + display string
         if link_id is not None:
             link = client.get_issue_link(link_id)
-            display = _format_link_display(link)
+            inward_key = (link.get("inwardIssue") or {}).get("key") or ""
+            outward_key = (link.get("outwardIssue") or {}).get("key") or ""
+            if issue_key.casefold() not in {inward_key.casefold(), outward_key.casefold()}:
+                error(f"Link id {link_id} is not associated with issue {issue_key}")
+                sys.exit(1)
+            display = _format_link_display(link, context_key=issue_key)
         else:
             issue = client.issue(issue_key, fields="issuelinks")
             raw_links = (issue.get("fields") or {}).get("issuelinks") or []
@@ -294,7 +307,10 @@ def delete(
                 sys.exit(1)
             link = matches[0]
             link_id = link.get("id")
-            display = _format_link_display(link)
+            if not link_id:
+                error("Matched link has no id; cannot delete")
+                sys.exit(1)
+            display = _format_link_display(link, context_key=issue_key)
 
         if dry_run:
             warning("DRY RUN - No link will be deleted")
@@ -315,7 +331,7 @@ def delete(
     except Exception as e:
         if ctx.obj["debug"]:
             raise
-        error(f"Failed to delete issue link: {e}")
+        error(f"Failed to delete issue link: {_sanitize_error(str(e))}")
         sys.exit(1)
 
 

--- a/skills/jira-communication/scripts/utility/jira-link.py
+++ b/skills/jira-communication/scripts/utility/jira-link.py
@@ -188,9 +188,7 @@ def list_cmd(ctx, issue_key: str):
             format_output(links, as_json=True)
         elif ctx.obj["quiet"]:
             for link_entry in links:
-                print(
-                    f"{link_entry['id']} {link_entry['type']} {link_entry['direction']} {link_entry['other_key']}"
-                )
+                print(f"{link_entry['id']} {link_entry['type']} {link_entry['direction']} {link_entry['other_key']}")
         else:
             if not links:
                 print(f"No issue links on {issue_key}")

--- a/skills/jira-communication/scripts/utility/jira-link.py
+++ b/skills/jira-communication/scripts/utility/jira-link.py
@@ -298,7 +298,7 @@ def delete(
             raw_links = (issue.get("fields") or {}).get("issuelinks") or []
             matches = [lnk for lnk in raw_links if _link_matches(lnk, to_key, link_type)]
             if not matches:
-                error(f"No {link_type!r} link from {issue_key} to {to_key}")
+                error(f"No {link_type!r} link between {issue_key} and {to_key}")
                 sys.exit(1)
             if len(matches) > 1:
                 ids = ", ".join(m.get("id", "?") for m in matches)

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -176,11 +176,21 @@ class TestLinkList:
 
 class TestLinkDelete:
     def test_delete_by_id(self):
+        # get_issue_link returns a global link view with BOTH endpoints.
+        # issue_key matches outwardIssue.key so verbiage comes from the
+        # outward label.
         mc = _make_mock_client()
-        mc.get_issue_link.return_value = _issue_link("42", "Blocks", "outward", "TEST-2", "Blocked")
-        result, _ = _run_link(["delete", "TEST-1", "--id", "42"], mc)
+        mc.get_issue_link.return_value = {
+            "id": "42",
+            "type": {"name": "Blocks", "outward": "blocks", "inward": "is blocked by"},
+            "inwardIssue": {"key": "TEST-1", "fields": {"summary": "Src", "status": {"name": "Open"}}},
+            "outwardIssue": {"key": "TEST-2", "fields": {"summary": "Blocked", "status": {"name": "Open"}}},
+        }
+        result, _ = _run_link(["delete", "TEST-2", "--id", "42"], mc)
         assert result.exit_code == 0, result.output
         assert "Deleted link" in result.output
+        # issue_key=TEST-2 matches outwardIssue, so display uses outward verbiage
+        assert "blocks" in result.output
         mc.remove_issue_link.assert_called_once_with("42")
 
     def test_delete_by_to_and_type(self):
@@ -201,7 +211,12 @@ class TestLinkDelete:
 
     def test_delete_dry_run(self):
         mc = _make_mock_client()
-        mc.get_issue_link.return_value = _issue_link("42", "Blocks", "outward", "TEST-2", "X")
+        mc.get_issue_link.return_value = {
+            "id": "42",
+            "type": {"name": "Blocks", "outward": "blocks", "inward": "is blocked by"},
+            "inwardIssue": {"key": "TEST-1", "fields": {"summary": "X", "status": {"name": "Open"}}},
+            "outwardIssue": {"key": "TEST-2", "fields": {"summary": "Y", "status": {"name": "Open"}}},
+        }
         result, _ = _run_link(["delete", "TEST-1", "--id", "42", "--dry-run"], mc)
         assert result.exit_code == 0, result.output
         assert "DRY RUN" in result.output
@@ -262,7 +277,12 @@ class TestLinkDelete:
 
     def test_delete_json_output(self):
         mc = _make_mock_client()
-        mc.get_issue_link.return_value = _issue_link("42", "Blocks", "outward", "TEST-2", "X")
+        mc.get_issue_link.return_value = {
+            "id": "42",
+            "type": {"name": "Blocks", "outward": "blocks", "inward": "is blocked by"},
+            "inwardIssue": {"key": "TEST-1", "fields": {"summary": "X", "status": {"name": "Open"}}},
+            "outwardIssue": {"key": "TEST-2", "fields": {"summary": "Y", "status": {"name": "Open"}}},
+        }
         result, _ = _run_link(["--json", "delete", "TEST-1", "--id", "42"], mc)
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
@@ -272,15 +292,68 @@ class TestLinkDelete:
 
     def test_delete_quiet_output(self):
         mc = _make_mock_client()
-        mc.get_issue_link.return_value = _issue_link("42", "Blocks", "outward", "TEST-2", "X")
+        mc.get_issue_link.return_value = {
+            "id": "42",
+            "type": {"name": "Blocks", "outward": "blocks", "inward": "is blocked by"},
+            "inwardIssue": {"key": "TEST-1", "fields": {"summary": "X", "status": {"name": "Open"}}},
+            "outwardIssue": {"key": "TEST-2", "fields": {"summary": "Y", "status": {"name": "Open"}}},
+        }
         result, _ = _run_link(["--quiet", "delete", "TEST-1", "--id", "42"], mc)
         assert result.exit_code == 0
         assert result.output.strip() == "ok"
 
     def test_delete_api_exception_shows_error(self):
         mc = _make_mock_client()
-        mc.get_issue_link.return_value = _issue_link("42", "Blocks", "outward", "TEST-2", "X")
+        # Link has TEST-1 as inward so delete against TEST-1 resolves correctly.
+        mc.get_issue_link.return_value = {
+            "id": "42",
+            "type": {"name": "Blocks", "outward": "blocks", "inward": "is blocked by"},
+            "inwardIssue": {"key": "TEST-1", "fields": {"summary": "X", "status": {"name": "Open"}}},
+            "outwardIssue": {"key": "TEST-2", "fields": {"summary": "Y", "status": {"name": "Open"}}},
+        }
         mc.remove_issue_link.side_effect = Exception("403 Forbidden")
         result, _ = _run_link(["delete", "TEST-1", "--id", "42"], mc)
         assert result.exit_code == 1
         assert "Failed to delete issue link" in result.output
+
+    def test_delete_by_id_wrong_issue_key(self):
+        """Reject delete when the link id is not associated with issue_key."""
+        mc = _make_mock_client()
+        mc.get_issue_link.return_value = {
+            "id": "42",
+            "type": {"name": "Blocks", "outward": "blocks", "inward": "is blocked by"},
+            "inwardIssue": {"key": "OTHER-A", "fields": {"summary": "A", "status": {"name": "Open"}}},
+            "outwardIssue": {"key": "OTHER-B", "fields": {"summary": "B", "status": {"name": "Open"}}},
+        }
+        result, _ = _run_link(["delete", "UNRELATED-1", "--id", "42"], mc)
+        assert result.exit_code == 1
+        assert "not associated" in result.output
+        mc.remove_issue_link.assert_not_called()
+
+    def test_delete_by_id_context_chooses_inward_direction(self):
+        """When issue_key is the inward side, verbiage uses the inward label."""
+        mc = _make_mock_client()
+        mc.get_issue_link.return_value = {
+            "id": "42",
+            "type": {"name": "Blocks", "outward": "blocks", "inward": "is blocked by"},
+            "inwardIssue": {"key": "PROJ-B", "fields": {"summary": "B", "status": {"name": "Open"}}},
+            "outwardIssue": {"key": "PROJ-A", "fields": {"summary": "A", "status": {"name": "Open"}}},
+        }
+        result, _ = _run_link(["delete", "PROJ-B", "--id", "42"], mc)
+        assert result.exit_code == 0, result.output
+        assert "is blocked by PROJ-A" in result.output
+        assert "blocks PROJ-A" not in result.output
+
+    def test_delete_by_to_lowercase(self):
+        """--to PROJ-2 should match even when Jira returns TEST-2 (case-insensitive)."""
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue_with_links(
+            "TEST-1",
+            [_issue_link("7", "Blocks", "outward", "TEST-2", "X")],
+        )
+        result, _ = _run_link(
+            ["delete", "TEST-1", "--to", "test-2", "--type", "blocks"],
+            mc,
+        )
+        assert result.exit_code == 0, result.output
+        mc.remove_issue_link.assert_called_once_with("7")

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -357,3 +357,23 @@ class TestLinkDelete:
         )
         assert result.exit_code == 0, result.output
         mc.remove_issue_link.assert_called_once_with("7")
+
+    def test_delete_by_id_context_key_case_insensitive(self):
+        """Display direction must remain correct when ISSUE_KEY case differs from Jira's canonical case.
+
+        Regression: without casefold the context match fell through to the
+        generic outward branch and displayed "blocks PROJ-A" even when the
+        user's issue was on the outward side (correct: "blocks PROJ-B").
+        """
+        mc = _make_mock_client()
+        mc.get_issue_link.return_value = {
+            "id": "42",
+            "type": {"name": "Blocks", "outward": "blocks", "inward": "is blocked by"},
+            "inwardIssue": {"key": "PROJ-B", "fields": {"summary": "B", "status": {"name": "Open"}}},
+            "outwardIssue": {"key": "PROJ-A", "fields": {"summary": "A", "status": {"name": "Open"}}},
+        }
+        result, _ = _run_link(["delete", "proj-a", "--id", "42"], mc)
+        assert result.exit_code == 0, result.output
+        # proj-a matches outward (PROJ-A), so display should use outward verb + inward key
+        assert "blocks PROJ-B" in result.output
+        assert "is blocked by" not in result.output

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,0 +1,286 @@
+"""Tests for jira-link.py list + delete subcommands."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import click.testing
+import pytest
+
+# Add scripts to path for lib imports
+_test_dir = Path(__file__).parent
+_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
+sys.path.insert(0, str(_scripts_path))
+
+
+def _load_script(name: str, subdir: str = "utility"):
+    """Load a hyphenated CLI script via importlib."""
+    path = _scripts_path / subdir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_link_mod = _load_script("jira-link", "utility")
+
+
+def _make_mock_client():
+    mc = mock.Mock()
+    mc.with_context = mock.Mock()
+    return mc
+
+
+def _run_link(args, mock_client=None):
+    """Run jira-link CLI with a mocked LazyJiraClient."""
+    if mock_client is None:
+        mock_client = _make_mock_client()
+    runner = click.testing.CliRunner()
+    with mock.patch.object(_link_mod, "LazyJiraClient", return_value=mock_client):
+        result = runner.invoke(_link_mod.cli, args)
+    return result, mock_client
+
+
+def _issue_link(link_id="10042", type_name="Blocks", direction="outward", other_key="TEST-2", other_summary="Other"):
+    """Build an issue link dict matching the Jira REST API shape.
+
+    direction: 'outward' or 'inward'
+    """
+    type_obj = {
+        "name": type_name,
+        "outward": type_name.lower().rstrip("s") + "s" if type_name else "",
+        "inward": "is " + (type_name.lower().rstrip("s") + "ed by") if type_name else "",
+    }
+    # Use canonical labels for Blocks so tests match reality
+    if type_name == "Blocks":
+        type_obj = {"name": "Blocks", "outward": "blocks", "inward": "is blocked by"}
+    elif type_name == "Relates":
+        type_obj = {"name": "Relates", "outward": "relates to", "inward": "is related to"}
+
+    other = {
+        "key": other_key,
+        "fields": {"summary": other_summary, "status": {"name": "Open"}},
+    }
+    link = {"id": str(link_id), "type": type_obj}
+    if direction == "outward":
+        link["outwardIssue"] = other
+    else:
+        link["inwardIssue"] = other
+    return link
+
+
+def _issue_with_links(key="TEST-1", links=None):
+    return {"key": key, "fields": {"issuelinks": links or []}}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: help smoke
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestLinkHelp:
+    """Subcommands must respond to --help with exit code 0."""
+
+    @pytest.mark.parametrize("subcmd", ["create", "list", "list-types", "delete"])
+    def test_subcommand_help(self, subcmd):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_link_mod.cli, [subcmd, "--help"])
+        assert result.exit_code == 0, result.output
+
+    def test_list_help_shows_issue_key_arg(self):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_link_mod.cli, ["list", "--help"])
+        assert result.exit_code == 0
+        assert "ISSUE_KEY" in result.output
+
+    def test_delete_help_shows_id_and_to(self):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_link_mod.cli, ["delete", "--help"])
+        assert result.exit_code == 0
+        assert "--id" in result.output
+        assert "--to" in result.output
+        assert "--type" in result.output
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: list subcommand
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestLinkList:
+    def test_list_text_output(self):
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue_with_links(
+            "TEST-1",
+            [
+                _issue_link("101", "Blocks", "outward", "TEST-2", "Blocked task"),
+                _issue_link("102", "Relates", "inward", "TEST-3", "Related"),
+            ],
+        )
+        result, _ = _run_link(["list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "101" in result.output
+        assert "Blocks" in result.output
+        assert "TEST-2" in result.output
+        assert "102" in result.output
+        assert "TEST-3" in result.output
+
+    def test_list_json_output(self):
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue_with_links(
+            "TEST-1",
+            [_issue_link("101", "Blocks", "outward", "TEST-2", "Blocked task")],
+        )
+        result, _ = _run_link(["--json", "list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["id"] == "101"
+        assert data[0]["type"] == "Blocks"
+        assert data[0]["direction"] == "outward"
+        assert data[0]["other_key"] == "TEST-2"
+
+    def test_list_empty(self):
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue_with_links("TEST-1", [])
+        result, _ = _run_link(["list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "No issue links" in result.output
+
+    def test_list_quiet(self):
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue_with_links(
+            "TEST-1",
+            [_issue_link("55", "Blocks", "outward", "TEST-2", "X")],
+        )
+        result, _ = _run_link(["--quiet", "list", "TEST-1"], mc)
+        assert result.exit_code == 0
+        assert "55" in result.output
+        assert "Blocks" in result.output
+        assert "TEST-2" in result.output
+
+    def test_list_api_exception_shows_error(self):
+        mc = _make_mock_client()
+        mc.issue.side_effect = Exception("500 Server Error")
+        result, _ = _run_link(["list", "TEST-1"], mc)
+        assert result.exit_code == 1
+        assert "Failed to list issue links" in result.output
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: delete subcommand
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestLinkDelete:
+    def test_delete_by_id(self):
+        mc = _make_mock_client()
+        mc.get_issue_link.return_value = _issue_link("42", "Blocks", "outward", "TEST-2", "Blocked")
+        result, _ = _run_link(["delete", "TEST-1", "--id", "42"], mc)
+        assert result.exit_code == 0, result.output
+        assert "Deleted link" in result.output
+        mc.remove_issue_link.assert_called_once_with("42")
+
+    def test_delete_by_to_and_type(self):
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue_with_links(
+            "TEST-1",
+            [
+                _issue_link("7", "Blocks", "outward", "TEST-2", "B"),
+                _issue_link("8", "Relates", "outward", "TEST-9", "R"),
+            ],
+        )
+        result, _ = _run_link(
+            ["delete", "TEST-1", "--to", "TEST-2", "--type", "Blocks"],
+            mc,
+        )
+        assert result.exit_code == 0, result.output
+        mc.remove_issue_link.assert_called_once_with("7")
+
+    def test_delete_dry_run(self):
+        mc = _make_mock_client()
+        mc.get_issue_link.return_value = _issue_link("42", "Blocks", "outward", "TEST-2", "X")
+        result, _ = _run_link(["delete", "TEST-1", "--id", "42", "--dry-run"], mc)
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        assert "Would delete" in result.output
+        mc.remove_issue_link.assert_not_called()
+
+    def test_delete_missing_all_identifiers(self):
+        result, _ = _run_link(["delete", "TEST-1"])
+        assert result.exit_code == 1
+        assert "--id" in result.output or "--to" in result.output
+
+    def test_delete_conflicting_identifiers(self):
+        result, _ = _run_link(
+            ["delete", "TEST-1", "--id", "42", "--to", "TEST-2", "--type", "Blocks"],
+        )
+        assert result.exit_code == 1
+        assert "OR" in result.output or "not both" in result.output
+
+    def test_delete_to_without_type(self):
+        result, _ = _run_link(["delete", "TEST-1", "--to", "TEST-2"])
+        assert result.exit_code == 1
+
+    def test_delete_type_without_to(self):
+        result, _ = _run_link(["delete", "TEST-1", "--type", "Blocks"])
+        assert result.exit_code == 1
+
+    def test_delete_to_type_no_match(self):
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue_with_links(
+            "TEST-1",
+            [_issue_link("7", "Relates", "outward", "TEST-9", "R")],
+        )
+        result, _ = _run_link(
+            ["delete", "TEST-1", "--to", "TEST-2", "--type", "Blocks"],
+            mc,
+        )
+        assert result.exit_code == 1
+        assert "No" in result.output
+
+    def test_delete_to_type_multiple_matches(self):
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue_with_links(
+            "TEST-1",
+            [
+                _issue_link("7", "Blocks", "outward", "TEST-2", "A"),
+                _issue_link("8", "Blocks", "outward", "TEST-2", "B"),
+            ],
+        )
+        result, _ = _run_link(
+            ["delete", "TEST-1", "--to", "TEST-2", "--type", "Blocks"],
+            mc,
+        )
+        assert result.exit_code == 1
+        assert "Multiple" in result.output
+        assert "7" in result.output
+        assert "8" in result.output
+        mc.remove_issue_link.assert_not_called()
+
+    def test_delete_json_output(self):
+        mc = _make_mock_client()
+        mc.get_issue_link.return_value = _issue_link("42", "Blocks", "outward", "TEST-2", "X")
+        result, _ = _run_link(["--json", "delete", "TEST-1", "--id", "42"], mc)
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["deleted"] is True
+        assert data["id"] == "42"
+        assert data["key"] == "TEST-1"
+
+    def test_delete_quiet_output(self):
+        mc = _make_mock_client()
+        mc.get_issue_link.return_value = _issue_link("42", "Blocks", "outward", "TEST-2", "X")
+        result, _ = _run_link(["--quiet", "delete", "TEST-1", "--id", "42"], mc)
+        assert result.exit_code == 0
+        assert result.output.strip() == "ok"
+
+    def test_delete_api_exception_shows_error(self):
+        mc = _make_mock_client()
+        mc.get_issue_link.return_value = _issue_link("42", "Blocks", "outward", "TEST-2", "X")
+        mc.remove_issue_link.side_effect = Exception("403 Forbidden")
+        result, _ = _run_link(["delete", "TEST-1", "--id", "42"], mc)
+        assert result.exit_code == 1
+        assert "Failed to delete issue link" in result.output


### PR DESCRIPTION
## Summary

- Adds `jira-link list ISSUE_KEY` — shows all issue links with IDs, type, direction, related key/summary/status. Supports `--json` / `--quiet`.
- Adds `jira-link delete ISSUE_KEY` — deletes by `--id` or by `--to`/`--type`. Detects ambiguous matches and requires `--id` to disambiguate. Supports `--dry-run`.
- Documents `jira-link` CRUD and previously-undocumented `jira-weblink update`/`delete` in `SKILL.md` (closing a discoverability gap that had agents falling back to raw REST).

## Why

`jira-link.py` only had `create` and `list-types`. Agents that needed to remove a link either gave up or hand-rolled `DELETE /rest/api/2/issueLink/{linkId}`. The web-link deletion *already* existed but was undocumented, so agents assumed it was also missing. Fixing both the real feature gap and the doc gap.

Implementation mirrors `jira-weblink.py`'s CRUD pattern and uses `atlassian-python-api`'s `remove_issue_link()` — no direct HTTP.

## Test plan

- [x] 23 new tests in `tests/test_link.py` (help, list: text/json/quiet/empty/error, delete: by id, by to+type, dry-run, arg validation, ambiguity, API errors)
- [x] Full suite: 346/346 pass
- [x] `ruff` clean
- [x] `bandit` (medium+) clean
- [ ] Smoke against real Jira (reviewer / release step)