### PR TITLE
feat(watchers): add jira-watchers.py (list/add/remove) + reference + evals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ uv.lock
 
 # Eval runner per-iteration transcripts (evals/results/*.json stays committed)
 evals/comprehensive-workspace/iteration-*/
+
+# Git worktrees
+.worktrees/

--- a/docs/plans/2026-04-20-changelog-design.md
+++ b/docs/plans/2026-04-20-changelog-design.md
@@ -1,0 +1,250 @@
+# Issue Changelog / History Design
+
+**Date:** 2026-04-20
+**Status:** Draft
+
+## Goal
+
+Expose an issue's change history ("who changed what, when") to agents and humans. The feature feeds audit trails, sprint retrospectives, and activity reports — answering questions like *who moved PROJ-123 to Done?*, *when did a given custom field last change?*, or *who un-assigned me yesterday?* External activity/reporting tools are likely consumers: feeding changelog rows lets them reconstruct "what did I touch this week" even when no worklog was booked.
+
+## Jira API
+
+Two endpoints exist, and they behave very differently:
+
+### Jira DC (v2) — embedded, capped at 100
+
+```
+GET /rest/api/2/issue/{key}?expand=changelog
+```
+
+The response contains a `changelog` object with `histories[]`. **The DC endpoint is hard-capped at 100 history entries**; there is no native pagination and no `startAt`/`maxResults` parameters on the issue resource. Long-lived tickets (e.g. long-running epics) will silently truncate. See [Jira DC 9.x — Get issue](https://docs.atlassian.com/software/jira/docs/api/REST/9.12.0/#api/2/issue-getIssue) and the `expand` notes on that page.
+
+### Jira Cloud (v3) — dedicated, paginated
+
+```
+GET /rest/api/3/issue/{issueIdOrKey}/changelog?startAt=0&maxResults=100
+```
+
+Paginated, default `maxResults=100`, max `1000`. Designed for long histories. See [Cloud v3 — Get changelogs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-changelog-get).
+
+### Payload shape (both)
+
+```json
+{
+  "histories": [
+    {
+      "id": "10001",
+      "author": { "accountId": "...", "name": "...", "displayName": "..." },
+      "created": "2026-04-18T09:12:33.000+0000",
+      "items": [
+        {
+          "field": "status",
+          "fieldtype": "jira",
+          "fieldId": "status",
+          "from": "10000", "fromString": "In Progress",
+          "to": "10001",   "toString": "Done"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Pitfall — JQL search does not reliably return histories
+
+`POST /rest/api/2/search` with `expand=changelog` returns histories on Cloud but is inconsistent on DC (truncated or omitted depending on the instance configuration). **Always hit the per-issue endpoint.** Bulk history across a JQL result set is out of scope for this feature.
+
+### `atlassian-python-api` support
+
+- DC form already works: `client.issue(key, expand="changelog")` returns `{"changelog": {"histories": [...]}}`.
+- No first-class Cloud helper was found by grepping the installed package (`rg -n "changelog" $(python -c 'import atlassian, os; print(os.path.dirname(atlassian.__file__))')`). If that remains true at implementation time, fall back to the raw call:
+  ```python
+  client.get(f"rest/api/3/issue/{key}/changelog", params={"startAt": 0, "maxResults": 100})
+  ```
+  — this re-uses the session/auth already configured on `LazyJiraClient`.
+
+### Permissions
+
+*Browse Projects* on the issue's project. No extra permissions; if the user can `get` the issue, they can read its changelog.
+
+## New Subcommand: `jira-issue.py changelog`
+
+Extend the existing `skills/jira-communication/scripts/core/jira-issue.py` — the changelog is tightly coupled to the issue resource, exactly like `get`, `update`, and `delete`. Adding a sibling command keeps the CLI surface discoverable (`jira-issue --help` lists it) and matches the pattern established by the weblink design (weblinks got their own script because they're a separate REST resource with full CRUD; changelog is read-only and attached to the issue).
+
+No new script, no new library module. The date-parsing helper is reused from `jira-worklog-query.py` (see below).
+
+## CLI surface
+
+```
+jira-issue.py changelog ISSUE_KEY
+    [--field FIELD]...          # repeatable; match by field id OR display name (case-insensitive)
+    [--since DATE]              # ISO (2026-03-01) or relative (7d, 2w, 1m) — same parser as jira-worklog-query
+    [--until DATE]              # same
+    [--author USER]             # username, accountId, display name, or "me"
+    [--limit N]                 # cap total entries printed
+```
+
+### Examples
+
+```
+jira-issue.py changelog PROJ-123
+jira-issue.py changelog PROJ-123 --field status
+jira-issue.py changelog PROJ-123 --field customfield_10100 --since 30d   # example custom field id — yours will differ
+jira-issue.py changelog PROJ-123 --author me --since 7d --json
+```
+
+### Filter semantics
+
+- `--field` is repeatable and case-insensitive. `--field status --field sprint` matches items whose `fieldId`, `field` (display), or `fieldSchema.customId` resolves to one of those. Resolution order: `fieldId` → `field` (display name, lowercased) → `"customfield_" + str(fieldSchema.customId)`.
+- `--since` / `--until` filter by the parent history entry's `created` timestamp. Date parsing is reused from `jira-worklog-query.py` (relative forms like `7d`, `2w`, `1m`, plus ISO `YYYY-MM-DD`). Extract the parser into `lib/dates.py` if it hasn't been extracted already — otherwise import from the utility script.
+- `--author` resolves via `resolve_assignee` in `lib/client.py` (already handles `me` and account-id vs username ambiguity); filtering compares against `author.accountId`, `author.name`, and `author.displayName`.
+- `--limit` is applied **after** filtering. On DC, when the raw payload returns exactly 100 histories, emit a warning regardless of limit:
+  ```
+  ⚠ DC returned 100 history entries (cap). Results may be truncated.
+  ```
+
+### Output
+
+**Default (human table):**
+
+```
+PROJ-123 changelog (3 entries)
+
+WHEN              WHO            FIELD       FROM           TO
+2026-04-18 09:12  Alice Example  status      In Progress    Done
+2026-04-17 14:55  Bob Example    assignee    Alice Example  Bob Example
+2026-04-17 14:55  Bob Example    Sprint      Sprint 42      Sprint 43
+```
+
+**`--json` (flattened rows, not raw API):**
+
+```json
+[
+  {
+    "created": "2026-04-18T09:12:33.000+0000",
+    "author": {"accountId": "...", "name": "aexample", "displayName": "Alice Example"},
+    "field": "status",
+    "fieldId": "status",
+    "from": "10000",
+    "to":   "10001",
+    "fromString": "In Progress",
+    "toString":   "Done"
+  }
+]
+```
+
+Rationale: agents want one row per item, not nested `histories[].items[]`. The fan-out happens once, here.
+
+**`--quiet` (tab-separated, one row per line):**
+
+```
+2026-04-18T09:12:33+0000	aexample	status	In Progress	Done
+```
+
+## Use cases
+
+```
+# 1. Who moved PROJ-123 to Done and when (audit trail)
+jira-issue.py changelog PROJ-123 --field status
+```
+→ One-shot answer to the most common retrospective question.
+
+```
+# 2. When did this custom field last change? (debugging sprint loss, etc.)
+jira-issue.py changelog PROJ-123 --field customfield_10100   # example custom field id — yours will differ
+```
+→ Custom fields (sprint, story points, team, …) sometimes drop silently when scope changes; this surfaces the culprit.
+
+```
+# 3. Epic link churn — reparenting audit
+jira-issue.py changelog PROJ-123 --field "Epic Link" --json
+```
+→ Feed into a script to detect tickets that hopped epics mid-sprint.
+
+```
+# 4. Review a field's change history before handing off to another team
+jira-issue.py changelog PROJ-123 --field customfield_10100 --limit 3   # example custom field id — yours will differ
+```
+→ Verify what the latest value was and who wrote it before transitioning the ticket onward.
+
+```
+# 5. All status transitions for a ticket (sprint retro)
+jira-issue.py changelog PROJ-123 --field status --since 30d
+```
+→ Reconstruct the ticket's flow through the board.
+
+```
+# 6. Reproduce "who un-assigned me from PROJ-456?"
+jira-issue.py changelog PROJ-456 --field assignee --since 14d
+```
+→ Debug workflow/automation misfires.
+
+```
+# 7. Feed external activity/reporting tools
+jira-issue.py changelog PROJ-123 --author me --since 7d --json
+```
+→ JSON rows slot straight into an activity timeline built by an external tool.
+
+## DC vs Cloud differences
+
+| Concern | DC v2 | Cloud v3 |
+|---|---|---|
+| Endpoint | `GET /rest/api/2/issue/{key}?expand=changelog` — embedded | `GET /rest/api/3/issue/{key}/changelog` — dedicated |
+| Pagination | none (hard cap 100) | `startAt` / `maxResults`, default 100, max 1000 |
+| Helper in `atlassian-python-api` | `client.issue(key, expand="changelog")` | likely none — fall back to `client.get(...)` |
+| Long histories | problematic, silent truncation | designed for it |
+| Truncation detection | `len(histories) == 100` heuristic | check `isLast` flag in response |
+
+### Detection
+
+Use `is_cloud` from `lib.config.load_config` (already exposed — check `lib/config.py` to confirm the exact attribute name). Dispatch:
+
+```python
+if client.is_cloud:
+    histories = _fetch_cloud_changelog(client, key, limit)
+else:
+    histories = _fetch_dc_changelog(client, key)  # warns if len == 100
+```
+
+Both helpers return the same `histories[]` shape so the flatten/filter/format pipeline stays single-path.
+
+## Gotchas
+
+- **Silent 100-entry cap on DC.** Surface a warning on stderr whenever `len(histories) == 100`. Don't raise — the user may genuinely have exactly 100 entries, but the warning prompts them to check the ticket in the browser for the full record.
+- **Field name vs id.** The `items[].field` value is sometimes a display name ("Sprint"), sometimes an id ("status"). For `--field` matching, check in order: `fieldId` → lowercased `field` → `"customfield_" + str(fieldSchema.customId)`. Write a `_item_matches_field(item, requested)` helper and unit-test it against both forms.
+- **`fromString` / `toString` may be null** when a field was cleared (e.g. assignee removed). Render as `∅` in the human table and leave as JSON `null` in `--json` output. Do not coalesce to empty string — that loses information.
+- **Author identity differs between DC and Cloud.** DC has `author.name`, Cloud has `author.accountId`. Reuse the account-id detection already in `lib/client.py` (`resolve_assignee` handles this for writes; factor out the read side if needed). The JSON `author` object keeps whichever keys the API returned.
+- **Timezone.** Jira returns `created` in the instance's configured zone with an offset suffix. Display in local time for the table, keep the raw ISO string in JSON.
+
+## Testing
+
+Follow patterns from `tests/test_weblink.py` and `tests/test_link.py`: mock `LazyJiraClient`, feed synthetic payloads, assert on formatter output and flattened JSON rows.
+
+**Fixtures needed:**
+- `fixture_changelog_dc_embedded.json` — DC shape: full issue with `changelog.histories` inline, exactly 100 entries (to exercise the truncation warning), plus a small 3-entry variant.
+- `fixture_changelog_cloud_paginated.json` — Cloud shape: `{values: [...], isLast: true, maxResults: 100, startAt: 0, total: 42}`, plus a paginated variant (`isLast: false`) to test fetch-all.
+
+**Test cases:**
+
+- `test_changelog_dc_parses_embedded` — basic happy path, DC
+- `test_changelog_cloud_paginated_fetches_all_pages` — follows `isLast: false` through two pages
+- `test_changelog_dc_warns_on_100_cap` — asserts stderr contains the cap warning
+- `test_filter_by_field_matches_fieldId` — `--field status`
+- `test_filter_by_field_matches_display_name_case_insensitive` — `--field Sprint` matches `field: "Sprint"`
+- `test_filter_by_field_matches_customfield_via_schema` — `--field customfield_10100` matches via `fieldSchema.customId: 10100`
+- `test_filter_by_since_until` — date window, including relative form `7d`
+- `test_filter_by_author_me` — resolves `me` via `myself()` and matches `accountId`
+- `test_filter_by_author_username_dc` — matches `author.name`
+- `test_null_from_to_strings_render_as_empty_sentinel` — `fromString: null` → `∅` in text, `null` in JSON
+- `test_json_output_is_flattened_rows` — one row per item, not nested histories
+- `test_quiet_output_tab_separated` — shape check
+- `test_limit_applied_after_filter` — `--field status --limit 2` returns 2 rows even if 50 status items exist
+
+## Out of scope
+
+- **Worklog history** — separate API (`/issue/{key}/worklog`), already covered by `jira-worklog-query.py`.
+- **Comment history** — comment edits have their own endpoint; not a priority.
+- **Attachment history** — tracked as `Attachment` items in the changelog already; no separate endpoint needed, but no dedicated filter either.
+- **Project- or board-level changelog** — no Jira endpoint exposes this; would require crawling many issues.
+- **Writing to the changelog** — read-only feature. Jira does not expose write access to history.
+- **Bulk changelog across a JQL result set** — DC's `expand=changelog` on search is unreliable; a proper bulk implementation would need per-issue fetches and belongs in an external activity/reporting tool, not this script.

--- a/docs/plans/2026-04-20-changelog-plan.md
+++ b/docs/plans/2026-04-20-changelog-plan.md
@@ -1,0 +1,1462 @@
+# Issue Changelog Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `changelog` subcommand to `jira-issue.py` that fetches an issue's change history (who changed what, when) with filtering by field, date range, author, and limit.
+
+**Architecture:** Extends the existing `jira-issue.py` Click group — no new script. Dual-path fetch dispatches on `is_cloud`: DC uses embedded `expand=changelog` (capped at 100, surfaces a truncation warning), Cloud uses the paginated `/issue/{key}/changelog` endpoint. The pipeline is pure-function friendly: `flatten_histories()` → `filter_histories()` → formatter, which keeps TDD tractable and makes DC/Cloud paths converge on one shape downstream of the fetch helpers.
+
+**Tech Stack:** Python 3.10+, click, LazyJiraClient, atlassian-python-api.
+
+**Design doc:** `docs/plans/2026-04-20-changelog-design.md`
+
+---
+
+## Reuse notes (before you start)
+
+Before writing any task, skim these facts — they change how code is placed:
+
+- **`parse_date` does not currently exist** in `jira-worklog-query.py` (the design doc's claim is outdated as of `2026-04-21`). `lib/` has no date helpers either. **Decision for this change-set:** define a local `parse_date()` helper inside `jira-issue.py`, documented with a FIXME referencing later DRY-up if a second consumer appears. Smaller blast radius than extracting to `lib/dates.py` today. Revisit when a third consumer materializes.
+- **`is_cloud` detection** is available through `lib.config.is_cloud_url(url)` combined with the `JIRA_CLOUD` env override — mirror the same two-line check already used in `lib/client.py:309-311`. The plan wraps this in `_resolve_is_cloud(client)` to keep the subcommand body clean.
+- **`LazyJiraClient` uses `__getattr__` delegation** (`lib/client.py:260`), so `client.issue(key, expand="changelog")` and `client.get("rest/api/3/issue/...", params=...)` both forward to the underlying `atlassian.Jira` instance. No new lib methods needed.
+- **Existing `jira-issue.py` structure** (verified at `skills/jira-communication/scripts/core/jira-issue.py`, 442 lines):
+  - Imports block: lines 11-25 (add new imports here)
+  - Click group + shared ctx: lines 32-48
+  - `get` subcommand: lines 51-125
+  - `_print_issue` helper: lines 128-289
+  - `update` subcommand: lines 292-379
+  - `delete` subcommand: lines 382-438
+  - Entry point: lines 441-442
+  - **Insertion target for changelog helpers:** right after `_print_issue`, before `update` (between lines 289 and 292).
+  - **Insertion target for the `@cli.command("changelog")` subcommand:** between `delete` and the `if __name__` block (between lines 438 and 441).
+
+---
+
+### Task 1: Scaffold test file with fixtures
+
+**Files:**
+- Create: `tests/test_issue_changelog.py`
+
+**Step 1: Create the test file**
+
+Model the skeleton on `tests/test_weblink.py:1-54` (importlib loader, click.testing, mock helpers).
+
+```python
+"""Tests for jira-issue.py changelog subcommand."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import click.testing
+import pytest
+
+# Add scripts to path for lib imports
+_test_dir = Path(__file__).parent
+_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
+sys.path.insert(0, str(_scripts_path))
+
+
+def _load_script():
+    """Load jira-issue.py via importlib."""
+    path = _scripts_path / "core" / "jira-issue.py"
+    spec = importlib.util.spec_from_file_location("jira_issue", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_script()
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Raw API payload fixtures — DC (embedded) and Cloud (paginated).
+# Keep these as dict literals (not external JSON) so tests read top-to-bottom.
+# ───────────────────────────────────────────────────────────────────────────────
+
+
+def _history(hid, created, author_name, items, *, account_id=None, display_name=None):
+    author = {"name": author_name, "displayName": display_name or author_name}
+    if account_id:
+        author["accountId"] = account_id
+    return {"id": hid, "author": author, "created": created, "items": items}
+
+
+def _item(field, from_str, to_str, *, field_id=None, schema_custom_id=None):
+    row = {
+        "field": field,
+        "fieldtype": "jira",
+        "from": None,
+        "to": None,
+        "fromString": from_str,
+        "toString": to_str,
+    }
+    if field_id:
+        row["fieldId"] = field_id
+    if schema_custom_id:
+        row["fieldSchema"] = {"customId": schema_custom_id}
+    return row
+
+
+DC_EMBEDDED_FIXTURE = {
+    "key": "PROJ-1",
+    "changelog": {
+        "histories": [
+            _history(
+                "10001",
+                "2026-04-18T09:12:33.000+0000",
+                "alice",
+                [_item("status", "In Progress", "Done", field_id="status")],
+                display_name="Alice Example",
+                account_id="acct-alice",
+            ),
+            _history(
+                "10002",
+                "2026-04-17T14:55:00.000+0000",
+                "bwilson",
+                [
+                    _item("assignee", "Alice Example", "Bob Wilson", field_id="assignee"),
+                    _item("Sprint", "Sprint 42", "Sprint 43", schema_custom_id=10020),
+                ],
+                display_name="Bob Wilson",
+                account_id="acct-bob",
+            ),
+            _history(
+                "10003",
+                "2026-04-10T08:00:00.000+0000",
+                "alice",
+                [_item("assignee", "Bob Wilson", None, field_id="assignee")],  # un-assigned
+                display_name="Alice Example",
+                account_id="acct-alice",
+            ),
+        ]
+    },
+}
+
+
+CLOUD_PAGINATED_FIXTURE = {
+    "startAt": 0,
+    "maxResults": 100,
+    "total": 3,
+    "isLast": True,
+    "values": DC_EMBEDDED_FIXTURE["changelog"]["histories"],
+}
+```
+
+**Step 2: Sanity-check the fixture loads**
+
+Run:
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py -q
+```
+
+Expected: collected 0 items (no tests yet), exit 5. Anything else indicates an import error — fix before proceeding.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_issue_changelog.py
+git commit -m "test(changelog): scaffold test file with DC and Cloud fixtures"
+```
+
+---
+
+### Task 2: `flatten_histories()` helper — pure fan-out
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+- Modify: `skills/jira-communication/scripts/core/jira-issue.py`
+
+**Step 1: Write failing tests**
+
+Append to `tests/test_issue_changelog.py`:
+
+```python
+class TestFlattenHistories:
+    def test_fans_out_items_into_rows(self):
+        histories = DC_EMBEDDED_FIXTURE["changelog"]["histories"]
+        rows = _mod.flatten_histories(histories)
+        # 1 status + 2 (assignee + Sprint) + 1 un-assign = 4 rows
+        assert len(rows) == 4
+
+    def test_row_shape(self):
+        rows = _mod.flatten_histories(DC_EMBEDDED_FIXTURE["changelog"]["histories"])
+        first = rows[0]
+        assert first["created"] == "2026-04-18T09:12:33.000+0000"
+        assert first["author"]["name"] == "alice"
+        assert first["field"] == "status"
+        assert first["fieldId"] == "status"
+        assert first["fromString"] == "In Progress"
+        assert first["toString"] == "Done"
+
+    def test_preserves_null_to_string(self):
+        rows = _mod.flatten_histories(DC_EMBEDDED_FIXTURE["changelog"]["histories"])
+        unassign = [r for r in rows if r["fromString"] == "Bob Wilson"][0]
+        assert unassign["toString"] is None  # NOT coalesced
+
+    def test_preserves_field_schema(self):
+        rows = _mod.flatten_histories(DC_EMBEDDED_FIXTURE["changelog"]["histories"])
+        sprint = [r for r in rows if r["field"] == "Sprint"][0]
+        assert sprint["fieldSchema"] == {"customId": 10020}
+
+    def test_empty_histories(self):
+        assert _mod.flatten_histories([]) == []
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFlattenHistories -q
+```
+
+Expected: all FAIL with `AttributeError: module 'jira_issue' has no attribute 'flatten_histories'`.
+
+**Step 3: Implement `flatten_histories()` in `jira-issue.py`**
+
+Insert at the top of the helper region — directly after `_print_issue` ends at line 289 and before the `@cli.command()` for `update` on line 292. Add a section banner to keep the file self-navigable.
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# Changelog helpers (pure functions — dual-path DC/Cloud converge here)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def flatten_histories(histories: list[dict]) -> list[dict]:
+    """Fan out Jira histories[].items[] into one row per item.
+
+    Each row preserves the parent entry's created/author plus the item's
+    field metadata. Null fromString/toString are preserved (callers decide
+    how to render them — coalescing loses information).
+    """
+    rows: list[dict] = []
+    for entry in histories or []:
+        created = entry.get("created")
+        author = entry.get("author", {}) or {}
+        for item in entry.get("items", []) or []:
+            rows.append(
+                {
+                    "created": created,
+                    "author": author,
+                    "field": item.get("field"),
+                    "fieldId": item.get("fieldId"),
+                    "fieldSchema": item.get("fieldSchema"),
+                    "from": item.get("from"),
+                    "to": item.get("to"),
+                    "fromString": item.get("fromString"),
+                    "toString": item.get("toString"),
+                }
+            )
+    return rows
+```
+
+**Step 4: Run to verify pass**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFlattenHistories -q
+```
+
+Expected: 5 passed.
+
+**Step 5: Commit**
+
+```bash
+git add skills/jira-communication/scripts/core/jira-issue.py tests/test_issue_changelog.py
+git commit -m "feat(changelog): add flatten_histories() pure helper"
+```
+
+---
+
+### Task 3: `filter_histories()` — field matching
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+- Modify: `skills/jira-communication/scripts/core/jira-issue.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestFilterHistoriesByField:
+    @pytest.fixture
+    def rows(self):
+        return _mod.flatten_histories(DC_EMBEDDED_FIXTURE["changelog"]["histories"])
+
+    def test_match_by_field_id(self, rows):
+        out = _mod.filter_histories(rows, fields=["status"])
+        assert len(out) == 1
+        assert out[0]["field"] == "status"
+
+    def test_match_by_display_name_case_insensitive(self, rows):
+        out = _mod.filter_histories(rows, fields=["sprint"])
+        assert len(out) == 1
+        assert out[0]["field"] == "Sprint"
+
+    def test_match_by_customfield_schema(self, rows):
+        out = _mod.filter_histories(rows, fields=["customfield_10020"])
+        assert len(out) == 1
+        assert out[0]["field"] == "Sprint"
+
+    def test_multiple_fields_union(self, rows):
+        out = _mod.filter_histories(rows, fields=["status", "assignee"])
+        # 1 status + 2 assignee = 3 rows
+        assert len(out) == 3
+
+    def test_unknown_field_returns_empty(self, rows):
+        assert _mod.filter_histories(rows, fields=["nope"]) == []
+
+    def test_no_fields_filter_returns_all(self, rows):
+        assert len(_mod.filter_histories(rows, fields=None)) == 4
+
+
+class TestItemMatchesField:
+    def test_fieldid_precedence(self):
+        row = {"field": "Assignee", "fieldId": "assignee", "fieldSchema": None}
+        assert _mod._row_matches_field(row, "assignee")
+
+    def test_display_name_lowercased(self):
+        row = {"field": "Sprint", "fieldId": None, "fieldSchema": None}
+        assert _mod._row_matches_field(row, "SPRINT")
+
+    def test_customfield_via_schema(self):
+        row = {"field": "Whatever", "fieldId": None, "fieldSchema": {"customId": 10100}}
+        assert _mod._row_matches_field(row, "customfield_10100")
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py -q -k "Filter or Matches"
+```
+
+Expected: all FAIL.
+
+**Step 3: Implement helpers**
+
+Append to the changelog helpers region in `jira-issue.py` (right after `flatten_histories`):
+
+```python
+def _row_matches_field(row: dict, requested: str) -> bool:
+    """Match a flattened row against a requested field identifier.
+
+    Resolution order (per design doc):
+      1. fieldId exact match (case-insensitive)
+      2. field (display name) exact match (case-insensitive)
+      3. "customfield_" + fieldSchema.customId exact match (case-insensitive)
+    """
+    req = requested.lower()
+    field_id = (row.get("fieldId") or "").lower()
+    if field_id and field_id == req:
+        return True
+    field_display = (row.get("field") or "").lower()
+    if field_display and field_display == req:
+        return True
+    schema = row.get("fieldSchema") or {}
+    custom_id = schema.get("customId")
+    if custom_id is not None and f"customfield_{custom_id}".lower() == req:
+        return True
+    return False
+
+
+def filter_histories(
+    rows: list[dict],
+    *,
+    fields: list[str] | None = None,
+    since: str | None = None,  # filled in Task 4
+    until: str | None = None,  # filled in Task 4
+    author: str | None = None,  # filled in Task 5
+) -> list[dict]:
+    """Filter flattened changelog rows by field, date range, and author.
+
+    Date and author parameters are placeholders at this task — implemented
+    in Tasks 4 and 5. Keep the signature stable to avoid churn.
+    """
+    out = rows
+    if fields:
+        requested = list(fields)
+        out = [r for r in out if any(_row_matches_field(r, f) for f in requested)]
+    return out
+```
+
+**Step 4: Run to verify pass**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py -q -k "Filter or Matches"
+```
+
+Expected: 9 passed (6 filter + 3 matcher).
+
+**Step 5: Commit**
+
+```bash
+git add skills/jira-communication/scripts/core/jira-issue.py tests/test_issue_changelog.py
+git commit -m "feat(changelog): filter_histories by field with id/display/customfield precedence"
+```
+
+---
+
+### Task 4: `filter_histories()` — date range + local `parse_date()`
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+- Modify: `skills/jira-communication/scripts/core/jira-issue.py`
+
+**Rationale:** Design doc says "reuse parse_date from jira-worklog-query.py" but no such helper exists there today (verified `2026-04-21`). Local copy for this change-set, FIXME marker for later extraction to `lib/dates.py`.
+
+**Step 1: Write failing tests**
+
+```python
+class TestParseDate:
+    def test_iso_date(self):
+        from datetime import date
+        assert _mod.parse_date("2026-03-01") == date(2026, 3, 1)
+
+    def test_relative_days(self, monkeypatch):
+        from datetime import date
+        fake_today = date(2026, 4, 20)
+
+        class _FakeDate(date):
+            @classmethod
+            def today(cls):
+                return fake_today
+
+        monkeypatch.setattr(_mod, "date", _FakeDate)
+        assert _mod.parse_date("7d") == date(2026, 4, 13)
+
+    def test_relative_weeks(self, monkeypatch):
+        from datetime import date
+        fake_today = date(2026, 4, 20)
+
+        class _FakeDate(date):
+            @classmethod
+            def today(cls):
+                return fake_today
+
+        monkeypatch.setattr(_mod, "date", _FakeDate)
+        assert _mod.parse_date("2w") == date(2026, 4, 6)
+
+    def test_relative_months_approx(self, monkeypatch):
+        from datetime import date
+        fake_today = date(2026, 4, 20)
+
+        class _FakeDate(date):
+            @classmethod
+            def today(cls):
+                return fake_today
+
+        monkeypatch.setattr(_mod, "date", _FakeDate)
+        # 1m = 30 days (documented approximation)
+        assert _mod.parse_date("1m") == date(2026, 3, 21)
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError):
+            _mod.parse_date("garbage")
+
+
+class TestFilterHistoriesByDate:
+    @pytest.fixture
+    def rows(self):
+        return _mod.flatten_histories(DC_EMBEDDED_FIXTURE["changelog"]["histories"])
+
+    def test_since_inclusive(self, rows):
+        out = _mod.filter_histories(rows, since="2026-04-17")
+        # Drops the 2026-04-10 entry
+        assert len(out) == 3
+        assert all(r["created"][:10] >= "2026-04-17" for r in out)
+
+    def test_until_inclusive(self, rows):
+        out = _mod.filter_histories(rows, until="2026-04-17")
+        # Drops the 2026-04-18 entry
+        assert len(out) == 3
+        assert all(r["created"][:10] <= "2026-04-17" for r in out)
+
+    def test_since_and_until(self, rows):
+        out = _mod.filter_histories(rows, since="2026-04-17", until="2026-04-17")
+        assert len(out) == 2  # both items on 2026-04-17
+
+    def test_since_filters_nothing_when_before_all(self, rows):
+        out = _mod.filter_histories(rows, since="2020-01-01")
+        assert len(out) == 4
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py -q -k "ParseDate or ByDate"
+```
+
+Expected: all FAIL.
+
+**Step 3: Import `date`/`timedelta` and `re` into `jira-issue.py`**
+
+Edit the imports block (lines 11-14). After `import json`, add:
+
+```python
+import json
+import re
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+```
+
+**Step 4: Implement `parse_date()` and extend `filter_histories()`**
+
+Add `parse_date` right before `_row_matches_field` in the changelog helpers region:
+
+```python
+# FIXME(changelog/dates): duplicated with a future jira-worklog-query consumer.
+# When a second caller appears, extract to lib/dates.py. See design doc
+# 2026-04-20-changelog-design.md §Filter semantics.
+_RELATIVE_DATE_RE = re.compile(r"^(\d+)([dwm])$")
+
+
+def parse_date(value: str) -> "date":
+    """Parse an ISO date or relative form (Nd / Nw / Nm) into a date.
+
+    Nd = N days ago, Nw = N weeks ago, Nm = N months ago (30-day approx).
+    Raises ValueError on unparseable input.
+    """
+    match = _RELATIVE_DATE_RE.match(value.strip())
+    if match:
+        amount = int(match.group(1))
+        unit = match.group(2)
+        today = date.today()
+        if unit == "d":
+            return today - timedelta(days=amount)
+        if unit == "w":
+            return today - timedelta(weeks=amount)
+        if unit == "m":
+            return today - timedelta(days=amount * 30)
+    # Fall through to ISO parse; raises ValueError on bad input.
+    return date.fromisoformat(value)
+```
+
+Extend `filter_histories` — replace the body:
+
+```python
+def filter_histories(
+    rows: list[dict],
+    *,
+    fields: list[str] | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    author: str | None = None,  # implemented in Task 5
+) -> list[dict]:
+    """Filter flattened changelog rows by field, date range, and author."""
+    out = rows
+    if fields:
+        requested = list(fields)
+        out = [r for r in out if any(_row_matches_field(r, f) for f in requested)]
+    if since:
+        since_str = parse_date(since).isoformat()
+        out = [r for r in out if (r.get("created") or "")[:10] >= since_str]
+    if until:
+        until_str = parse_date(until).isoformat()
+        out = [r for r in out if (r.get("created") or "")[:10] <= until_str]
+    return out
+```
+
+**Step 5: Run to verify pass**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py -q -k "ParseDate or ByDate"
+```
+
+Expected: 9 passed (5 parse_date + 4 date filter).
+
+**Step 6: Commit**
+
+```bash
+git add skills/jira-communication/scripts/core/jira-issue.py tests/test_issue_changelog.py
+git commit -m "feat(changelog): add parse_date and since/until filtering"
+```
+
+---
+
+### Task 5: `filter_histories()` — author matching
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+- Modify: `skills/jira-communication/scripts/core/jira-issue.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestFilterHistoriesByAuthor:
+    @pytest.fixture
+    def rows(self):
+        return _mod.flatten_histories(DC_EMBEDDED_FIXTURE["changelog"]["histories"])
+
+    def test_by_username(self, rows):
+        out = _mod.filter_histories(rows, author="bwilson")
+        assert len(out) == 2  # both items on the bwilson history entry
+        assert all(r["author"]["name"] == "bwilson" for r in out)
+
+    def test_by_display_name(self, rows):
+        out = _mod.filter_histories(rows, author="Alice Example")
+        assert len(out) == 2  # 1 status item + 1 un-assign item
+
+    def test_by_account_id(self, rows):
+        out = _mod.filter_histories(rows, author="acct-alice")
+        assert len(out) == 2
+
+    def test_unknown_author_empty(self, rows):
+        assert _mod.filter_histories(rows, author="nobody") == []
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFilterHistoriesByAuthor -q
+```
+
+Expected: all FAIL (filter ignores `author` so all 4 rows come back).
+
+**Step 3: Implement author filter**
+
+Extend `filter_histories` — add the author branch at the end of the function body, before `return out`:
+
+```python
+    if author:
+        out = [r for r in out if _row_matches_author(r, author)]
+    return out
+```
+
+Add the helper right below `_row_matches_field`:
+
+```python
+def _row_matches_author(row: dict, requested: str) -> bool:
+    """Match a row's author against a username, accountId, or display name.
+
+    Exact match; caller is responsible for resolving "me" to the current
+    user's identifier before calling (so this function stays pure).
+    """
+    a = row.get("author") or {}
+    return requested in (a.get("name", ""), a.get("accountId", ""), a.get("displayName", ""))
+```
+
+**Step 4: Run to verify pass**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFilterHistoriesByAuthor -q
+```
+
+Expected: 4 passed.
+
+**Step 5: Commit**
+
+```bash
+git add skills/jira-communication/scripts/core/jira-issue.py tests/test_issue_changelog.py
+git commit -m "feat(changelog): filter_histories by author (name/accountId/displayName)"
+```
+
+---
+
+### Task 6: DC fetch path
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+- Modify: `skills/jira-communication/scripts/core/jira-issue.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestFetchChangelogDc:
+    def test_calls_issue_with_expand_changelog(self):
+        client = mock.Mock()
+        client.issue.return_value = DC_EMBEDDED_FIXTURE
+        histories = _mod._fetch_changelog_dc(client, "PROJ-1")
+        client.issue.assert_called_once_with("PROJ-1", expand="changelog")
+        assert len(histories) == 3
+
+    def test_missing_changelog_returns_empty(self):
+        client = mock.Mock()
+        client.issue.return_value = {"key": "PROJ-1"}  # no changelog key
+        assert _mod._fetch_changelog_dc(client, "PROJ-1") == []
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFetchChangelogDc -q
+```
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Append to the changelog helpers region:
+
+```python
+def _fetch_changelog_dc(client, issue_key: str) -> list[dict]:
+    """Fetch changelog via DC's embedded expand=changelog.
+
+    DC is capped at 100 entries with no pagination. Caller is responsible
+    for surfacing the truncation warning (see _fetch_changelog).
+    """
+    issue = client.issue(issue_key, expand="changelog")
+    return issue.get("changelog", {}).get("histories", []) or []
+```
+
+**Step 4: Run to verify pass**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFetchChangelogDc -q
+```
+
+Expected: 2 passed.
+
+**Step 5: Commit**
+
+```bash
+git add skills/jira-communication/scripts/core/jira-issue.py tests/test_issue_changelog.py
+git commit -m "feat(changelog): add _fetch_changelog_dc helper"
+```
+
+---
+
+### Task 7: Cloud fetch path with pagination
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+- Modify: `skills/jira-communication/scripts/core/jira-issue.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestFetchChangelogCloud:
+    def test_single_page(self):
+        client = mock.Mock()
+        client.get.return_value = CLOUD_PAGINATED_FIXTURE
+        histories = _mod._fetch_changelog_cloud(client, "PROJ-1")
+        client.get.assert_called_once_with(
+            "rest/api/3/issue/PROJ-1/changelog",
+            params={"startAt": 0, "maxResults": 100},
+        )
+        assert len(histories) == 3
+
+    def test_follows_pagination_until_is_last(self):
+        client = mock.Mock()
+        page1 = {
+            "startAt": 0, "maxResults": 100, "total": 150, "isLast": False,
+            "values": DC_EMBEDDED_FIXTURE["changelog"]["histories"],  # 3 entries stand-in
+        }
+        page2 = {
+            "startAt": 100, "maxResults": 100, "total": 150, "isLast": True,
+            "values": DC_EMBEDDED_FIXTURE["changelog"]["histories"][:2],  # 2 entries
+        }
+        client.get.side_effect = [page1, page2]
+        histories = _mod._fetch_changelog_cloud(client, "PROJ-1")
+        assert len(histories) == 5
+        assert client.get.call_count == 2
+        # Second call offsets startAt by the page size.
+        second_params = client.get.call_args_list[1].kwargs["params"]
+        assert second_params["startAt"] == 100
+
+    def test_limit_stops_pagination(self):
+        client = mock.Mock()
+        client.get.return_value = {
+            "startAt": 0, "maxResults": 100, "total": 500, "isLast": False,
+            "values": DC_EMBEDDED_FIXTURE["changelog"]["histories"],  # 3 entries
+        }
+        histories = _mod._fetch_changelog_cloud(client, "PROJ-1", limit=2)
+        assert len(histories) == 2
+        # One fetch is enough — we hit the limit before asking for more.
+        assert client.get.call_count == 1
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFetchChangelogCloud -q
+```
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Append to changelog helpers:
+
+```python
+def _fetch_changelog_cloud(client, issue_key: str, limit: int | None = None) -> list[dict]:
+    """Fetch changelog via Cloud's paginated /issue/{key}/changelog endpoint.
+
+    Follows pagination until isLast=true or `limit` entries collected.
+    Returns the concatenated histories in API order.
+    """
+    all_histories: list[dict] = []
+    start_at = 0
+    page_size = 100
+    while True:
+        result = client.get(
+            f"rest/api/3/issue/{issue_key}/changelog",
+            params={"startAt": start_at, "maxResults": page_size},
+        )
+        values = result.get("values", []) or []
+        all_histories.extend(values)
+        if limit is not None and len(all_histories) >= limit:
+            return all_histories[:limit]
+        if result.get("isLast") is True or not values:
+            break
+        start_at += len(values) if values else page_size
+    return all_histories
+```
+
+**Step 4: Run to verify pass**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFetchChangelogCloud -q
+```
+
+Expected: 3 passed.
+
+**Step 5: Commit**
+
+```bash
+git add skills/jira-communication/scripts/core/jira-issue.py tests/test_issue_changelog.py
+git commit -m "feat(changelog): add _fetch_changelog_cloud helper with pagination"
+```
+
+---
+
+### Task 8: DC 100-cap truncation warning
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+- Modify: `skills/jira-communication/scripts/core/jira-issue.py`
+
+**Step 1: Write failing test**
+
+```python
+class TestDcCapWarning:
+    def test_warns_on_100_entries(self):
+        client = mock.Mock()
+        client.issue.return_value = {
+            "changelog": {"histories": [_history(str(i), "2026-04-18T00:00:00.000+0000",
+                                                 "alice", [_item("status", "x", "y")],
+                                                 display_name="Alice") for i in range(100)]}
+        }
+        with mock.patch.object(_mod, "warning") as mocked_warn:
+            _mod._fetch_changelog(client, "PROJ-1", is_cloud=False)
+        assert mocked_warn.called
+        msg = mocked_warn.call_args.args[0]
+        assert "100" in msg and "truncat" in msg.lower()
+
+    def test_no_warning_below_cap(self):
+        client = mock.Mock()
+        client.issue.return_value = DC_EMBEDDED_FIXTURE  # 3 entries
+        with mock.patch.object(_mod, "warning") as mocked_warn:
+            _mod._fetch_changelog(client, "PROJ-1", is_cloud=False)
+        assert not mocked_warn.called
+```
+
+Note: This test also exercises `_fetch_changelog` (the endpoint-dispatching helper from Task 9). Writing the warning tests before the dispatcher is deliberate — see Task 9 Step 3 for why the warning lives in the dispatcher.
+
+**Step 2: Run to verify failure**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestDcCapWarning -q
+```
+
+Expected: `AttributeError: module has no attribute '_fetch_changelog'`.
+
+**Step 3: Implementation deferred**
+
+`_fetch_changelog` is defined in Task 9 and includes the cap warning there. Leave these tests red until Task 9 lands, then verify both green together.
+
+**Step 4: Do not commit yet**
+
+These tests commit together with Task 9's dispatcher. Keep working tree dirty.
+
+---
+
+### Task 9: Endpoint dispatcher `_fetch_changelog()` + `_resolve_is_cloud()`
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+- Modify: `skills/jira-communication/scripts/core/jira-issue.py`
+
+**Step 1: Write failing tests for the dispatcher**
+
+```python
+class TestFetchChangelogDispatcher:
+    def test_dispatches_to_cloud_when_is_cloud_true(self):
+        client = mock.Mock()
+        client.get.return_value = CLOUD_PAGINATED_FIXTURE
+        _mod._fetch_changelog(client, "PROJ-1", is_cloud=True)
+        assert client.get.called
+        assert not client.issue.called
+
+    def test_dispatches_to_dc_when_is_cloud_false(self):
+        client = mock.Mock()
+        client.issue.return_value = DC_EMBEDDED_FIXTURE
+        _mod._fetch_changelog(client, "PROJ-1", is_cloud=False)
+        assert client.issue.called
+        assert not client.get.called
+
+    def test_cloud_forwards_limit(self):
+        client = mock.Mock()
+        client.get.return_value = CLOUD_PAGINATED_FIXTURE
+        _mod._fetch_changelog(client, "PROJ-1", is_cloud=True, limit=2)
+        params = client.get.call_args.kwargs["params"]
+        assert params["maxResults"] == 100  # page size stays 100; limit is applied in-helper
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFetchChangelogDispatcher tests/test_issue_changelog.py::TestDcCapWarning -q
+```
+
+Expected: all FAIL.
+
+**Step 3: Implement dispatcher + is_cloud resolver**
+
+Append to the changelog helpers region:
+
+```python
+DC_HISTORY_CAP = 100
+
+
+def _fetch_changelog(
+    client,
+    issue_key: str,
+    *,
+    is_cloud: bool,
+    limit: int | None = None,
+) -> list[dict]:
+    """Dispatch to the right fetch helper and surface DC truncation warnings."""
+    if is_cloud:
+        return _fetch_changelog_cloud(client, issue_key, limit=limit)
+    histories = _fetch_changelog_dc(client, issue_key)
+    if len(histories) >= DC_HISTORY_CAP:
+        warning(
+            f"DC returned {DC_HISTORY_CAP} history entries (cap). "
+            "Results may be truncated."
+        )
+    return histories
+
+
+def _resolve_is_cloud(client) -> bool:
+    """Decide whether the client is talking to Jira Cloud.
+
+    Mirrors the logic in lib/client.py:309-311 — JIRA_CLOUD env override
+    wins, otherwise fall back to URL pattern matching.
+    """
+    from lib.config import is_cloud_url, load_config
+
+    config = load_config()
+    explicit = str(config.get("JIRA_CLOUD", "")).lower()
+    if explicit in ("true", "false"):
+        return explicit == "true"
+    return is_cloud_url(config.get("JIRA_URL", ""))
+```
+
+**Step 4: Run both test classes to verify pass**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFetchChangelogDispatcher tests/test_issue_changelog.py::TestDcCapWarning -q
+```
+
+Expected: 5 passed (3 dispatcher + 2 cap warning).
+
+**Step 5: Commit**
+
+```bash
+git add skills/jira-communication/scripts/core/jira-issue.py tests/test_issue_changelog.py
+git commit -m "feat(changelog): dispatch DC/Cloud fetch and warn on DC 100-entry cap"
+```
+
+---
+
+### Task 10: Output formatters (table / JSON / quiet)
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+- Modify: `skills/jira-communication/scripts/core/jira-issue.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestFormatChangelog:
+    @pytest.fixture
+    def rows(self):
+        return _mod.flatten_histories(DC_EMBEDDED_FIXTURE["changelog"]["histories"])
+
+    def test_table_has_header_and_rows(self, rows):
+        out = _mod.format_changelog_table("PROJ-1", rows)
+        assert "PROJ-1" in out
+        assert "WHEN" in out and "WHO" in out and "FIELD" in out
+        assert "status" in out
+        assert "Alice Example" in out
+
+    def test_table_null_to_renders_dash(self, rows):
+        out = _mod.format_changelog_table("PROJ-1", rows)
+        # Un-assign row has toString=None — render as an em-dash sentinel.
+        assert "\u2014" in out  # em-dash sentinel
+
+    def test_json_is_flat_rows(self, rows):
+        out = _mod.format_changelog_json(rows)
+        parsed = json.loads(out)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 4
+        assert parsed[0]["field"] == "status"
+
+    def test_json_preserves_null_to_string(self, rows):
+        parsed = json.loads(_mod.format_changelog_json(rows))
+        unassign = next(r for r in parsed if r["fromString"] == "Bob Wilson")
+        assert unassign["toString"] is None
+
+    def test_quiet_is_tab_separated_one_row_per_line(self, rows):
+        out = _mod.format_changelog_quiet(rows)
+        lines = out.strip().splitlines()
+        assert len(lines) == 4
+        for line in lines:
+            parts = line.split("\t")
+            assert len(parts) == 5  # created, author, field, from, to
+
+    def test_empty_rows_table(self):
+        out = _mod.format_changelog_table("PROJ-1", [])
+        assert "no" in out.lower() or "0 entries" in out.lower()
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFormatChangelog -q
+```
+
+Expected: FAIL.
+
+**Step 3: Implement formatters**
+
+Append to changelog helpers region. Import `format_json` at the top of the file — edit the existing import on line 25:
+
+```python
+from lib.output import error, extract_adf_text, format_json, format_output, success, warning
+```
+
+Then implement:
+
+```python
+NULL_SENTINEL = "\u2014"  # em-dash — matches the design doc's rendering choice
+
+
+def _row_display(row: dict) -> tuple[str, str, str, str, str]:
+    """Extract display tuple (when, who, field, from, to) for a row."""
+    created = row.get("created", "") or ""
+    when = created[:16].replace("T", " ")  # "2026-04-18 09:12"
+    author = row.get("author", {}) or {}
+    who = author.get("displayName") or author.get("name") or ""
+    field = row.get("field") or row.get("fieldId") or ""
+    from_str = row.get("fromString")
+    to_str = row.get("toString")
+    from_disp = from_str if from_str is not None else NULL_SENTINEL
+    to_disp = to_str if to_str is not None else NULL_SENTINEL
+    return when, who, field, from_disp, to_disp
+
+
+def format_changelog_table(issue_key: str, rows: list[dict]) -> str:
+    """Render flattened rows as a fixed-column text table."""
+    if not rows:
+        return f"{issue_key} changelog (0 entries)\n"
+    lines = [f"{issue_key} changelog ({len(rows)} entries)", ""]
+    lines.append(f"{'WHEN':<17} {'WHO':<20} {'FIELD':<20} {'FROM':<20} TO")
+    for row in rows:
+        when, who, field, from_disp, to_disp = _row_display(row)
+        if len(who) > 20:
+            who = who[:17] + "..."
+        if len(field) > 20:
+            field = field[:17] + "..."
+        if len(from_disp) > 20:
+            from_disp = from_disp[:17] + "..."
+        lines.append(f"{when:<17} {who:<20} {field:<20} {from_disp:<20} {to_disp}")
+    return "\n".join(lines)
+
+
+def format_changelog_json(rows: list[dict]) -> str:
+    """Render rows as JSON (flattened, not nested histories)."""
+    return format_json(rows)
+
+
+def format_changelog_quiet(rows: list[dict]) -> str:
+    """Tab-separated: created\tauthor\tfield\tfrom\tto — one row per line."""
+    lines = []
+    for row in rows:
+        created = row.get("created", "") or ""
+        author = row.get("author", {}) or {}
+        who = author.get("name") or author.get("accountId") or author.get("displayName") or ""
+        field = row.get("field") or row.get("fieldId") or ""
+        from_str = row.get("fromString") if row.get("fromString") is not None else ""
+        to_str = row.get("toString") if row.get("toString") is not None else ""
+        lines.append(f"{created}\t{who}\t{field}\t{from_str}\t{to_str}")
+    return "\n".join(lines) + ("\n" if lines else "")
+```
+
+**Step 4: Run to verify pass**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestFormatChangelog -q
+```
+
+Expected: 6 passed.
+
+**Step 5: Commit**
+
+```bash
+git add skills/jira-communication/scripts/core/jira-issue.py tests/test_issue_changelog.py
+git commit -m "feat(changelog): add table/JSON/quiet formatters with null-sentinel rendering"
+```
+
+---
+
+### Task 11: Wire the `@cli.command("changelog")` subcommand
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+- Modify: `skills/jira-communication/scripts/core/jira-issue.py`
+
+**Step 1: Write failing happy-path integration test**
+
+```python
+class TestChangelogCli:
+    def _run(self, args, *, dc_fixture=None, is_cloud=False):
+        client = mock.Mock()
+        client.with_context = mock.Mock()
+        if dc_fixture is not None:
+            client.issue.return_value = dc_fixture
+        runner = click.testing.CliRunner()
+        with (
+            mock.patch.object(_mod, "LazyJiraClient", return_value=client),
+            mock.patch.object(_mod, "_resolve_is_cloud", return_value=is_cloud),
+        ):
+            result = runner.invoke(_mod.cli, args)
+        return result, client
+
+    def test_happy_path_table(self):
+        result, _ = self._run(
+            ["changelog", "PROJ-1"], dc_fixture=DC_EMBEDDED_FIXTURE, is_cloud=False
+        )
+        assert result.exit_code == 0, result.output
+        assert "PROJ-1 changelog" in result.output
+        assert "status" in result.output
+        assert "Alice Example" in result.output
+
+    def test_json_flag_emits_array(self):
+        result, _ = self._run(
+            ["--json", "changelog", "PROJ-1"], dc_fixture=DC_EMBEDDED_FIXTURE
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 4
+
+    def test_quiet_flag_tabs(self):
+        result, _ = self._run(
+            ["--quiet", "changelog", "PROJ-1"], dc_fixture=DC_EMBEDDED_FIXTURE
+        )
+        assert result.exit_code == 0
+        first_line = result.output.splitlines()[0]
+        assert first_line.count("\t") == 4
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestChangelogCli -q
+```
+
+Expected: FAIL with "No such command 'changelog'".
+
+**Step 3: Wire the subcommand in `jira-issue.py`**
+
+Insert between `delete` (ends at line 438) and `if __name__ == "__main__":` (line 441). Copy the decorator style, docstring style, and error handling pattern directly from `delete`.
+
+```python
+@cli.command()
+@click.argument("issue_key")
+@click.option(
+    "--field",
+    "fields",
+    multiple=True,
+    help="Filter by field id or display name (repeatable, case-insensitive)",
+)
+@click.option("--since", help="Start date: ISO (2026-03-01) or relative (7d, 2w, 1m)")
+@click.option("--until", help="End date: ISO or relative form")
+@click.option("--author", help="Filter by username, accountId, display name, or 'me'")
+@click.option("--limit", type=int, help="Cap total entries returned after filtering")
+@click.pass_context
+def changelog(
+    ctx,
+    issue_key: str,
+    fields: tuple[str, ...],
+    since: str | None,
+    until: str | None,
+    author: str | None,
+    limit: int | None,
+):
+    """Show an issue's change history.
+
+    ISSUE_KEY: The Jira issue key (e.g., PROJ-123)
+
+    Examples:
+
+      jira-issue changelog PROJ-123
+
+      jira-issue changelog PROJ-123 --field status
+
+      jira-issue changelog PROJ-123 --author me --since 7d --json
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+
+    try:
+        is_cloud = _resolve_is_cloud(client)
+
+        # Resolve "me" before filtering so filter_histories stays pure.
+        resolved_author = author
+        if author and author.lower() == "me":
+            me = client.myself()
+            resolved_author = me.get("accountId") or me.get("name") or me.get("displayName") or author
+
+        # Cloud can pre-trim at the API; DC fetches everything it has.
+        fetch_limit = limit if is_cloud and not (fields or since or until or author) else None
+        histories = _fetch_changelog(client, issue_key, is_cloud=is_cloud, limit=fetch_limit)
+
+        rows = flatten_histories(histories)
+        rows = filter_histories(
+            rows,
+            fields=list(fields) if fields else None,
+            since=since,
+            until=until,
+            author=resolved_author,
+        )
+        if limit is not None:
+            rows = rows[:limit]
+
+        if ctx.obj["json"]:
+            click.echo(format_changelog_json(rows))
+        elif ctx.obj["quiet"]:
+            click.echo(format_changelog_quiet(rows), nl=False)
+        else:
+            click.echo(format_changelog_table(issue_key, rows))
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to get changelog for {issue_key}: {e}")
+        sys.exit(1)
+```
+
+**Step 4: Run to verify pass**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestChangelogCli -q
+```
+
+Expected: 3 passed.
+
+**Step 5: Commit**
+
+```bash
+git add skills/jira-communication/scripts/core/jira-issue.py tests/test_issue_changelog.py
+git commit -m "feat(changelog): wire @cli.command('changelog') with --json/--quiet/default output"
+```
+
+---
+
+### Task 12: Integration test — all flags together
+
+**Files:**
+- Modify: `tests/test_issue_changelog.py`
+
+**Step 1: Extend the rich fixture and add a combined-flags test**
+
+Append to the `TestChangelogCli` class:
+
+```python
+    def test_all_flags_together(self):
+        # Rich fixture: status change by alice, assignee change by bwilson,
+        # another status change by alice outside the window, and an older
+        # status change by alice inside the window.
+        fixture = {
+            "changelog": {
+                "histories": [
+                    _history("1", "2026-04-20T10:00:00.000+0000", "alice",
+                             [_item("status", "To Do", "In Progress", field_id="status")],
+                             display_name="Alice", account_id="acct-alice"),
+                    _history("2", "2026-04-19T10:00:00.000+0000", "bwilson",
+                             [_item("assignee", "Alice", "Bob", field_id="assignee")],
+                             display_name="Bob", account_id="acct-bob"),
+                    _history("3", "2026-04-15T10:00:00.000+0000", "alice",
+                             [_item("status", "In Progress", "Done", field_id="status")],
+                             display_name="Alice", account_id="acct-alice"),
+                    _history("4", "2026-03-01T10:00:00.000+0000", "alice",
+                             [_item("status", "Open", "To Do", field_id="status")],
+                             display_name="Alice", account_id="acct-alice"),
+                ]
+            }
+        }
+        result, _ = self._run(
+            [
+                "changelog", "PROJ-1",
+                "--field", "status",
+                "--since", "2026-04-01",
+                "--until", "2026-04-30",
+                "--author", "alice",
+                "--limit", "10",
+            ],
+            dc_fixture=fixture,
+            is_cloud=False,
+        )
+        assert result.exit_code == 0, result.output
+        # Keeps history 1 and 3 (status + alice + in window), drops 2 (not alice),
+        # drops 4 (outside window).
+        assert "To Do" in result.output and "In Progress" in result.output
+        assert "Done" in result.output
+        assert "assignee" not in result.output  # history 2 filtered out by --field
+        assert "2026-03-01" not in result.output  # history 4 filtered out by --since
+```
+
+**Step 2: Run**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_issue_changelog.py::TestChangelogCli::test_all_flags_together -q
+```
+
+Expected: pass.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_issue_changelog.py
+git commit -m "test(changelog): integration test exercising all filter flags together"
+```
+
+---
+
+### Task 13: CLI smoke test coverage
+
+**Files:**
+- Modify: `tests/test_cli_smoke.py`
+
+**Step 1: Verify the existing `jira-issue --help` smoke test lists `changelog`**
+
+`tests/test_cli_smoke.py:62-64` already calls `--help` on `_issue_mod.cli`. After adding the subcommand, `--help` lists it in the Commands block. Strengthen `test_issue_help` to assert the subcommand is discoverable.
+
+Edit `tests/test_cli_smoke.py`, replacing `test_issue_help`:
+
+```python
+    def test_issue_help(self):
+        output = self._run_help(_issue_mod.cli)
+        assert "issue" in output.lower()
+        # changelog subcommand must be listed in the help output
+        assert "changelog" in output.lower()
+```
+
+**Step 2: Add a direct help check on the subcommand**
+
+Inside `TestHelpOutput`, append:
+
+```python
+    def test_issue_changelog_help(self):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_issue_mod.cli, ["changelog", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "changelog" in result.output.lower()
+        assert "--field" in result.output
+        assert "--since" in result.output
+        assert "--author" in result.output
+```
+
+**Step 3: Run smoke tests**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_cli_smoke.py -q
+```
+
+Expected: all pass including the new `test_issue_changelog_help`.
+
+**Step 4: Commit**
+
+```bash
+git add tests/test_cli_smoke.py
+git commit -m "test(changelog): extend smoke tests to cover changelog subcommand --help"
+```
+
+---
+
+### Task 14: Update SKILL.md
+
+**Files:**
+- Modify: `skills/jira-communication/SKILL.md`
+
+**Step 1: Add the changelog subcommand example**
+
+Locate the `jira-issue` example block in `skills/jira-communication/SKILL.md` (the file covering `get`/`update`/`delete` usage). Append — matching the surrounding example style, no new sections:
+
+```bash
+# Show issue changelog (who changed what, when)
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py changelog PROJ-123
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py changelog PROJ-123 --field status --since 30d
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py changelog PROJ-123 --author me --since 7d --json
+```
+
+**Step 2: Do not touch metadata.version or any other doc file**
+
+Per `CLAUDE.md`: version is managed only in `.claude-plugin/plugin.json` and SKILL.md metadata during releases, not per-feature.
+
+**Step 3: Commit**
+
+```bash
+git add skills/jira-communication/SKILL.md
+git commit -m "docs(changelog): add jira-issue changelog examples to SKILL.md"
+```
+
+---
+
+### Task 15: Full sweep — lint, security, tests
+
+**Files:** none (validation only; commit autofixes if any)
+
+**Step 1: Ruff**
+
+```bash
+uv run --no-project --with ruff ruff check skills/jira-communication/scripts/core/jira-issue.py tests/test_issue_changelog.py
+```
+
+Expected: clean. If any issues, run `ruff check --fix` on the same paths, re-run, commit as `style(changelog): apply ruff autofixes`.
+
+**Step 2: Bandit**
+
+```bash
+uv run --no-project --with bandit bandit -r skills/jira-communication/scripts/ scripts/ -c pyproject.toml --severity-level medium
+```
+
+Expected: clean.
+
+**Step 3: Full pytest**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/ -q
+```
+
+Expected: all tests pass. The suite previously had 187 tests (per MEMORY.md); after Tasks 1-12 it grows by roughly 40 tests (5 flatten + 9 filter-field + 9 date + 4 author + 2 dc + 3 cloud + 2 cap + 3 dispatcher + 6 format + 4 cli + 1 smoke ≈ 48).
+
+**Step 4: Pre-commit smoke**
+
+```bash
+uv run skills/jira-communication/scripts/core/jira-validate.py --help
+uv run skills/jira-communication/scripts/core/jira-issue.py changelog --help
+```
+
+Expected: both print help, exit 0.
+
+**Step 5: Invoke skill-repo before final commit**
+
+Per MEMORY.md: run `/skill-repo` to mirror CI's SKILL.md / plugin.json / composer.json validation. If it flags anything, fix and commit as `chore(changelog): address skill-repo findings`.
+
+**Step 6: No commit unless fixes were required**
+
+If all checks are clean, Task 15 produces no commit. If autofixes landed, commit them with the conventional prefix matching what changed (`style(changelog): ...` for ruff, `chore(changelog): ...` for metadata).

--- a/docs/plans/2026-04-20-versions-design.md
+++ b/docs/plans/2026-04-20-versions-design.md
@@ -1,0 +1,327 @@
+# Project Versions CRUD Design
+
+**Date:** 2026-04-20
+**Status:** Draft
+
+## Goal
+
+Add full CRUD for Jira project versions (a.k.a. "fix versions", "affects versions", "releases") to the Jira CLI skill, enabling release managers and developers to drive the release lifecycle from the command line. Typical flows covered: listing versions for a project, creating the next version before a sprint starts, marking a version released (`released=true` + `releaseDate`) after deploy, archiving old versions that no longer belong in pickers, and merging or deleting a version while reassigning `fixVersions` references on existing issues. The script should compose cleanly with `jira-search`, `jira-create`, and `jira-issue update` so that a release can be planned, executed, and closed end-to-end from the shell.
+
+## Jira API
+
+All endpoints below are documented under [Project Versions (Server/DC)](https://developer.atlassian.com/server/jira/platform/rest/v10002/api-group-project-version/) and [Project Versions (Cloud)](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-versions/).
+
+| Method | Path | Purpose | Min. Permission |
+|--------|------|---------|------------------|
+| `GET` | `/rest/api/2/project/{projectIdOrKey}/versions` | List all versions for a project (flat array) | Browse Projects |
+| `GET` | `/rest/api/2/project/{projectIdOrKey}/version?orderBy=&query=&status=released,unreleased` | Paginated search (DC ≥9.x, Cloud) | Browse Projects |
+| `POST` | `/rest/api/2/version` | Create a version | Administer Projects |
+| `GET` | `/rest/api/2/version/{id}` | Read one version | Browse Projects |
+| `PUT` | `/rest/api/2/version/{id}` | Update any field (supports `expand=operations`) | Administer Projects |
+| `DELETE` | `/rest/api/2/version/{id}?moveFixIssuesTo=&moveAffectedIssuesTo=` | Delete, optionally reassign `fixVersions` / `versions` refs | Administer Projects |
+| `POST` | `/rest/api/2/version/{id}/move` | Reorder: `{"after": ".../version/{otherId}"}` **or** `{"position": "First\|Last\|Earlier\|Later"}` | Administer Projects |
+| `POST` | `/rest/api/2/version/{id}/mergeto/{moveIssuesTo}` | Merge source into target (reassigns + deletes source) | Administer Projects |
+| `GET` | `/rest/api/2/version/{id}/relatedIssueCounts` | Fixed + affected issue counts | Browse Projects |
+| `GET` | `/rest/api/2/version/{id}/unresolvedIssueCount` | Unresolved count only | Browse Projects |
+
+### Minimal payloads
+
+Create (`POST /version`):
+
+```json
+{
+  "name": "1.4.0",
+  "project": "PROJ",
+  "description": "Q2 2026 release",
+  "startDate": "2026-05-01",
+  "releaseDate": "2026-05-31",
+  "released": false,
+  "archived": false
+}
+```
+
+Update (`PUT /version/{id}`) takes the same shape; see the safe-merge note in Gotchas.
+
+Move (`POST /version/{id}/move`):
+
+```json
+{"after": "https://jira.example.com/rest/api/2/version/10042"}
+```
+
+…or:
+
+```json
+{"position": "Earlier"}
+```
+
+### atlassian-python-api coverage
+
+The library exposes these helpers (verify against installed version with
+`python -c "import atlassian; help(atlassian.Jira.add_version)"`):
+
+- `get_project_versions(key)` — flat list
+- `get_project_versions_paginated(key, start, limit, order_by=None, expand=None)` — DC ≥9.x / Cloud
+- `add_version(name, project_key, is_released=False, is_archived=False)` — limited keyword set
+- `update_version(version, name=None, description=None, is_released=None, is_archived=None, start_date=None, release_date=None)`
+- `get_version(version)`
+- `delete_version(version, moved_fixed=None, move_affected=None)`
+
+The library does **not** wrap `move`, `mergeto`, `relatedIssueCounts`, or `unresolvedIssueCount`. For those, call the underlying HTTP client directly:
+
+```python
+client.post(f"rest/api/2/version/{vid}/move", data={"position": "Last"})
+client.get(f"rest/api/2/version/{vid}/relatedIssueCounts")
+```
+
+Prefer raw HTTP for `add_version` / `update_version` as well, because the wrapper's argument surface drops several fields (e.g. `startDate`). A thin internal helper (`_put_version`, `_post_version`) keeps payload construction explicit and testable.
+
+## Field name gotcha
+
+Two issue fields reference versions, with confusingly similar names:
+
+| Issue field | Jira UI label | Meaning |
+|-------------|---------------|---------|
+| `fixVersions` | "Fix Version/s" | Version(s) the issue is (or will be) fixed/released in |
+| `versions` | "Affects Version/s" | Version(s) in which the issue was observed |
+
+Both take an array of reference objects — either `[{"id": "10042"}]` or `[{"name": "1.4.0"}]`. It is a common bug to post `"version"` (singular) or `"fixVersion"` (singular, no `s`); Jira silently ignores unknown fields on create and returns a confusing "field does not exist on screen" on update. Wherever the script emits or consumes these, use the exact plural field names.
+
+## New Script: `jira-version.py`
+
+Location: `skills/jira-communication/scripts/workflow/jira-version.py` (workflow/, because version lifecycle is release-management-adjacent and composes with `jira-create` / `jira-transition`).
+
+Follows existing conventions: PEP 723 header with `atlassian-python-api` and `click`, Click group with the standard global flags (`--json`, `--quiet`, `--env-file`, `--profile`, `--debug`), `LazyJiraClient`, and `lib.output` (`success`, `warning`, `error`, `format_output`).
+
+### Subcommands
+
+#### `list PROJECT_KEY [--status released|unreleased|archived|all] [--query TEXT] [--order-by sequence|name|startDate|releaseDate]`
+
+Lists versions in a project. Default `--status unreleased`. Uses the paginated endpoint when `--query` or `--order-by` is set, otherwise falls back to the flat endpoint for older DC servers.
+
+```
+$ jira-version list PROJ --status unreleased --order-by releaseDate
+Unreleased versions in PROJ (3):
+
+  ID       NAME     STATUS       START        RELEASE      ISSUES
+  10042    1.4.0    unreleased   2026-05-01   2026-05-31   12
+  10045    1.5.0    unreleased   2026-06-01   2026-06-30   0
+  10048    1.6.0    unreleased   -            -            0
+```
+
+JSON output: array of version objects as returned by the API, with `issueCount` merged in from `relatedIssueCounts` when present.
+
+#### `get VERSION_ID_OR_NAME [--project PROJECT] [--counts]`
+
+Reads one version. Accepts either a numeric ID or a name; when a name is given, `--project` must be set and the script resolves it via `list`. `--counts` additionally fetches `relatedIssueCounts` and `unresolvedIssueCount`.
+
+```
+$ jira-version get 10042 --counts
+Version 10042 — 1.4.0
+  Project:      PROJ
+  Status:       unreleased
+  Start:        2026-05-01
+  Release:      2026-05-31
+  Description:  Q2 2026 release
+  Issues:       fixed=12 affected=3 unresolved=4
+```
+
+#### `create PROJECT_KEY NAME [--description TEXT] [--start-date YYYY-MM-DD] [--release-date YYYY-MM-DD] [--released] [--archived] [--dry-run]`
+
+Creates a new version. `--released` + `--archived` default to `false`.
+
+```
+$ jira-version create PROJ "1.4.0" --release-date 2026-05-31 --description "Q2 2026 release"
+Created version 10042 "1.4.0" in PROJ (release 2026-05-31)
+```
+
+Dry-run prints the composed payload without posting.
+
+#### `update ID (--name|--description|--start-date|--release-date|--released/--unreleased|--archived/--unarchived)... [--dry-run]`
+
+Updates any subset of fields. Internally performs **GET → merge → PUT** to protect against deployments that treat `PUT` as replace rather than patch (see Gotchas).
+
+```
+$ jira-version update 10042 --description "Q2 2026 release (postponed)" --release-date 2026-06-07
+Updated version 10042
+```
+
+#### `release ID [--release-date YYYY-MM-DD] [--dry-run]`
+
+Convenience wrapper: sets `released=true` and `releaseDate` (default: today). Equivalent to `update ID --released --release-date <d>`.
+
+```
+$ jira-version release 10042 --release-date 2026-05-31
+Released version 10042 "1.4.0" on 2026-05-31
+```
+
+#### `unrelease ID [--dry-run]`
+
+Sets `released=false` and clears `releaseDate`. **Important:** because Jira's `PUT` is treated as replace by some deployments, clearing `releaseDate` means **explicitly setting the key to `null`** in the merged payload — not omitting it. The safe-update helper handles this.
+
+#### `archive ID [--dry-run]` / `unarchive ID [--dry-run]`
+
+Toggle the `archived` flag. Archived versions disappear from most issue-level pickers but remain queryable.
+
+#### `move ID (--after OTHER_ID | --position First|Last|Earlier|Later) [--dry-run]`
+
+Reorder a version in the project's version list (affects sort order in pickers and reports).
+
+```
+$ jira-version move 10045 --after 10042
+Moved version 10045 after 10042
+
+$ jira-version move 10042 --position First
+Moved version 10042 to First
+```
+
+#### `merge SRC_ID INTO DST_ID [--dry-run]`
+
+Reassigns all `fixVersions` / `versions` references from SRC to DST, then deletes SRC. Dry-run fetches `relatedIssueCounts` on both sides and shows what would move.
+
+```
+$ jira-version merge 10050 INTO 10042 --dry-run
+DRY RUN - No changes will be made
+Would merge 10050 "1.4.0-dup" into 10042 "1.4.0":
+  fixed issues to reassign:    7
+  affected issues to reassign: 1
+  source version would be deleted
+```
+
+#### `delete ID [--move-fix-to ID] [--move-affected-to ID] [--dry-run]`
+
+Delete a version. Without `--move-fix-to` / `--move-affected-to`, references on existing issues become orphaned — the script prints a warning and requires `--dry-run` confirmation before the first non-dry-run invocation suggests a target.
+
+```
+$ jira-version delete 10050 --move-fix-to 10042
+Deleted version 10050; 7 fixVersion refs reassigned to 10042
+```
+
+All destructive operations (`delete`, `merge`, `release`, `unrelease`, `archive`, `unarchive`) support `--dry-run`.
+
+## Use Cases
+
+Common release-management flows the script enables end-to-end from the shell:
+
+1. **Create the next release at sprint start.**
+   ```
+   jira-version create PROJ "1.4.0" --release-date 2026-05-31 --description "Q2 2026 release"
+   ```
+   Release manager opens the sprint with the version already in the picker.
+
+2. **Pick a fix-version when filing a new ticket.**
+   ```
+   jira-version list PROJ --status unreleased --order-by releaseDate
+   ```
+   Developers see upcoming versions in release-date order before setting `fixVersions`.
+
+3. **Mark a version released after deploy.**
+   ```
+   jira-version release 10041 --release-date 2026-04-30
+   ```
+   Closes out the version and triggers release-report generation in Jira.
+
+4. **Merge a duplicate version a PM accidentally created.**
+   ```
+   jira-version merge 10050 INTO 10042 --dry-run
+   jira-version merge 10050 INTO 10042
+   ```
+   Reassigns references without touching issue history.
+
+5. **Delete an abandoned version but preserve issue history.**
+   ```
+   jira-version delete 10048 --move-fix-to 10042
+   ```
+   Avoids orphaned `fixVersions` references.
+
+6. **Decide whether a version is safe to archive.**
+   ```
+   jira-version get 10039 --counts
+   ```
+   Release manager checks `unresolved=0` before archiving.
+
+7. **Bulk-retag issues to a renamed version.**
+   ```
+   jira-search query 'project = PROJ AND fixVersion = "1.4.0-candidate"' --fields key
+   while read key; do
+     jira-issue update "$key" --fields-json '{"fixVersions": [{"name": "1.4.0"}]}'
+   done
+   ```
+   Composes with existing scripts; no new flags needed.
+
+8. **Auto-assign fixVersion on new tickets for an active sprint.**
+   ```
+   VER=$(jira-version list PROJ --status unreleased --json | jq -r '.[0].name')
+   jira-create issue PROJ "New task" -t "Technical task" \
+     --fields-json "{\"fixVersions\": [{\"name\": \"$VER\"}]}"
+   ```
+   Chains `jira-version list` with `jira-create` without plumbing a dedicated flag.
+
+## DC vs Cloud differences
+
+| Concern | DC v2 | Cloud v3 |
+|---------|-------|----------|
+| Base path | `/rest/api/2/version` | `/rest/api/3/version` |
+| Paginated search | `/project/{key}/version` (DC ≥9.x) | `/project/{key}/version` |
+| Project field in create | `project` (key) or `projectId` | same |
+| Description format | wiki markup | ADF (Atlassian Document Format) |
+| Archive field | `archived` boolean | same |
+| Move endpoint | `/version/{id}/move` | same |
+| `expand=operations` | supported | supported |
+
+The script targets `/rest/api/2/...` (DC is the primary deployment); Cloud works if wiki-markup descriptions are acceptable. A follow-up can add an `--api-version` switch if ADF support becomes necessary.
+
+## Gotchas
+
+- **`fixVersions` vs `versions`.** On issues, `fixVersions` = Fix Version/s, `versions` = Affects Version/s. Both are plural. Using the singular form (`fixVersion`, `version`) silently no-ops on create.
+- **PUT is replace on some deployments.** `PUT /version/{id}` has been observed to clear omitted fields on older DC versions and some Cloud tenants. The `update` subcommand **always GETs first, merges user-provided fields, then PUTs** the full object. Clearing a field (e.g. `unrelease`) sets it to `null` explicitly in the merged payload — it does not omit it.
+- **Date format.** `startDate` / `releaseDate` must be ISO `YYYY-MM-DD`. Timestamps (`...T00:00:00Z`) are rejected with a 400. The script validates the format client-side before posting.
+- **Duplicate names.** Jira returns HTTP 409 when a version with the same name already exists in the project. Surface this as a clear `error()` message: `Version "1.4.0" already exists in PROJ (id=10042)` rather than a raw stack trace.
+- **`move` uses self URLs.** The `--after` form requires a fully qualified `self` URL (`https://{JIRA_URL}/rest/api/2/version/{id}`), not a bare ID. Build it from `LazyJiraClient.base_url` — never hand-construct from user input.
+- **Orphaned references on delete.** `DELETE /version/{id}` without `moveFixIssuesTo` / `moveAffectedIssuesTo` leaves dangling `fixVersions` / `versions` arrays on issues. The script warns with the fixed/affected counts from `relatedIssueCounts` and refuses to proceed without either `--move-*-to` or an explicit `--force` style confirmation (re-running with `--dry-run=false` after a prior dry-run).
+- **Archived versions still filterable.** Archive does not hide a version from JQL (`fixVersion = "1.3.0"` still works); it only suppresses it in pickers. Document this in SKILL.md to avoid surprises.
+- **`mergeto` deletes the source.** There is no "undo merge." Dry-run is mandatory for review; the script prints the issue counts on both sides before executing.
+
+## Testing
+
+Tests live at `tests/test_version.py` and follow the patterns in `tests/test_weblink.py` / `tests/test_link.py` (mock `LazyJiraClient`, assert on the request payload and on stdout).
+
+Cases to cover:
+
+- `list` with each `--status` value (`released`, `unreleased`, `archived`, `all`)
+- `list` falls back to flat endpoint when `--order-by` / `--query` are absent
+- `get` by numeric ID (direct GET)
+- `get` by name with `--project` (calls list, filters, exits 1 on ambiguous/missing)
+- `get --counts` merges `relatedIssueCounts` + `unresolvedIssueCount`
+- `create` success (201) and duplicate-name 409 surfaces a clean error
+- `create --dry-run` posts nothing and prints the composed payload
+- `update` performs GET → merge → PUT; omitted fields retain their GET values
+- `update` with `--unreleased` explicitly sets `releaseDate: null` in the payload
+- `release` / `unrelease` set `released` + `releaseDate` correctly
+- `archive` / `unarchive` toggle `archived` only; other fields untouched
+- `move --after` builds the correct self URL from `LazyJiraClient.base_url`
+- `move --position` posts `{"position": "First"}` etc.
+- `merge --dry-run` fetches `relatedIssueCounts` on both sides and prints counts
+- `merge` (non-dry) calls `/mergeto/{dst}` and does **not** issue a separate DELETE
+- `delete` with `--move-fix-to` appends the query params correctly
+- `delete` without any `--move-*-to` prints the orphan warning
+- `delete --dry-run` makes no DELETE call
+
+Fixtures: a `make_version(id, name, released=False, archived=False, **dates)` helper and a `mock_client` fixture that stubs `get`/`post`/`put`/`delete` on the underlying HTTP client.
+
+## Files Changed
+
+| Change | File | Description |
+|--------|------|-------------|
+| New | `scripts/workflow/jira-version.py` | Version CRUD script |
+| New | `tests/test_version.py` | Tests for version subcommands |
+| Modify | `SKILL.md` | Document new script; note `fixVersions` vs `versions` |
+
+No changes required to `lib/client.py` or `lib/output.py`; existing helpers are sufficient. No new dependencies, so `plugin.json` is untouched.
+
+## Out of Scope
+
+- **Component CRUD** (`/rest/api/2/component`). Structurally similar but a separate feature; tracked for a follow-up design doc.
+- **Issue-level `--fix-version` flag** on `jira-create` and `jira-issue update`. Users currently pass `--fields-json '{"fixVersions": [{"name": "..."}]}'`. A first-class flag would be nicer and is a likely follow-up, but is deliberately excluded here to keep this PR ~300 LOC.
+- **Release notes generation** from version issue lists. Out of scope for this script; compose with `jira-search` over `fixVersion = "<name>"` if needed.
+- **Cloud ADF description support.** `--description` accepts plain text / wiki markup only; ADF conversion is out of scope.
+- **Sprint-to-version auto-linking.** No hook to set `fixVersions` on all issues in a sprint; can be composed with `jira-search` + `jira-issue update` in a one-liner.

--- a/docs/plans/2026-04-20-versions-plan.md
+++ b/docs/plans/2026-04-20-versions-plan.md
@@ -1,0 +1,2260 @@
+# Project Versions CRUD Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `jira-version.py` — a workflow script with full project-version CRUD (list, get, create, update, release, unrelease, archive, unarchive, move, merge, delete) so release managers can drive the release lifecycle from the shell.
+
+**Architecture:** New script at `skills/jira-communication/scripts/workflow/jira-version.py`, Click group with one subcommand per operation. All updates use a safe-merge pattern (GET then PUT with merged dict) to tolerate deployments that treat PUT as replace. Destructive ops (`delete`, `merge`, `release`, `unrelease`, `archive`, `unarchive`, `update`, `create`, `move`) support `--dry-run`. The `move --after` form builds a full self URL from the configured Jira base URL (`client.url`) rather than accepting a raw URL from the user.
+
+**Tech Stack:** Python 3.10+, click, LazyJiraClient, atlassian-python-api, PEP 723 inline deps.
+
+**Design doc:** `docs/plans/2026-04-20-versions-design.md`
+
+---
+
+### Task 1: Scaffold test file and script skeleton
+
+**Files:**
+- Create: `tests/test_version.py`
+- Create: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Create `tests/test_version.py` with loader and helpers**
+
+```python
+"""Tests for jira-version.py — project versions CRUD."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import click.testing
+import pytest
+
+_test_dir = Path(__file__).parent
+_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
+sys.path.insert(0, str(_scripts_path))
+
+
+def _load_script(name: str = "jira-version", subdir: str = "workflow"):
+    path = _scripts_path / subdir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_script()
+
+
+def _make_mock_client(url: str = "https://jira.example.com"):
+    mc = mock.Mock()
+    mc.with_context = mock.Mock()
+    mc.url = url  # atlassian.Jira exposes .url on the client instance
+    return mc
+
+
+def _run(args, mock_client=None):
+    if mock_client is None:
+        mock_client = _make_mock_client()
+    runner = click.testing.CliRunner()
+    with mock.patch.object(_mod, "LazyJiraClient", return_value=mock_client):
+        result = runner.invoke(_mod.cli, args)
+    return result, mock_client
+
+
+def _make_version(
+    vid: str = "10042",
+    name: str = "1.4.0",
+    project: str = "PROJ",
+    released: bool = False,
+    archived: bool = False,
+    description: str | None = None,
+    start_date: str | None = None,
+    release_date: str | None = None,
+) -> dict:
+    """Build a version dict matching the Jira REST API shape."""
+    v = {
+        "id": vid,
+        "name": name,
+        "projectId": 10000,
+        "project": project,
+        "released": released,
+        "archived": archived,
+        "self": f"https://jira.example.com/rest/api/2/version/{vid}",
+    }
+    if description is not None:
+        v["description"] = description
+    if start_date is not None:
+        v["startDate"] = start_date
+    if release_date is not None:
+        v["releaseDate"] = release_date
+    return v
+```
+
+**Step 2: Create `skills/jira-communication/scripts/workflow/jira-version.py`**
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "atlassian-python-api>=3.41.0,<4",
+#     "click>=8.1.0,<9",
+# ]
+# ///
+"""Jira project version operations - list, get, create, update, release lifecycle, move, merge, delete."""
+
+import sys
+from pathlib import Path
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Shared library import (TR1.1.1 - PYTHONPATH approach)
+# ═══════════════════════════════════════════════════════════════════════════════
+_script_dir = Path(__file__).parent
+_lib_path = _script_dir.parent / "lib"
+if _lib_path.exists():
+    sys.path.insert(0, str(_lib_path.parent))
+
+import click
+from lib.client import LazyJiraClient
+from lib.output import error, format_output, format_table, success, warning
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CLI Definition
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@click.group()
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.option("--quiet", "-q", is_flag=True, help="Minimal output")
+@click.option("--env-file", type=click.Path(), help="Environment file path")
+@click.option("--profile", "-P", help="Jira profile name from ~/.jira/profiles.json")
+@click.option("--debug", is_flag=True, help="Show debug information on errors")
+@click.pass_context
+def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str | None, debug: bool):
+    """Jira project version operations.
+
+    Manage the release lifecycle: list, create, release, archive, merge, delete versions.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj["json"] = output_json
+    ctx.obj["quiet"] = quiet
+    ctx.obj["debug"] = debug
+    ctx.obj["client"] = LazyJiraClient(env_file=env_file, profile=profile)
+
+
+# All subcommands are stubs. TDD will flesh them out task by task.
+
+
+@cli.command("list")
+@click.argument("project_key")
+@click.pass_context
+def list_versions(ctx, project_key: str):
+    """List versions in a project."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("version")
+@click.pass_context
+def get(ctx, version: str):
+    """Get a single version by ID or name."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("project_key")
+@click.argument("name")
+@click.pass_context
+def create(ctx, project_key: str, name: str):
+    """Create a new version in a project."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("version_id")
+@click.pass_context
+def update(ctx, version_id: str):
+    """Update fields on an existing version (GET + merge + PUT)."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("version_id")
+@click.pass_context
+def release(ctx, version_id: str):
+    """Mark a version released (sets released=true + releaseDate)."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("version_id")
+@click.pass_context
+def unrelease(ctx, version_id: str):
+    """Mark a version unreleased (clears releaseDate)."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("version_id")
+@click.pass_context
+def archive(ctx, version_id: str):
+    """Archive a version (hides it from pickers)."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("version_id")
+@click.pass_context
+def unarchive(ctx, version_id: str):
+    """Unarchive a version."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("version_id")
+@click.pass_context
+def move(ctx, version_id: str):
+    """Reorder a version within its project."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("src_id")
+@click.argument("into", type=click.Choice(["INTO"]))
+@click.argument("dst_id")
+@click.pass_context
+def merge(ctx, src_id: str, into: str, dst_id: str):
+    """Merge SRC_ID INTO DST_ID (reassign refs + delete source)."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("version_id")
+@click.pass_context
+def delete(ctx, version_id: str):
+    """Delete a version, optionally reassigning fixVersions/versions refs."""
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    cli()
+```
+
+**Step 3: Write the CLI help smoke test**
+
+Add to `tests/test_version.py`:
+
+```python
+class TestHelp:
+    """All subcommands must respond to --help with exit code 0."""
+
+    @pytest.mark.parametrize(
+        "subcmd",
+        ["list", "get", "create", "update", "release", "unrelease",
+         "archive", "unarchive", "move", "merge", "delete"],
+    )
+    def test_subcommand_help(self, subcmd):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_mod.cli, [subcmd, "--help"])
+        assert result.exit_code == 0, result.output
+
+    def test_cli_help_lists_all_subcommands(self):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_mod.cli, ["--help"])
+        assert result.exit_code == 0
+        for sub in ("list", "get", "create", "update", "release", "unrelease",
+                    "archive", "unarchive", "move", "merge", "delete"):
+            assert sub in result.output
+```
+
+**Step 4: Run the smoke test**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestHelp -v --no-header`
+
+Expected: all tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): scaffold jira-version.py and subcommand stubs"
+```
+
+---
+
+### Task 2: `list` subcommand — happy path (flat endpoint)
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+The wrapper `client.get_project_versions(key)` is available per the design doc, but we use the raw HTTP path for consistency with the rest of the script (which needs raw HTTP for `move`, `mergeto`, etc.). Verify via `python -c "import atlassian; import inspect; print(inspect.signature(atlassian.Jira.get_project_versions))"` before choosing; the tests mock the raw `client.get` path.
+
+**Step 1: Write failing list test**
+
+```python
+class TestList:
+    def test_list_flat_endpoint_default(self):
+        mc = _make_mock_client()
+        mc.get.return_value = [
+            _make_version("10042", "1.4.0", released=False,
+                          start_date="2026-05-01", release_date="2026-05-31"),
+            _make_version("10048", "1.6.0", released=False),
+        ]
+        result, _ = _run(["list", "PROJ"], mc)
+        assert result.exit_code == 0, result.output
+        # The flat endpoint returns ALL versions; filter happens client-side
+        mc.get.assert_called_once_with("rest/api/2/project/PROJ/versions")
+        assert "10042" in result.output
+        assert "1.4.0" in result.output
+        # Default --status unreleased: both are unreleased so both show
+        assert "10048" in result.output
+
+    def test_list_table_columns(self):
+        mc = _make_mock_client()
+        mc.get.return_value = [
+            _make_version("10042", "1.4.0", released=False,
+                          start_date="2026-05-01", release_date="2026-05-31"),
+        ]
+        result, _ = _run(["list", "PROJ"], mc)
+        assert result.exit_code == 0
+        # Header keywords
+        for header in ("ID", "NAME", "STATUS", "START", "RELEASE", "ISSUES"):
+            assert header in result.output
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestList -v --no-header`
+
+Expected: FAIL with `NotImplementedError`.
+
+**Step 3: Implement helpers and flat-path `list`**
+
+In `jira-version.py`, add above the CLI group:
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _status_of(v: dict) -> str:
+    if v.get("archived"):
+        return "archived"
+    return "released" if v.get("released") else "unreleased"
+
+
+def _fmt_list_row(v: dict) -> dict:
+    return {
+        "ID": v.get("id", ""),
+        "NAME": v.get("name", ""),
+        "STATUS": _status_of(v),
+        "START": v.get("startDate", "-") or "-",
+        "RELEASE": v.get("releaseDate", "-") or "-",
+        "ISSUES": v.get("issueCount", "-") if v.get("issueCount") is not None else "-",
+    }
+```
+
+Replace the `list_versions` stub:
+
+```python
+@cli.command("list")
+@click.argument("project_key")
+@click.option("--status", type=click.Choice(["released", "unreleased", "archived", "all"]),
+              default="unreleased", help="Filter by status")
+@click.option("--query", help="Filter by name substring (paginated endpoint)")
+@click.option("--order-by", type=click.Choice(["sequence", "name", "startDate", "releaseDate"]),
+              help="Sort order (paginated endpoint)")
+@click.pass_context
+def list_versions(ctx, project_key: str, status: str, query: str | None, order_by: str | None):
+    """List versions in a project.
+
+    Uses the flat `/project/{key}/versions` endpoint unless --query or --order-by
+    is provided, in which case it switches to the paginated endpoint.
+    """
+    client = ctx.obj["client"]
+    try:
+        if query or order_by:
+            versions = _fetch_versions_paginated(client, project_key, status=status,
+                                                 query=query, order_by=order_by)
+        else:
+            versions = client.get(f"rest/api/2/project/{project_key}/versions") or []
+            if status != "all":
+                versions = [v for v in versions if _status_of(v) == status]
+
+        if ctx.obj["json"]:
+            format_output(versions, as_json=True)
+            return
+        if ctx.obj["quiet"]:
+            for v in versions:
+                print(v.get("id", ""))
+            return
+
+        print(f"{status.capitalize()} versions in {project_key} ({len(versions)}):\n")
+        rows = [_fmt_list_row(v) for v in versions]
+        print(format_table(rows, columns=["ID", "NAME", "STATUS", "START", "RELEASE", "ISSUES"]))
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to list versions: {e}")
+        sys.exit(1)
+
+
+def _fetch_versions_paginated(client, project_key, status=None, query=None, order_by=None):
+    """Paginated search — DC >=9.x and Cloud only. Filter by name and/or order server-side."""
+    raise NotImplementedError  # Implemented in Task 3
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestList -v --no-header`
+
+Expected: both tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): implement list with flat endpoint and client-side status filter"
+```
+
+---
+
+### Task 3: `list` — paginated endpoint with `--query` / `--order-by`
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestListPaginated:
+    def test_list_with_query_uses_paginated_endpoint(self):
+        mc = _make_mock_client()
+        mc.get.return_value = {
+            "isLast": True,
+            "values": [_make_version("10042", "1.4.0-rc1", released=False)],
+        }
+        result, _ = _run(["list", "PROJ", "--query", "rc"], mc)
+        assert result.exit_code == 0, result.output
+        # First positional arg to .get should be the paginated path
+        called_path = mc.get.call_args.args[0]
+        assert called_path == "rest/api/2/project/PROJ/version"
+        called_params = mc.get.call_args.kwargs.get("params", {})
+        assert called_params.get("query") == "rc"
+
+    def test_list_with_order_by_uses_paginated_endpoint(self):
+        mc = _make_mock_client()
+        mc.get.return_value = {"isLast": True, "values": []}
+        result, _ = _run(["list", "PROJ", "--order-by", "releaseDate"], mc)
+        assert result.exit_code == 0, result.output
+        called_params = mc.get.call_args.kwargs.get("params", {})
+        assert called_params.get("orderBy") == "releaseDate"
+
+    def test_list_paginated_follows_next_page(self):
+        mc = _make_mock_client()
+        mc.get.side_effect = [
+            {"isLast": False, "values": [_make_version("10042", "1.4.0")], "startAt": 0, "maxResults": 1},
+            {"isLast": True, "values": [_make_version("10045", "1.5.0")], "startAt": 1, "maxResults": 1},
+        ]
+        result, _ = _run(["list", "PROJ", "--query", "1."], mc)
+        assert result.exit_code == 0, result.output
+        assert mc.get.call_count == 2
+        assert "10042" in result.output and "10045" in result.output
+
+    def test_status_all_filters_nothing_on_paginated(self):
+        mc = _make_mock_client()
+        mc.get.return_value = {
+            "isLast": True,
+            "values": [
+                _make_version("10042", "1.4.0", released=False),
+                _make_version("10041", "1.3.0", released=True),
+                _make_version("10030", "1.2.0", archived=True),
+            ],
+        }
+        result, _ = _run(["list", "PROJ", "--query", ".", "--status", "all"], mc)
+        assert result.exit_code == 0
+        for vid in ("10042", "10041", "10030"):
+            assert vid in result.output
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestListPaginated -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement `_fetch_versions_paginated`**
+
+```python
+def _fetch_versions_paginated(client, project_key, status=None, query=None, order_by=None):
+    """Paginated search via `/project/{key}/version`.
+
+    Availability: Jira Server/DC >=9.x and Jira Cloud. Older DC versions return
+    404 — callers should rely on the flat `/project/{key}/versions` endpoint
+    and filter client-side when `--query` / `--order-by` are not supplied.
+    """
+    all_values: list[dict] = []
+    start_at = 0
+    page_size = 50
+    while True:
+        params = {"startAt": start_at, "maxResults": page_size}
+        if query:
+            params["query"] = query
+        if order_by:
+            params["orderBy"] = order_by
+        if status and status != "all":
+            params["status"] = status
+        page = client.get(f"rest/api/2/project/{project_key}/version", params=params) or {}
+        values = page.get("values", [])
+        all_values.extend(values)
+        if page.get("isLast", True) or not values:
+            break
+        start_at += len(values) or page_size
+    return all_values
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestListPaginated -v --no-header`
+
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): add paginated list with --query and --order-by"
+```
+
+---
+
+### Task 4: `list` — JSON and quiet output modes
+
+**Files:**
+- Modify: `tests/test_version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestListOutputModes:
+    def test_list_json_output(self):
+        mc = _make_mock_client()
+        versions = [_make_version("10042", "1.4.0"), _make_version("10048", "1.6.0")]
+        mc.get.return_value = versions
+        result, _ = _run(["--json", "list", "PROJ"], mc)
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert {v["id"] for v in parsed} == {"10042", "10048"}
+
+    def test_list_quiet_output(self):
+        mc = _make_mock_client()
+        mc.get.return_value = [_make_version("10042", "1.4.0"), _make_version("10048", "1.6.0")]
+        result, _ = _run(["--quiet", "list", "PROJ"], mc)
+        assert result.exit_code == 0
+        lines = [ln for ln in result.output.strip().splitlines() if ln]
+        assert lines == ["10042", "10048"]
+```
+
+**Step 2: Run → expected pass (already implemented in Task 2)**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestListOutputModes -v --no-header`
+
+Expected: PASS. If either fails, adjust the `list` subcommand's output branch.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_version.py
+git commit -m "test(version): cover list --json and --quiet output modes"
+```
+
+---
+
+### Task 5: `get` — by numeric ID
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestGetById:
+    def test_get_by_id(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version(
+            "10042", "1.4.0", released=False, description="Q2 release",
+            start_date="2026-05-01", release_date="2026-05-31",
+        )
+        result, _ = _run(["get", "10042"], mc)
+        assert result.exit_code == 0, result.output
+        mc.get.assert_called_once_with("rest/api/2/version/10042")
+        assert "1.4.0" in result.output
+        assert "Q2 release" in result.output
+        assert "2026-05-31" in result.output
+
+    def test_get_by_id_json(self):
+        mc = _make_mock_client()
+        v = _make_version("10042", "1.4.0")
+        mc.get.return_value = v
+        result, _ = _run(["--json", "get", "10042"], mc)
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["id"] == "10042"
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestGetById -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement `get` for numeric IDs**
+
+```python
+def _is_numeric_id(s: str) -> bool:
+    return s.isdigit()
+
+
+def _render_version(v: dict, counts: dict | None = None) -> str:
+    lines = [
+        f"Version {v.get('id', '?')} — {v.get('name', '')}",
+        f"  Project:      {v.get('project', v.get('projectId', ''))}",
+        f"  Status:       {_status_of(v)}",
+        f"  Start:        {v.get('startDate', '-') or '-'}",
+        f"  Release:      {v.get('releaseDate', '-') or '-'}",
+    ]
+    if v.get("description"):
+        lines.append(f"  Description:  {v['description']}")
+    if counts:
+        fixed = counts.get("issuesFixedCount", counts.get("fixed", "?"))
+        affected = counts.get("issuesAffectedCount", counts.get("affected", "?"))
+        unresolved = counts.get("issuesUnresolvedCount", counts.get("unresolved", "?"))
+        lines.append(f"  Issues:       fixed={fixed} affected={affected} unresolved={unresolved}")
+    return "\n".join(lines)
+```
+
+Replace the `get` stub:
+
+```python
+@cli.command()
+@click.argument("version")
+@click.option("--project", help="Required when VERSION is a name (not an ID)")
+@click.option("--counts", is_flag=True, help="Include fixed/affected/unresolved issue counts")
+@click.pass_context
+def get(ctx, version: str, project: str | None, counts: bool):
+    """Get a single version by ID or name."""
+    client = ctx.obj["client"]
+    try:
+        if _is_numeric_id(version):
+            v = client.get(f"rest/api/2/version/{version}")
+        else:
+            v = _resolve_version_by_name(client, version, project)  # implemented in Task 6
+
+        extra = None
+        if counts:
+            extra = _fetch_counts(client, v["id"])  # implemented in Task 7
+
+        if ctx.obj["json"]:
+            payload = dict(v)
+            if extra:
+                payload["_counts"] = extra
+            format_output(payload, as_json=True)
+            return
+        if ctx.obj["quiet"]:
+            print(v.get("id", ""))
+            return
+        print(_render_version(v, counts=extra))
+
+    except SystemExit:
+        raise
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to get version: {e}")
+        sys.exit(1)
+
+
+def _resolve_version_by_name(client, name, project_key):
+    raise NotImplementedError  # Task 6
+
+
+def _fetch_counts(client, vid):
+    raise NotImplementedError  # Task 7
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestGetById -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): implement get by numeric ID"
+```
+
+---
+
+### Task 6: `get` — by name with `--project`
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestGetByName:
+    def test_get_by_name_requires_project(self):
+        mc = _make_mock_client()
+        result, _ = _run(["get", "1.4.0"], mc)
+        assert result.exit_code != 0
+        assert "--project" in result.output.lower() or "project" in result.output.lower()
+
+    def test_get_by_name_resolves(self):
+        mc = _make_mock_client()
+        mc.get.return_value = [
+            _make_version("10041", "1.3.0"),
+            _make_version("10042", "1.4.0"),
+        ]
+        result, _ = _run(["get", "1.4.0", "--project", "PROJ"], mc)
+        assert result.exit_code == 0, result.output
+        mc.get.assert_called_once_with("rest/api/2/project/PROJ/versions")
+        assert "10042" in result.output
+
+    def test_get_by_name_no_match(self):
+        mc = _make_mock_client()
+        mc.get.return_value = [_make_version("10041", "1.3.0")]
+        result, _ = _run(["get", "1.4.0", "--project", "PROJ"], mc)
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower() or "no version" in result.output.lower()
+
+    def test_get_by_name_ambiguous(self):
+        mc = _make_mock_client()
+        mc.get.return_value = [
+            _make_version("10042", "1.4.0"),
+            _make_version("10043", "1.4.0"),  # duplicate name
+        ]
+        result, _ = _run(["get", "1.4.0", "--project", "PROJ"], mc)
+        assert result.exit_code != 0
+        assert "multiple" in result.output.lower() or "ambiguous" in result.output.lower()
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestGetByName -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement `_resolve_version_by_name`**
+
+```python
+def _resolve_version_by_name(client, name: str, project_key: str | None) -> dict:
+    if not project_key:
+        error("--project is required when looking up a version by name")
+        sys.exit(2)
+    versions = client.get(f"rest/api/2/project/{project_key}/versions") or []
+    matches = [v for v in versions if v.get("name") == name]
+    if not matches:
+        error(f'No version named "{name}" found in {project_key}')
+        sys.exit(1)
+    if len(matches) > 1:
+        ids = ", ".join(v.get("id", "?") for v in matches)
+        error(f'Multiple versions named "{name}" in {project_key} (ids: {ids})')
+        sys.exit(1)
+    return matches[0]
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestGetByName -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): resolve version by name with --project"
+```
+
+---
+
+### Task 7: `get --counts`
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing test**
+
+```python
+class TestGetCounts:
+    def test_counts_fetches_both_endpoints(self):
+        mc = _make_mock_client()
+        # Three GETs: version, relatedIssueCounts, unresolvedIssueCount
+        mc.get.side_effect = [
+            _make_version("10042", "1.4.0"),
+            {"issuesFixedCount": 12, "issuesAffectedCount": 3},
+            {"issuesUnresolvedCount": 4},
+        ]
+        result, _ = _run(["get", "10042", "--counts"], mc)
+        assert result.exit_code == 0, result.output
+        assert mc.get.call_count == 3
+        paths = [c.args[0] for c in mc.get.call_args_list]
+        assert paths[0] == "rest/api/2/version/10042"
+        assert paths[1] == "rest/api/2/version/10042/relatedIssueCounts"
+        assert paths[2] == "rest/api/2/version/10042/unresolvedIssueCount"
+        assert "fixed=12" in result.output
+        assert "affected=3" in result.output
+        assert "unresolved=4" in result.output
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestGetCounts -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement `_fetch_counts`**
+
+```python
+def _fetch_counts(client, vid: str) -> dict:
+    related = client.get(f"rest/api/2/version/{vid}/relatedIssueCounts") or {}
+    unresolved = client.get(f"rest/api/2/version/{vid}/unresolvedIssueCount") or {}
+    return {**related, **unresolved}
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestGetCounts -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): add --counts to get subcommand"
+```
+
+---
+
+### Task 8: Date validator helper
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestValidateIsoDate:
+    def test_accepts_iso_date(self):
+        assert _mod._validate_iso_date("2026-05-31") == "2026-05-31"
+
+    def test_accepts_leap_day(self):
+        assert _mod._validate_iso_date("2024-02-29") == "2024-02-29"
+
+    def test_rejects_invalid_day(self):
+        with pytest.raises(click.BadParameter):
+            _mod._validate_iso_date("2026-02-30")
+
+    def test_rejects_timestamp(self):
+        with pytest.raises(click.BadParameter):
+            _mod._validate_iso_date("2026-05-31T00:00:00Z")
+
+    def test_rejects_garbage(self):
+        with pytest.raises(click.BadParameter):
+            _mod._validate_iso_date("tomorrow")
+
+    def test_rejects_slashes(self):
+        with pytest.raises(click.BadParameter):
+            _mod._validate_iso_date("2026/05/31")
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestValidateIsoDate -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+```python
+import re
+from datetime import date as _date
+
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _validate_iso_date(s: str) -> str:
+    """Validate an ISO date string (YYYY-MM-DD) and return it unchanged.
+
+    Jira rejects full timestamps like `2026-05-31T00:00:00Z` with a 400 on
+    version start/release dates. This helper enforces the date-only shape
+    client-side with a clear error.
+    """
+    if not isinstance(s, str) or not _ISO_DATE_RE.match(s):
+        raise click.BadParameter(
+            f'Expected YYYY-MM-DD, got "{s}". Timestamps are not allowed.'
+        )
+    try:
+        y, m, d = (int(p) for p in s.split("-"))
+        _date(y, m, d)
+    except ValueError as e:
+        raise click.BadParameter(f'Invalid date "{s}": {e}') from e
+    return s
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestValidateIsoDate -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): add ISO date validator helper"
+```
+
+---
+
+### Task 9: `create` subcommand
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestCreate:
+    def test_create_minimal(self):
+        mc = _make_mock_client()
+        mc.post.return_value = _make_version("10042", "1.4.0")
+        result, _ = _run(["create", "PROJ", "1.4.0"], mc)
+        assert result.exit_code == 0, result.output
+        mc.post.assert_called_once()
+        path = mc.post.call_args.args[0]
+        assert path == "rest/api/2/version"
+        body = mc.post.call_args.kwargs.get("data") or mc.post.call_args.kwargs.get("json")
+        assert body["name"] == "1.4.0"
+        assert body["project"] == "PROJ"
+        assert body.get("released", False) is False
+        assert body.get("archived", False) is False
+
+    def test_create_with_dates_and_description(self):
+        mc = _make_mock_client()
+        mc.post.return_value = _make_version("10042", "1.4.0")
+        result, _ = _run(
+            ["create", "PROJ", "1.4.0",
+             "--description", "Q2 2026",
+             "--start-date", "2026-05-01",
+             "--release-date", "2026-05-31"],
+            mc,
+        )
+        assert result.exit_code == 0, result.output
+        body = mc.post.call_args.kwargs.get("data") or mc.post.call_args.kwargs.get("json")
+        assert body["description"] == "Q2 2026"
+        assert body["startDate"] == "2026-05-01"
+        assert body["releaseDate"] == "2026-05-31"
+
+    def test_create_released_and_archived_flags(self):
+        mc = _make_mock_client()
+        mc.post.return_value = _make_version("10042", "1.4.0", released=True, archived=True)
+        result, _ = _run(
+            ["create", "PROJ", "1.4.0", "--released", "--archived",
+             "--release-date", "2026-05-31"],
+            mc,
+        )
+        assert result.exit_code == 0, result.output
+        body = mc.post.call_args.kwargs.get("data") or mc.post.call_args.kwargs.get("json")
+        assert body["released"] is True
+        assert body["archived"] is True
+
+    def test_create_rejects_bad_date(self):
+        mc = _make_mock_client()
+        result, _ = _run(["create", "PROJ", "1.4.0", "--release-date", "2026/05/31"], mc)
+        assert result.exit_code != 0
+        assert "YYYY-MM-DD" in result.output or "Invalid date" in result.output
+        mc.post.assert_not_called()
+
+    def test_create_dry_run(self):
+        mc = _make_mock_client()
+        result, _ = _run(["create", "PROJ", "1.4.0", "--release-date", "2026-05-31", "--dry-run"], mc)
+        assert result.exit_code == 0
+        mc.post.assert_not_called()
+        assert "DRY RUN" in result.output
+        assert "1.4.0" in result.output
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestCreate -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement `create`**
+
+Replace the `create` stub:
+
+```python
+@cli.command()
+@click.argument("project_key")
+@click.argument("name")
+@click.option("--description", help="Version description (plain text or wiki markup)")
+@click.option("--start-date", help="Start date YYYY-MM-DD")
+@click.option("--release-date", help="Release date YYYY-MM-DD")
+@click.option("--released", is_flag=True, help="Mark as released on creation")
+@click.option("--archived", is_flag=True, help="Mark as archived on creation")
+@click.option("--dry-run", is_flag=True, help="Show what would be created")
+@click.pass_context
+def create(ctx, project_key, name, description, start_date, release_date, released, archived, dry_run):
+    """Create a new version in a project."""
+    client = ctx.obj["client"]
+    payload = {"name": name, "project": project_key, "released": released, "archived": archived}
+    if description:
+        payload["description"] = description
+    if start_date:
+        payload["startDate"] = _validate_iso_date(start_date)
+    if release_date:
+        payload["releaseDate"] = _validate_iso_date(release_date)
+
+    if dry_run:
+        warning("DRY RUN - No version will be created")
+        print(f"Would POST rest/api/2/version with:\n  {payload}")
+        return
+
+    try:
+        created = client.post("rest/api/2/version", data=payload)
+        vid = (created or {}).get("id", "?")
+
+        if ctx.obj["json"]:
+            format_output(created, as_json=True)
+        elif ctx.obj["quiet"]:
+            print(vid)
+        else:
+            extra = f" (release {release_date})" if release_date else ""
+            success(f'Created version {vid} "{name}" in {project_key}{extra}')
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        # Delegate 409 handling to Task 10
+        error(f"Failed to create version: {e}")
+        sys.exit(1)
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestCreate -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): implement create with dates, flags, and --dry-run"
+```
+
+---
+
+### Task 10: `create` — surface 409 duplicate-name as a clean error
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing test**
+
+```python
+class TestCreateConflict:
+    def test_duplicate_name_409(self):
+        mc = _make_mock_client()
+        # atlassian-python-api raises HTTPError on 4xx; simulate that shape
+        from requests.exceptions import HTTPError
+        from requests import Response
+        resp = Response()
+        resp.status_code = 409
+        resp._content = b'{"errors":{"name":"A version with this name already exists."}}'
+        err = HTTPError("409 Conflict", response=resp)
+        mc.post.side_effect = err
+
+        result, _ = _run(["create", "PROJ", "1.4.0"], mc)
+        assert result.exit_code != 0
+        # Clean message, not a stack trace
+        assert "already exists" in result.output.lower()
+        assert "1.4.0" in result.output
+        assert "PROJ" in result.output
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestCreateConflict -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Add 409 handling**
+
+Update the `except` block in `create`:
+
+```python
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        status = getattr(getattr(e, "response", None), "status_code", None)
+        if status == 409:
+            error(f'Version "{name}" already exists in {project_key}')
+        else:
+            error(f"Failed to create version: {e}")
+        sys.exit(1)
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestCreateConflict -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): surface 409 duplicate-name as clear error"
+```
+
+---
+
+### Task 11: Safe-merge update helper
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests for `_safe_update_version`**
+
+```python
+class TestSafeUpdate:
+    def test_merges_patch_onto_current(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version(
+            "10042", "1.4.0", released=False,
+            description="old", start_date="2026-05-01", release_date="2026-05-31",
+        )
+        mc.put.return_value = {}
+        _mod._safe_update_version(mc, "10042", description="new", releaseDate="2026-06-07")
+
+        mc.get.assert_called_once_with("rest/api/2/version/10042")
+        path = mc.put.call_args.args[0]
+        assert path == "rest/api/2/version/10042"
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["description"] == "new"
+        assert body["releaseDate"] == "2026-06-07"
+        # Untouched fields retained from GET
+        assert body["name"] == "1.4.0"
+        assert body["startDate"] == "2026-05-01"
+        assert body["released"] is False
+
+    def test_explicit_none_sets_null(self):
+        """Clearing a field (e.g. unrelease) means explicit None -> null in the PUT body."""
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version(
+            "10042", "1.4.0", released=True, release_date="2026-05-31",
+        )
+        mc.put.return_value = {}
+        _mod._safe_update_version(mc, "10042", released=False, releaseDate=None)
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["released"] is False
+        assert "releaseDate" in body
+        assert body["releaseDate"] is None
+
+    def test_does_not_send_unset_kwargs(self):
+        """Kwargs not passed by the caller must not appear in the patch."""
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0", description="orig")
+        mc.put.return_value = {}
+        _mod._safe_update_version(mc, "10042", name="1.4.0-rc")
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["name"] == "1.4.0-rc"
+        # description retained from GET, not cleared
+        assert body["description"] == "orig"
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestSafeUpdate -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement `_safe_update_version`**
+
+```python
+# Sentinel distinguishes "caller did not provide this key" from "caller passed None to clear".
+_UNSET = object()
+
+
+def _safe_update_version(client, vid: str, **patch) -> dict:
+    """Safely update a version by GET + dict-merge + PUT.
+
+    Why: Jira's `PUT /version/{id}` is treated as *replace* on some Server/DC
+    deployments (and a few Cloud tenants), meaning any field omitted from the
+    body is cleared. To avoid accidentally wiping `description`, `startDate`,
+    etc. when the user only wants to update one field, we always fetch the
+    current version first and merge the caller's patch onto it before PUTting.
+
+    Any kwarg whose value is not the _UNSET sentinel is applied verbatim. Pass
+    an explicit ``None`` to clear a field (e.g. `releaseDate=None` on unrelease);
+    the null is preserved in the PUT body.
+    """
+    current = client.get(f"rest/api/2/version/{vid}") or {}
+    merged = dict(current)
+    for key, value in patch.items():
+        if value is _UNSET:
+            continue
+        merged[key] = value
+    # Strip server-managed fields we shouldn't echo back
+    for ro in ("self", "operations", "projectId"):
+        merged.pop(ro, None)
+    return client.put(f"rest/api/2/version/{vid}", data=merged)
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestSafeUpdate -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): add safe-merge update helper (GET + merge + PUT)"
+```
+
+---
+
+### Task 12: `update` subcommand
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestUpdate:
+    def test_update_description(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0", description="old")
+        mc.put.return_value = {}
+        result, _ = _run(["update", "10042", "--description", "new"], mc)
+        assert result.exit_code == 0, result.output
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["description"] == "new"
+        assert body["name"] == "1.4.0"  # retained
+
+    def test_update_name(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0")
+        mc.put.return_value = {}
+        result, _ = _run(["update", "10042", "--name", "1.4.0-final"], mc)
+        assert result.exit_code == 0
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["name"] == "1.4.0-final"
+
+    def test_update_dates(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0")
+        mc.put.return_value = {}
+        result, _ = _run(
+            ["update", "10042", "--start-date", "2026-05-01", "--release-date", "2026-06-07"], mc
+        )
+        assert result.exit_code == 0
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["startDate"] == "2026-05-01"
+        assert body["releaseDate"] == "2026-06-07"
+
+    def test_update_released_flag(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0", released=False)
+        mc.put.return_value = {}
+        result, _ = _run(["update", "10042", "--released"], mc)
+        assert result.exit_code == 0
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["released"] is True
+
+    def test_update_unreleased_clears_release_date(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0", released=True, release_date="2026-05-31")
+        mc.put.return_value = {}
+        result, _ = _run(["update", "10042", "--unreleased"], mc)
+        assert result.exit_code == 0
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["released"] is False
+        assert body["releaseDate"] is None
+
+    def test_update_dry_run(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0")
+        result, _ = _run(["update", "10042", "--description", "new", "--dry-run"], mc)
+        assert result.exit_code == 0
+        mc.put.assert_not_called()
+        assert "DRY RUN" in result.output
+
+    def test_update_rejects_bad_date(self):
+        mc = _make_mock_client()
+        result, _ = _run(["update", "10042", "--release-date", "tomorrow"], mc)
+        assert result.exit_code != 0
+        mc.put.assert_not_called()
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestUpdate -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement `update`**
+
+Replace the `update` stub:
+
+```python
+@cli.command()
+@click.argument("version_id")
+@click.option("--name", help="New name")
+@click.option("--description", help="New description")
+@click.option("--start-date", help="New start date YYYY-MM-DD")
+@click.option("--release-date", help="New release date YYYY-MM-DD")
+@click.option("--released/--unreleased", default=None, help="Mark released or unreleased")
+@click.option("--archived/--unarchived", default=None, help="Mark archived or unarchived")
+@click.option("--dry-run", is_flag=True, help="Show what would be updated")
+@click.pass_context
+def update(ctx, version_id, name, description, start_date, release_date,
+           released, archived, dry_run):
+    """Update fields on an existing version (safe-merge: GET + merge + PUT)."""
+    client = ctx.obj["client"]
+
+    patch: dict = {}
+    if name is not None:
+        patch["name"] = name
+    if description is not None:
+        patch["description"] = description
+    if start_date is not None:
+        patch["startDate"] = _validate_iso_date(start_date)
+    if release_date is not None:
+        patch["releaseDate"] = _validate_iso_date(release_date)
+    if released is True:
+        patch["released"] = True
+    elif released is False:
+        # --unreleased: clear releaseDate unless caller also set --release-date
+        patch["released"] = False
+        patch.setdefault("releaseDate", None)
+    if archived is True:
+        patch["archived"] = True
+    elif archived is False:
+        patch["archived"] = False
+
+    if not patch:
+        error("No fields to update. Provide at least one of --name / --description / --start-date / --release-date / --released/--unreleased / --archived/--unarchived")
+        sys.exit(2)
+
+    if dry_run:
+        warning("DRY RUN - No version will be updated")
+        print(f"Would PUT rest/api/2/version/{version_id} with patch:\n  {patch}")
+        return
+
+    try:
+        _safe_update_version(client, version_id, **patch)
+        if ctx.obj["json"]:
+            format_output({"id": version_id, "updated": True, "patch": patch}, as_json=True)
+        elif ctx.obj["quiet"]:
+            print("ok")
+        else:
+            success(f"Updated version {version_id}")
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to update version: {e}")
+        sys.exit(1)
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestUpdate -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): wire update CLI flags to safe-merge helper"
+```
+
+---
+
+### Task 13: `release` and `unrelease` subcommands
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestReleaseUnrelease:
+    def test_release_with_date(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0", released=False)
+        mc.put.return_value = {}
+        result, _ = _run(["release", "10042", "--release-date", "2026-05-31"], mc)
+        assert result.exit_code == 0, result.output
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["released"] is True
+        assert body["releaseDate"] == "2026-05-31"
+
+    def test_release_defaults_to_today(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0", released=False)
+        mc.put.return_value = {}
+        result, _ = _run(["release", "10042"], mc)
+        assert result.exit_code == 0, result.output
+        from datetime import date
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["released"] is True
+        assert body["releaseDate"] == date.today().isoformat()
+
+    def test_unrelease_clears_release_date(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version(
+            "10042", "1.4.0", released=True, release_date="2026-05-31"
+        )
+        mc.put.return_value = {}
+        result, _ = _run(["unrelease", "10042"], mc)
+        assert result.exit_code == 0, result.output
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["released"] is False
+        assert body["releaseDate"] is None
+
+    def test_release_dry_run(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0")
+        result, _ = _run(["release", "10042", "--release-date", "2026-05-31", "--dry-run"], mc)
+        assert result.exit_code == 0
+        mc.put.assert_not_called()
+        assert "DRY RUN" in result.output
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestReleaseUnrelease -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Replace the `release` and `unrelease` stubs:
+
+```python
+@cli.command()
+@click.argument("version_id")
+@click.option("--release-date", help="Release date YYYY-MM-DD (default: today)")
+@click.option("--dry-run", is_flag=True, help="Show what would change")
+@click.pass_context
+def release(ctx, version_id, release_date, dry_run):
+    """Mark a version released (sets released=true + releaseDate)."""
+    from datetime import date as _d
+    rdate = _validate_iso_date(release_date) if release_date else _d.today().isoformat()
+    patch = {"released": True, "releaseDate": rdate}
+
+    if dry_run:
+        warning("DRY RUN - No version will be updated")
+        print(f"Would release {version_id} on {rdate}")
+        return
+
+    client = ctx.obj["client"]
+    try:
+        _safe_update_version(client, version_id, **patch)
+        success(f"Released version {version_id} on {rdate}")
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to release version: {e}")
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument("version_id")
+@click.option("--dry-run", is_flag=True, help="Show what would change")
+@click.pass_context
+def unrelease(ctx, version_id, dry_run):
+    """Mark a version unreleased (clears releaseDate)."""
+    patch = {"released": False, "releaseDate": None}
+
+    if dry_run:
+        warning("DRY RUN - No version will be updated")
+        print(f"Would unrelease {version_id} (releaseDate cleared)")
+        return
+
+    client = ctx.obj["client"]
+    try:
+        _safe_update_version(client, version_id, **patch)
+        success(f"Unreleased version {version_id}")
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to unrelease version: {e}")
+        sys.exit(1)
+```
+
+Note on `releaseDate: null`: the design doc warns that some deployments may reject explicit null. If integration testing surfaces a 400, fall back to omitting `releaseDate` from the merged body (drop it in `_safe_update_version` when the value is `None` for this field only). Keep the behavior covered by tests either way.
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestReleaseUnrelease -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): add release and unrelease subcommands"
+```
+
+---
+
+### Task 14: `archive` and `unarchive` subcommands
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestArchiveUnarchive:
+    def test_archive(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0", archived=False)
+        mc.put.return_value = {}
+        result, _ = _run(["archive", "10042"], mc)
+        assert result.exit_code == 0, result.output
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["archived"] is True
+        # Other fields untouched
+        assert body["name"] == "1.4.0"
+
+    def test_unarchive(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0", archived=True)
+        mc.put.return_value = {}
+        result, _ = _run(["unarchive", "10042"], mc)
+        assert result.exit_code == 0
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert body["archived"] is False
+
+    def test_archive_dry_run(self):
+        mc = _make_mock_client()
+        mc.get.return_value = _make_version("10042", "1.4.0")
+        result, _ = _run(["archive", "10042", "--dry-run"], mc)
+        assert result.exit_code == 0
+        mc.put.assert_not_called()
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestArchiveUnarchive -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Replace the `archive` and `unarchive` stubs:
+
+```python
+@cli.command()
+@click.argument("version_id")
+@click.option("--dry-run", is_flag=True, help="Show what would change")
+@click.pass_context
+def archive(ctx, version_id, dry_run):
+    """Archive a version (hides it from pickers)."""
+    if dry_run:
+        warning("DRY RUN - No version will be updated")
+        print(f"Would archive {version_id}")
+        return
+    client = ctx.obj["client"]
+    try:
+        _safe_update_version(client, version_id, archived=True)
+        success(f"Archived version {version_id}")
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to archive version: {e}")
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument("version_id")
+@click.option("--dry-run", is_flag=True, help="Show what would change")
+@click.pass_context
+def unarchive(ctx, version_id, dry_run):
+    """Unarchive a version."""
+    if dry_run:
+        warning("DRY RUN - No version will be updated")
+        print(f"Would unarchive {version_id}")
+        return
+    client = ctx.obj["client"]
+    try:
+        _safe_update_version(client, version_id, archived=False)
+        success(f"Unarchived version {version_id}")
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to unarchive version: {e}")
+        sys.exit(1)
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestArchiveUnarchive -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): add archive and unarchive subcommands"
+```
+
+---
+
+### Task 15: Self-URL builder helper
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestSelfUrl:
+    def test_builds_self_url(self):
+        mc = _make_mock_client(url="https://jira.example.com")
+        assert _mod._version_self_url(mc, "10042") == \
+            "https://jira.example.com/rest/api/2/version/10042"
+
+    def test_strips_trailing_slash(self):
+        mc = _make_mock_client(url="https://jira.example.com/")
+        assert _mod._version_self_url(mc, "10042") == \
+            "https://jira.example.com/rest/api/2/version/10042"
+
+    def test_preserves_context_path(self):
+        mc = _make_mock_client(url="https://corp.example.com/jira")
+        assert _mod._version_self_url(mc, "10042") == \
+            "https://corp.example.com/jira/rest/api/2/version/10042"
+
+    def test_raises_without_url(self):
+        mc = mock.Mock()
+        mc.url = ""
+        with pytest.raises(RuntimeError):
+            _mod._version_self_url(mc, "10042")
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestSelfUrl -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+```python
+def _version_self_url(client, vid: str) -> str:
+    """Build a fully-qualified self URL for a version from the client's base URL.
+
+    Used by `move --after OTHER_ID` where the Jira API expects a `self` URL
+    rather than a bare ID. Constructed from the configured Jira base URL
+    (never from user input) to avoid SSRF or cross-instance spoofing.
+    """
+    base = getattr(client, "url", "") or ""
+    if not base:
+        raise RuntimeError("Jira client has no configured URL; cannot build self URL")
+    base = base.rstrip("/")
+    return f"{base}/rest/api/2/version/{vid}"
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestSelfUrl -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): add self-URL builder for move --after"
+```
+
+---
+
+### Task 16: `move` subcommand
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestMove:
+    def test_move_after(self):
+        mc = _make_mock_client(url="https://jira.example.com")
+        mc.post.return_value = {}
+        result, _ = _run(["move", "10045", "--after", "10042"], mc)
+        assert result.exit_code == 0, result.output
+        path = mc.post.call_args.args[0]
+        assert path == "rest/api/2/version/10045/move"
+        body = mc.post.call_args.kwargs.get("data") or mc.post.call_args.kwargs.get("json")
+        assert body["after"] == "https://jira.example.com/rest/api/2/version/10042"
+
+    def test_move_position(self):
+        mc = _make_mock_client()
+        mc.post.return_value = {}
+        result, _ = _run(["move", "10042", "--position", "First"], mc)
+        assert result.exit_code == 0, result.output
+        body = mc.post.call_args.kwargs.get("data") or mc.post.call_args.kwargs.get("json")
+        assert body == {"position": "First"}
+
+    def test_move_requires_after_or_position(self):
+        mc = _make_mock_client()
+        result, _ = _run(["move", "10042"], mc)
+        assert result.exit_code != 0
+        mc.post.assert_not_called()
+
+    def test_move_after_and_position_mutually_exclusive(self):
+        mc = _make_mock_client()
+        result, _ = _run(["move", "10042", "--after", "10041", "--position", "Last"], mc)
+        assert result.exit_code != 0
+        mc.post.assert_not_called()
+
+    def test_move_dry_run(self):
+        mc = _make_mock_client()
+        result, _ = _run(["move", "10042", "--position", "First", "--dry-run"], mc)
+        assert result.exit_code == 0
+        mc.post.assert_not_called()
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestMove -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Replace the `move` stub:
+
+```python
+@cli.command()
+@click.argument("version_id")
+@click.option("--after", help="Move this version to directly after the given version ID")
+@click.option("--position", type=click.Choice(["First", "Last", "Earlier", "Later"]),
+              help="Move relative to current position")
+@click.option("--dry-run", is_flag=True, help="Show what would change")
+@click.pass_context
+def move(ctx, version_id, after, position, dry_run):
+    """Reorder a version within its project."""
+    if bool(after) == bool(position):
+        error("Provide exactly one of --after or --position")
+        sys.exit(2)
+
+    client = ctx.obj["client"]
+    if after:
+        body = {"after": _version_self_url(client, after)}
+    else:
+        body = {"position": position}
+
+    if dry_run:
+        warning("DRY RUN - No version will be moved")
+        print(f"Would POST rest/api/2/version/{version_id}/move with:\n  {body}")
+        return
+
+    try:
+        client.post(f"rest/api/2/version/{version_id}/move", data=body)
+        if after:
+            success(f"Moved version {version_id} after {after}")
+        else:
+            success(f"Moved version {version_id} to {position}")
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to move version: {e}")
+        sys.exit(1)
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestMove -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): add move subcommand with --after and --position"
+```
+
+---
+
+### Task 17: `merge` subcommand
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestMerge:
+    def test_merge_executes(self):
+        mc = _make_mock_client()
+        mc.post.return_value = {}
+        result, _ = _run(["merge", "10050", "INTO", "10042"], mc)
+        assert result.exit_code == 0, result.output
+        path = mc.post.call_args.args[0]
+        assert path == "rest/api/2/version/10050/mergeto/10042"
+
+    def test_merge_requires_INTO(self):
+        mc = _make_mock_client()
+        result, _ = _run(["merge", "10050", "BESIDE", "10042"], mc)
+        assert result.exit_code != 0
+        mc.post.assert_not_called()
+
+    def test_merge_dry_run_fetches_counts(self):
+        mc = _make_mock_client()
+        mc.get.side_effect = [
+            {"issuesFixedCount": 7, "issuesAffectedCount": 1},  # src relatedIssueCounts
+            _make_version("10050", "1.4.0-dup"),                 # src version
+            _make_version("10042", "1.4.0"),                     # dst version
+        ]
+        result, _ = _run(["merge", "10050", "INTO", "10042", "--dry-run"], mc)
+        assert result.exit_code == 0, result.output
+        mc.post.assert_not_called()
+        assert "DRY RUN" in result.output
+        assert "7" in result.output   # fixed count
+        assert "1" in result.output   # affected count
+        assert "1.4.0-dup" in result.output
+        assert "1.4.0" in result.output
+
+    def test_merge_does_not_issue_separate_delete(self):
+        """mergeto deletes the source server-side; no extra DELETE needed."""
+        mc = _make_mock_client()
+        mc.post.return_value = {}
+        result, _ = _run(["merge", "10050", "INTO", "10042"], mc)
+        assert result.exit_code == 0
+        mc.delete.assert_not_called()
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestMerge -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement**
+
+Replace the `merge` stub:
+
+```python
+@cli.command()
+@click.argument("src_id")
+@click.argument("into", type=click.Choice(["INTO"]))
+@click.argument("dst_id")
+@click.option("--dry-run", is_flag=True, help="Show what would change without calling mergeto")
+@click.pass_context
+def merge(ctx, src_id, into, dst_id, dry_run):
+    """Merge SRC_ID INTO DST_ID.
+
+    Reassigns fixVersions / versions references from SRC to DST, then deletes
+    SRC server-side. There is no undo.
+    """
+    client = ctx.obj["client"]
+
+    if dry_run:
+        warning("DRY RUN - No changes will be made")
+        counts = client.get(f"rest/api/2/version/{src_id}/relatedIssueCounts") or {}
+        src = client.get(f"rest/api/2/version/{src_id}") or {}
+        dst = client.get(f"rest/api/2/version/{dst_id}") or {}
+        fixed = counts.get("issuesFixedCount", "?")
+        affected = counts.get("issuesAffectedCount", "?")
+        print(f'Would merge {src_id} "{src.get("name", "?")}" INTO '
+              f'{dst_id} "{dst.get("name", "?")}":')
+        print(f"  fixed issues to reassign:    {fixed}")
+        print(f"  affected issues to reassign: {affected}")
+        print("  source version would be deleted")
+        return
+
+    try:
+        client.post(f"rest/api/2/version/{src_id}/mergeto/{dst_id}")
+        success(f"Merged {src_id} into {dst_id}; source deleted")
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to merge version: {e}")
+        sys.exit(1)
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestMerge -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): add merge subcommand with --dry-run counts preview"
+```
+
+---
+
+### Task 18: `delete` subcommand — dry-run preview
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing test**
+
+```python
+class TestDeleteDryRun:
+    def test_delete_dry_run_fetches_counts(self):
+        mc = _make_mock_client()
+        mc.get.side_effect = [
+            _make_version("10050", "1.4.0-dup"),
+            {"issuesFixedCount": 7, "issuesAffectedCount": 1},
+        ]
+        result, _ = _run(["delete", "10050", "--dry-run"], mc)
+        assert result.exit_code == 0, result.output
+        mc.delete.assert_not_called()
+        assert "DRY RUN" in result.output
+        assert "7" in result.output
+        assert "1" in result.output
+        assert "1.4.0-dup" in result.output
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestDeleteDryRun -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Implement dry-run branch of `delete`**
+
+Replace the `delete` stub (real-delete branch filled in Task 19):
+
+```python
+@cli.command()
+@click.argument("version_id")
+@click.option("--move-fix-to", help="Reassign fixVersions refs to this version ID")
+@click.option("--move-affected-to", help="Reassign affectsVersions refs to this version ID")
+@click.option("--dry-run", is_flag=True, help="Show what would be deleted")
+@click.pass_context
+def delete(ctx, version_id, move_fix_to, move_affected_to, dry_run):
+    """Delete a version, optionally reassigning fixVersions/versions refs."""
+    client = ctx.obj["client"]
+    if dry_run:
+        v = client.get(f"rest/api/2/version/{version_id}") or {}
+        counts = client.get(f"rest/api/2/version/{version_id}/relatedIssueCounts") or {}
+        warning("DRY RUN - No version will be deleted")
+        fixed = counts.get("issuesFixedCount", "?")
+        affected = counts.get("issuesAffectedCount", "?")
+        print(f'Would delete {version_id} "{v.get("name", "?")}":')
+        print(f"  fixVersion refs:        {fixed}"
+              + (f" → {move_fix_to}" if move_fix_to else " (would be orphaned)"))
+        print(f"  affectsVersion refs:    {affected}"
+              + (f" → {move_affected_to}" if move_affected_to else " (would be orphaned)"))
+        return
+
+    raise NotImplementedError  # Task 19
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestDeleteDryRun -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): add delete --dry-run with reference counts"
+```
+
+---
+
+### Task 19: `delete` — real delete with reassign / orphan warning
+
+**Files:**
+- Modify: `tests/test_version.py`
+- Modify: `skills/jira-communication/scripts/workflow/jira-version.py`
+
+**Step 1: Write failing tests**
+
+```python
+class TestDelete:
+    def test_delete_with_move_fix_to(self):
+        mc = _make_mock_client()
+        mc.delete.return_value = {}
+        result, _ = _run(["delete", "10050", "--move-fix-to", "10042"], mc)
+        assert result.exit_code == 0, result.output
+        path = mc.delete.call_args.args[0]
+        assert path == "rest/api/2/version/10050"
+        params = mc.delete.call_args.kwargs.get("params") or {}
+        assert params.get("moveFixIssuesTo") == "10042"
+        # Not provided → absent
+        assert "moveAffectedIssuesTo" not in params
+
+    def test_delete_with_both_move_targets(self):
+        mc = _make_mock_client()
+        mc.delete.return_value = {}
+        result, _ = _run(
+            ["delete", "10050", "--move-fix-to", "10042", "--move-affected-to", "10043"], mc
+        )
+        assert result.exit_code == 0
+        params = mc.delete.call_args.kwargs.get("params") or {}
+        assert params.get("moveFixIssuesTo") == "10042"
+        assert params.get("moveAffectedIssuesTo") == "10043"
+
+    def test_delete_without_move_targets_warns(self):
+        mc = _make_mock_client()
+        mc.delete.return_value = {}
+        result, _ = _run(["delete", "10050"], mc)
+        assert result.exit_code == 0, result.output
+        # Warning printed (to stderr captured by CliRunner into result.output)
+        assert "orphan" in result.output.lower() or "warning" in result.output.lower() or "⚠" in result.output
+        params = mc.delete.call_args.kwargs.get("params") or {}
+        assert "moveFixIssuesTo" not in params
+        assert "moveAffectedIssuesTo" not in params
+```
+
+**Step 2: Run → verify failure**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestDelete -v --no-header`
+
+Expected: FAIL.
+
+**Step 3: Replace the `NotImplementedError` branch in `delete`**
+
+```python
+    # non-dry-run
+    params: dict = {}
+    if move_fix_to:
+        params["moveFixIssuesTo"] = move_fix_to
+    if move_affected_to:
+        params["moveAffectedIssuesTo"] = move_affected_to
+
+    if not move_fix_to and not move_affected_to:
+        warning(
+            f"No --move-fix-to / --move-affected-to provided. "
+            f"fixVersions/versions references on existing issues will be orphaned."
+        )
+
+    try:
+        client.delete(f"rest/api/2/version/{version_id}", params=params or None)
+        parts = []
+        if move_fix_to:
+            parts.append(f"fixVersion refs reassigned to {move_fix_to}")
+        if move_affected_to:
+            parts.append(f"affectsVersion refs reassigned to {move_affected_to}")
+        detail = "; " + "; ".join(parts) if parts else ""
+        success(f"Deleted version {version_id}{detail}")
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to delete version: {e}")
+        sys.exit(1)
+```
+
+**Step 4: Run → verify pass**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_version.py::TestDelete -v --no-header`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_version.py skills/jira-communication/scripts/workflow/jira-version.py
+git commit -m "feat(version): implement delete with reassign flags and orphan warning"
+```
+
+---
+
+### Task 20: Add `jira-version` to CLI smoke tests
+
+**Files:**
+- Modify: `tests/test_cli_smoke.py`
+
+**Step 1: Add module load and help test**
+
+In the module-load section (near `_weblink_mod = _load_script(...)`):
+
+```python
+_version_mod = _load_script("jira-version", "workflow")
+```
+
+In `TestHelpOutput`:
+
+```python
+    def test_version_help(self):
+        output = self._run_help(_version_mod.cli)
+        assert "version" in output.lower()
+```
+
+**Step 2: Run all smoke tests**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_cli_smoke.py -v --no-header`
+
+Expected: all PASS.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_cli_smoke.py
+git commit -m "test(version): include jira-version in CLI smoke tests"
+```
+
+---
+
+### Task 21: Update SKILL.md
+
+**Files:**
+- Modify: `skills/jira-communication/SKILL.md`
+
+**Step 1: Update the Scripts section**
+
+Change the Workflow line (line 24) to include `jira-version.py`:
+
+```
+**Workflow**: `jira-create.py`, `jira-transition.py`, `jira-comment.py` (add/edit/delete/list), `jira-move.py`, `jira-sprint.py`, `jira-board.py`, `jira-version.py`
+```
+
+**Step 2: Add a `# Versions` subsection under Common Tasks**
+
+After the existing command blocks (near the "Move / link / web links" section), add:
+
+```bash
+# Versions (list, create, release lifecycle, merge, delete)
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-version.py list PROJ
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-version.py list PROJ --status unreleased --order-by releaseDate
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-version.py get 10042 --counts
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-version.py create PROJ "1.4.0" --release-date 2026-05-31 --description "Q2 release"
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-version.py release 10042 --release-date 2026-05-31
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-version.py archive 10039
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-version.py merge 10050 INTO 10042 --dry-run
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-version.py delete 10050 --move-fix-to 10042
+```
+
+Add one gotcha line near the end of the same section:
+
+```
+# Note: on issues, use plural field names — fixVersions / versions — never fixVersion / version.
+# Archived versions still match JQL `fixVersion = "..."` — archive only hides from pickers.
+```
+
+**Step 3: Verify SKILL.md word count / metadata**
+
+Run (per the project memory): `/skill-repo` or manually:
+
+```bash
+uv run skills/jira-communication/scripts/core/jira-validate.py --help
+```
+
+Expected: exit 0. No metadata changes needed (no version bump in this plan).
+
+**Step 4: Commit**
+
+```bash
+git add skills/jira-communication/SKILL.md
+git commit -m "docs(version): document jira-version.py in SKILL.md"
+```
+
+---
+
+### Task 22: Full lint / bandit / test sweep
+
+**Files:** none (verification only, commit fixes if required).
+
+**Step 1: Run the full test suite**
+
+Run: `uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/ -q`
+
+Expected: all tests PASS (187 existing + ~40 new).
+
+**Step 2: Lint**
+
+Run: `uv run --no-project --with ruff ruff check skills/jira-communication/scripts/workflow/jira-version.py tests/test_version.py`
+
+Expected: clean. If autofixes are needed: `uv run --no-project --with ruff ruff check --fix skills/jira-communication/scripts/workflow/jira-version.py tests/test_version.py` then re-run.
+
+**Step 3: Format**
+
+Run: `uv run --no-project --with ruff ruff format skills/jira-communication/scripts/workflow/jira-version.py tests/test_version.py`
+
+Expected: no changes, or minor whitespace fixups.
+
+**Step 4: Bandit**
+
+Run: `uv run --no-project --with bandit bandit -r skills/jira-communication/scripts/workflow/jira-version.py -c pyproject.toml --severity-level medium`
+
+Expected: no medium+ findings.
+
+**Step 5: Pre-commit smoke check**
+
+Run: `uv run skills/jira-communication/scripts/core/jira-validate.py --help`
+
+Expected: help text, exit 0.
+
+**Step 6: Commit any autofixes**
+
+```bash
+git add -A
+git diff --cached --quiet || git commit -m "chore(version): ruff autofixes"
+```
+
+If no diff, skip the commit.
+
+---
+
+## Follow-ups (not in this PR)
+
+Per the design doc "Out of Scope":
+
+- Component CRUD (`/rest/api/2/component`) — separate design doc.
+- First-class `--fix-version` flag on `jira-create` and `jira-issue update` (currently done via `--fields-json '{"fixVersions": [{"name": "..."}]}'`).
+- Release-notes generation from version issue lists — compose with `jira-search` on `fixVersion = "<name>"`.
+- Cloud ADF description support.
+- Sprint-to-version auto-linking.

--- a/docs/plans/2026-04-20-watchers-design.md
+++ b/docs/plans/2026-04-20-watchers-design.md
@@ -1,0 +1,198 @@
+# Watchers CRUD Design
+
+**Date:** 2026-04-20
+**Status:** Draft
+
+## Goal
+
+Add a `jira-watchers.py` script to list, add, and remove watchers on Jira issues. Watchers are currently not exposed anywhere in the skill, so users cannot self-subscribe to issues transitioned to review, attach a stakeholder to tickets with new UAT instructions, or un-watch noisy epics in bulk without leaving the CLI.
+
+## Jira API
+
+Watchers are a per-issue collection with a single REST path and three verbs. Reference: <https://docs.atlassian.com/software/jira/docs/api/REST/9.12.0/#api/2/issue-getIssueWatchers>.
+
+- `GET /rest/api/2/issue/{key}/watchers` — list watchers
+  - Returns `{"self": ..., "isWatching": bool, "watchCount": int, "watchers": [{...}]}`
+  - Requires **View Voters and Watchers** on the project (plus **Browse Projects**).
+
+- `POST /rest/api/2/issue/{key}/watchers` — add a watcher
+  - Body is a **raw JSON string**, not a JSON object: `"jdoe"` on DC, `"557058:..."` on Cloud (quotes included, `Content-Type: application/json`).
+  - Adding yourself requires only **Browse Projects**; adding someone else requires **Manage Watchers**.
+  - Returns `204 No Content` on success.
+
+- `DELETE /rest/api/2/issue/{key}/watchers?username=jdoe` (DC) or `?accountId=557058:...` (Cloud)
+  - Removing yourself requires only **Browse Projects**; removing someone else requires **Manage Watchers**.
+  - Returns `204 No Content` on success.
+
+The `atlassian-python-api` library exposes all three (verified in 3.41.x):
+
+- `issue_get_watchers(issue_key)` — `GET`
+- `issue_add_watcher(issue_key, user)` — `POST`, passes `user` through as the raw body
+- `issue_delete_watcher(issue_key, user=None, account_id=None)` — `DELETE`, picks query-param based on `client.cloud`
+
+No fallback to `client.post/get/delete` is needed.
+
+## New Script: `jira-watchers.py`
+
+Location: `skills/jira-communication/scripts/utility/jira-watchers.py`
+
+Follows existing conventions: PEP 723 header, Click group, `LazyJiraClient`, `lib.output` helpers, `--json` / `--quiet` / `--env-file` / `--profile` / `--debug` group options.
+
+User identity is resolved through a small `_resolve_watcher_identifier(client, identifier)` helper that reuses `resolve_assignee()` from `lib/client.py`:
+
+- `me` → `client.myself()` → `{"accountId": ...}` or `{"name": ...}`
+- account-id-shaped string → `{"accountId": ...}` (via `is_account_id()`)
+- anything else → `user_find_by_user_string(query=...)`, pick first hit
+
+The add/delete calls need a flat string, not the dict that `resolve_assignee()` returns, so the helper unwraps it:
+
+```python
+def _resolve_watcher_identifier(client, identifier: str) -> tuple[str, bool]:
+    """Return (value, is_account_id) suitable for issue_add_watcher / issue_delete_watcher."""
+    resolved = resolve_assignee(client, identifier)
+    if "accountId" in resolved:
+        return resolved["accountId"], True
+    return resolved["name"], False
+```
+
+## Subcommands
+
+### `list ISSUE_KEY`
+
+List watchers on an issue.
+
+```
+$ jira-watchers list PROJ-123
+Watchers for PROJ-123 (3):
+
+  jdoe           John Doe              (isWatching)
+  asmith         Alice Smith
+  bwilson        Bob Wilson            (isWatching = you)
+```
+
+JSON output: the raw API response (`{"watchCount": 3, "isWatching": true, "watchers": [...]}`).
+Quiet output: one `username` (DC) or `accountId` (Cloud) per line.
+
+### `add ISSUE_KEY [--user me|USER]`
+
+Subscribe a user (default: yourself) to an issue. Idempotent — Jira silently accepts duplicate self-adds.
+
+```
+$ jira-watchers add PROJ-123
+✓ Added watcher to PROJ-123: bwilson (you)
+
+$ jira-watchers add PROJ-123 --user asmith
+✓ Added watcher to PROJ-123: asmith
+```
+
+JSON output: `{"key": "PROJ-123", "user": "asmith", "added": true}`.
+
+### `remove ISSUE_KEY [--user me|USER] [--dry-run]`
+
+Unsubscribe a user (default: yourself). Supports `--dry-run` (writes are destructive per house rules).
+
+```
+$ jira-watchers remove PROJ-123
+✓ Removed watcher from PROJ-123: bwilson (you)
+
+$ jira-watchers remove PROJ-123 --user asmith --dry-run
+⚠ DRY RUN - No watcher will be removed
+Would remove asmith from PROJ-123
+```
+
+JSON output: `{"key": "PROJ-123", "user": "asmith", "removed": true}`.
+
+## Use Cases
+
+```bash
+# Subscribe yourself when taking over a ticket
+jira-watchers add PROJ-123
+```
+Stay in the loop on comments after picking up work.
+
+```bash
+# Subscribe a stakeholder when moving an issue to review
+jira-watchers add PROJ-123 --user product.owner
+```
+The stakeholder gets notified about the review without a separate `@mention`.
+
+```bash
+# Subscribe QA when transitioning to QA
+jira-watchers add PROJ-456 --user qa.lead
+```
+Useful as a follow-up to a transition when handing over to QA.
+
+```bash
+# Un-watch a noisy epic
+jira-watchers remove PROJ-789
+```
+Shortcut for "stop notifying me about this epic" without opening the web UI.
+
+```bash
+# Bulk-watch all children of an epic (no bulk endpoint — loop JQL)
+jira-search.py query '"Epic Link" = PROJ-789' --json \
+  | jq -r '.issues[].key' \
+  | xargs -I{} jira-watchers add {}
+```
+There is no `POST /watchers/bulk`, so loop client-side.
+
+```bash
+# After leaving a sprint mid-flight, re-watch only the ones still open
+jira-search.py query 'sprint = 42 AND assignee was currentUser() AND resolution = Unresolved' --json \
+  | jq -r '.issues[].key' \
+  | xargs -I{} jira-watchers add {}
+```
+Keeps you informed about the handover without claiming them again.
+
+## DC vs Cloud Differences
+
+| Concern | Server / DC | Cloud |
+|---|---|---|
+| User identity | `username` (e.g. `jdoe`) | `accountId` (e.g. `557058:d5765ebc-...`) |
+| `POST` body | `"jdoe"` (JSON string) | `"557058:..."` (JSON string) |
+| `DELETE` query param | `?username=jdoe` | `?accountId=557058:...` |
+| `client.cloud` flag | `False` | `True` — drives `issue_delete_watcher`'s param choice |
+
+Identity resolution leans on existing helpers in `skills/jira-communication/scripts/lib/client.py`:
+
+- `is_account_id(s)` — distinguishes Cloud account IDs (new-style `557058:...` and legacy 24-char hex) from usernames.
+- `resolve_assignee(client, identifier)` — the canonical flow used by `jira-create.py` / `jira-issue.py`; we reuse it so `me`, `asmith`, `alice.smith@example.com`, and raw account IDs all resolve the same way they do elsewhere.
+
+Because `issue_add_watcher` uses the same raw-body format on both deployments, one code path handles both — the resolved string simply differs.
+
+## Gotchas
+
+- **POST body is a raw JSON-encoded string, not an object.** `{"name": "jdoe"}` returns `400`. `atlassian-python-api` handles this correctly (it passes `data=user` straight through), but any fallback to `client.post(...)` must do the same — pass the username/accountId as a bare string and let the library JSON-encode it.
+- **Success is `204 No Content`**, so the add/remove responses have no body. Do not try to parse JSON from the return value of `issue_add_watcher` / `issue_delete_watcher`.
+- **Self-watch is idempotent.** Adding yourself when you are already watching returns `204`, not an error. The script should treat repeated adds as success (no special handling needed).
+- **No bulk watcher endpoint exists.** For multi-issue operations, loop over a JQL result set (see the epic-children example above). Do not build a bulk wrapper inside the script — keep the shell pipeline idiomatic.
+- **Removing a watcher who is not watching** returns `404` on DC and `404` on Cloud. Surface this as a clear error; do not silently succeed.
+- **Cloud email lookup is deprecated.** `user_find_by_user_string(query=email)` still works but may return `[]` for privacy-protected accounts — fall back to asking for an accountId.
+
+## Testing
+
+Follow the patterns in `tests/test_weblink.py` and `tests/test_link.py`: Click `CliRunner` with `obj={"client": MagicMock(...)}`, no real network.
+
+Cases to add in `tests/test_watchers.py`:
+
+- `list` — watchers present: renders header, count, display names, `isWatching` marker.
+- `list` — empty watcher list: prints `No watchers for {key}`.
+- `list --json` — returns the raw API payload unchanged.
+- `add` default — resolves `me` via `client.myself()`, calls `issue_add_watcher` with the unwrapped identifier.
+- `add --user asmith` — calls `user_find_by_user_string`, then `issue_add_watcher` with `"asmith"`.
+- `add --user 557058:abc...` — account-id-shaped input skips search and is passed through.
+- `remove` default + DC — calls `issue_delete_watcher(user="bwilson")`.
+- `remove` default + Cloud — calls `issue_delete_watcher(account_id="557058:...")` (gate on `client.cloud`).
+- `remove --dry-run` — prints the warning, does not call `issue_delete_watcher`.
+- `remove` against a non-watcher — 404 surfaces as a clean error, exit code 1.
+- Quiet mode on `add` / `remove` prints `ok`; JSON mode emits the documented payload.
+
+## Out of Scope
+
+- Bulk watcher endpoint wrappers (no such API — use shell loops).
+- Adding a watcher section to `jira-issue.py get` (separate API call, noisy by default; reconsider later).
+- Vote operations — same REST neighborhood but a distinct feature; track separately.
+- Watcher subscriptions based on JQL saved filters (Jira-side feature, not API-exposed).
+- Slack / email notification routing — orthogonal to Jira watchers.
+- Changes to `lib/client.py` or `lib/output.py` (existing helpers sufficient).
+- Changes to `plugin.json` (no new dependencies).

--- a/docs/plans/2026-04-20-watchers-plan.md
+++ b/docs/plans/2026-04-20-watchers-plan.md
@@ -1,0 +1,1048 @@
+# Watchers Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `jira-watchers.py` — a Click subcommand group that lists, adds, and removes watchers on a Jira issue across Server/DC and Cloud.
+
+**Architecture:** One standalone script in `scripts/utility/` with three subcommands (`list`, `add`, `remove`) on a `@click.group()`. Thin wrapper over `atlassian-python-api`'s `issue_get_watchers` / `issue_add_watcher` / `issue_delete_watcher`. User identity flows through a small pure helper that unwraps `resolve_assignee()`'s dict into a flat `(value, is_account_id)` pair suitable for the raw-string POST body and the DC-vs-Cloud DELETE query-param switch.
+
+**Tech Stack:** Python 3.10+, click, PEP 723 inline deps, LazyJiraClient, atlassian-python-api.
+
+**Design doc:** `docs/plans/2026-04-20-watchers-design.md`
+
+**Sub-skills to use while executing:**
+- `@superpowers:executing-plans` — task-by-task execution cadence.
+- `@superpowers:test-driven-development` — fail/pass/commit cycle, one behavior at a time.
+- `@superpowers:verification-before-completion` — run tests and confirm output before claiming done.
+
+---
+
+### Task 1: Scaffold test file and script skeleton
+
+**Files:**
+- Create: `tests/test_watchers.py`
+- Create: `skills/jira-communication/scripts/utility/jira-watchers.py`
+
+**Step 1: Create the test file with imports, loader, and first failing test**
+
+Write `tests/test_watchers.py`:
+
+```python
+"""Tests for jira-watchers.py — list/add/remove issue watchers."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import click.testing
+import pytest
+
+# Add scripts to path for lib imports
+_test_dir = Path(__file__).parent
+_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
+sys.path.insert(0, str(_scripts_path))
+
+
+def _load_script(name: str, subdir: str = "utility"):
+    """Load a hyphenated CLI script via importlib."""
+    path = _scripts_path / subdir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_watchers_mod = _load_script("jira-watchers", "utility")
+
+
+def _make_mock_client(cloud: bool = False):
+    mc = mock.Mock()
+    mc.with_context = mock.Mock()
+    # Explicit attribute — LazyJiraClient exposes .cloud via atlassian.Jira
+    object.__setattr__(mc, "cloud", cloud)
+    return mc
+
+
+def _run(args, mock_client=None):
+    """Run jira-watchers CLI with a mocked LazyJiraClient."""
+    if mock_client is None:
+        mock_client = _make_mock_client()
+    runner = click.testing.CliRunner()
+    with mock.patch.object(_watchers_mod, "LazyJiraClient", return_value=mock_client):
+        result = runner.invoke(_watchers_mod.cli, args)
+    return result, mock_client
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: help / subcommand registration
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWatchersHelp:
+    def test_cli_help_shows_subcommands(self):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_watchers_mod.cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "list" in result.output
+        assert "add" in result.output
+        assert "remove" in result.output
+```
+
+**Step 2: Create the script skeleton**
+
+Write `skills/jira-communication/scripts/utility/jira-watchers.py`:
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "atlassian-python-api>=3.41.0,<4",
+#     "click>=8.1.0,<9",
+# ]
+# ///
+"""Jira watcher operations — list, add, and remove issue watchers."""
+
+import sys
+from pathlib import Path
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Shared library import (TR1.1.1 - PYTHONPATH approach)
+# ═══════════════════════════════════════════════════════════════════════════════
+_script_dir = Path(__file__).parent
+_lib_path = _script_dir.parent / "lib"
+if _lib_path.exists():
+    sys.path.insert(0, str(_lib_path.parent))
+
+import click
+from lib.client import LazyJiraClient, is_account_id, resolve_assignee
+from lib.output import error, format_json, success, warning
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CLI Definition
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@click.group()
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.option("--quiet", "-q", is_flag=True, help="Minimal output")
+@click.option("--env-file", type=click.Path(), help="Environment file path")
+@click.option("--profile", "-P", help="Jira profile name from ~/.jira/profiles.json")
+@click.option("--debug", is_flag=True, help="Show debug information on errors")
+@click.pass_context
+def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str | None, debug: bool):
+    """Jira watcher operations.
+
+    List, add, and remove watchers on Jira issues.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj["json"] = output_json
+    ctx.obj["quiet"] = quiet
+    ctx.obj["debug"] = debug
+    ctx.obj["client"] = LazyJiraClient(env_file=env_file, profile=profile)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _resolve_watcher_identifier(client, identifier: str) -> tuple[str, bool]:
+    """Return (value, is_account_id) suitable for issue_add_watcher / issue_delete_watcher.
+
+    Reuses resolve_assignee() for the hard part (me / accountId / user search) and
+    unwraps the dict into a flat string — the watchers REST API takes a bare
+    identifier, not {"name": ...} / {"accountId": ...}.
+    """
+    raise NotImplementedError
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Subcommands
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@cli.command("list")
+@click.argument("issue_key")
+@click.pass_context
+def list_watchers(ctx, issue_key: str):
+    """List watchers on an issue.
+
+    ISSUE_KEY: The Jira issue key (e.g. PROJ-123)
+    """
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("issue_key")
+@click.option("--user", default="me", help="Username, accountId, email, or 'me' (default: me)")
+@click.pass_context
+def add(ctx, issue_key: str, user: str):
+    """Add a watcher to an issue (default: yourself)."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("issue_key")
+@click.option("--user", default="me", help="Username, accountId, email, or 'me' (default: me)")
+@click.option("--dry-run", is_flag=True, help="Show what would be removed")
+@click.pass_context
+def remove(ctx, issue_key: str, user: str, dry_run: bool):
+    """Remove a watcher from an issue (default: yourself)."""
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    cli()
+```
+
+**Step 3: Run the test to verify it passes**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersHelp -v --no-header
+```
+
+Expected: `test_cli_help_shows_subcommands PASSED`. (Help text is exercised before the `NotImplementedError` body is ever reached, so Click's group registration alone is enough.)
+
+**Step 4: Smoke-check the script loads end-to-end**
+
+```bash
+uv run skills/jira-communication/scripts/utility/jira-watchers.py --help
+```
+
+Expected: help banner listing `list`, `add`, `remove` subcommands, exit code 0.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_watchers.py skills/jira-communication/scripts/utility/jira-watchers.py
+git commit -m "feat(watchers): scaffold jira-watchers script and help test"
+```
+
+---
+
+### Task 2: `list` subcommand — happy path with watchers
+
+**Files:**
+- Modify: `tests/test_watchers.py`
+- Modify: `skills/jira-communication/scripts/utility/jira-watchers.py`
+
+**Step 1: Write failing test**
+
+Append to `tests/test_watchers.py`:
+
+```python
+def _watcher(name="jdoe", display="John Doe", account_id=None):
+    """Build a watcher dict matching the Jira API shape."""
+    w = {"name": name, "displayName": display, "active": True}
+    if account_id is not None:
+        w["accountId"] = account_id
+    return w
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: list subcommand
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWatchersList:
+    def test_list_text_output(self):
+        mc = _make_mock_client()
+        mc.issue_get_watchers.return_value = {
+            "watchCount": 2,
+            "isWatching": False,
+            "watchers": [
+                _watcher("jdoe", "John Doe"),
+                _watcher("asmith", "Alice Smith"),
+            ],
+        }
+        result, _ = _run(["list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "TEST-1" in result.output
+        assert "jdoe" in result.output
+        assert "John Doe" in result.output
+        assert "asmith" in result.output
+        assert "Alice Smith" in result.output
+        mc.issue_get_watchers.assert_called_once_with("TEST-1")
+```
+
+**Step 2: Run and verify FAIL**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersList -v --no-header
+```
+
+Expected: `NotImplementedError` raised inside `list_watchers`.
+
+**Step 3: Implement `list_watchers`**
+
+Replace the `list_watchers` stub in `jira-watchers.py`:
+
+```python
+@cli.command("list")
+@click.argument("issue_key")
+@click.pass_context
+def list_watchers(ctx, issue_key: str):
+    """List watchers on an issue.
+
+    ISSUE_KEY: The Jira issue key (e.g. PROJ-123)
+
+    Example:
+
+      jira-watchers list PROJ-123
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+
+    try:
+        data = client.issue_get_watchers(issue_key)
+
+        if ctx.obj["json"]:
+            print(format_json(data))
+            return
+
+        watchers = data.get("watchers", []) or []
+        count = data.get("watchCount", len(watchers))
+
+        if ctx.obj["quiet"]:
+            for w in watchers:
+                print(w.get("accountId") or w.get("name", ""))
+            return
+
+        if not watchers:
+            print(f"(no watchers) for {issue_key}")
+            return
+
+        print(f"Watchers for {issue_key} ({count}):\n")
+        for w in watchers:
+            name = w.get("name") or w.get("accountId", "")
+            display = w.get("displayName", "")
+            print(f"  {name:<20} {display}")
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to list watchers: {e}")
+        sys.exit(1)
+```
+
+**Step 4: Run and verify PASS**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersList -v --no-header
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_watchers.py skills/jira-communication/scripts/utility/jira-watchers.py
+git commit -m "feat(watchers): implement list subcommand with watchers present"
+```
+
+---
+
+### Task 3: `list` — empty result shows placeholder
+
+**Files:**
+- Modify: `tests/test_watchers.py`
+
+**Step 1: Write failing test**
+
+Add inside `class TestWatchersList`:
+
+```python
+    def test_list_empty(self):
+        mc = _make_mock_client()
+        mc.issue_get_watchers.return_value = {
+            "watchCount": 0, "isWatching": False, "watchers": [],
+        }
+        result, _ = _run(["list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "(no watchers)" in result.output
+        assert "TEST-1" in result.output
+```
+
+**Step 2: Run and verify PASS**
+
+The Task 2 implementation already handles the empty case. Run the test to confirm:
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersList::test_list_empty -v --no-header
+```
+
+Expected: PASS. If it FAILS, fix `list_watchers` so that an empty `watchers` list prints `(no watchers) for {issue_key}`.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_watchers.py
+git commit -m "test(watchers): verify list shows placeholder for empty watcher list"
+```
+
+---
+
+### Task 4: `list` — JSON and quiet output modes
+
+**Files:**
+- Modify: `tests/test_watchers.py`
+
+**Step 1: Write failing tests**
+
+Add inside `class TestWatchersList`:
+
+```python
+    def test_list_json_output(self):
+        mc = _make_mock_client()
+        payload = {
+            "watchCount": 1,
+            "isWatching": True,
+            "watchers": [_watcher("jdoe", "John Doe")],
+        }
+        mc.issue_get_watchers.return_value = payload
+        result, _ = _run(["--json", "list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["watchCount"] == 1
+        assert data["isWatching"] is True
+        assert data["watchers"][0]["name"] == "jdoe"
+
+    def test_list_quiet_cloud_prints_account_ids(self):
+        mc = _make_mock_client(cloud=True)
+        mc.issue_get_watchers.return_value = {
+            "watchCount": 2,
+            "isWatching": False,
+            "watchers": [
+                _watcher("a", "A", account_id="557058:aaa"),
+                _watcher("b", "B", account_id="557058:bbb"),
+            ],
+        }
+        result, _ = _run(["--quiet", "list", "TEST-1"], mc)
+        assert result.exit_code == 0
+        lines = [ln for ln in result.output.splitlines() if ln.strip()]
+        assert lines == ["557058:aaa", "557058:bbb"]
+
+    def test_list_quiet_dc_prints_usernames(self):
+        mc = _make_mock_client(cloud=False)
+        mc.issue_get_watchers.return_value = {
+            "watchCount": 2,
+            "isWatching": False,
+            "watchers": [_watcher("jdoe", "J"), _watcher("asmith", "A")],
+        }
+        result, _ = _run(["--quiet", "list", "TEST-1"], mc)
+        assert result.exit_code == 0
+        lines = [ln for ln in result.output.splitlines() if ln.strip()]
+        assert lines == ["jdoe", "asmith"]
+```
+
+**Step 2: Run and verify PASS**
+
+The implementation from Task 2 already handles both modes. Run:
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersList -v --no-header
+```
+
+Expected: all four `TestWatchersList` tests PASS. If JSON or quiet output does not match, adjust `list_watchers` to emit exactly `format_json(data)` and, for quiet, one `accountId or name` per line.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_watchers.py
+git commit -m "test(watchers): cover list --json and --quiet output modes"
+```
+
+---
+
+### Task 5: `add` subcommand — self-watch default
+
+**Files:**
+- Modify: `tests/test_watchers.py`
+- Modify: `skills/jira-communication/scripts/utility/jira-watchers.py`
+
+**Step 1: Write failing test**
+
+Append:
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: add subcommand
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWatchersAdd:
+    def test_add_self_default(self):
+        mc = _make_mock_client()
+        # Default --user is "me", resolve_assignee calls client.myself()
+        mc.myself.return_value = {"name": "bwilson", "displayName": "Bob Wilson"}
+        mc.issue_add_watcher.return_value = None  # 204 No Content
+        result, _ = _run(["add", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "Added watcher" in result.output
+        assert "TEST-1" in result.output
+        assert "bwilson" in result.output
+        # Raw string identifier, not a dict — Jira's watchers POST body is
+        # a JSON-encoded string; atlassian-python-api passes this straight
+        # through as the request body.
+        mc.issue_add_watcher.assert_called_once_with("TEST-1", "bwilson")
+```
+
+**Step 2: Run and verify FAIL**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersAdd::test_add_self_default -v --no-header
+```
+
+Expected: `NotImplementedError` from either `_resolve_watcher_identifier` or `add`.
+
+**Step 3: Implement `_resolve_watcher_identifier` and `add`**
+
+Replace the `_resolve_watcher_identifier` stub:
+
+```python
+def _resolve_watcher_identifier(client, identifier: str) -> tuple[str, bool]:
+    """Return (value, is_account_id) suitable for issue_add_watcher / issue_delete_watcher.
+
+    Reuses resolve_assignee() for 'me' / accountId / user-search handling and
+    unwraps the {"name": ...} / {"accountId": ...} dict into a flat string,
+    because the watchers REST API takes a bare identifier as its JSON body
+    (not an object). atlassian-python-api passes the string through verbatim.
+    """
+    resolved = resolve_assignee(client, identifier)
+    if "accountId" in resolved:
+        return resolved["accountId"], True
+    return resolved["name"], False
+```
+
+Replace the `add` stub:
+
+```python
+@cli.command()
+@click.argument("issue_key")
+@click.option("--user", default="me", help="Username, accountId, email, or 'me' (default: me)")
+@click.pass_context
+def add(ctx, issue_key: str, user: str):
+    """Add a watcher to an issue (default: yourself).
+
+    ISSUE_KEY: The Jira issue key (e.g. PROJ-123)
+
+    Adding yourself requires only Browse Projects; adding someone else
+    requires the Manage Watchers permission. Self-adds are idempotent —
+    Jira silently accepts repeated adds.
+
+    Examples:
+
+      jira-watchers add PROJ-123
+
+      jira-watchers add PROJ-123 --user asmith
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+
+    try:
+        identifier, _is_acct = _resolve_watcher_identifier(client, user)
+
+        # POST body is a raw JSON-encoded string (e.g. '"jdoe"'), NOT
+        # {"name": "jdoe"}. atlassian-python-api's issue_add_watcher handles
+        # that correctly — do not wrap in a dict.
+        client.issue_add_watcher(issue_key, identifier)
+
+        suffix = " (you)" if user.lower() == "me" else ""
+
+        if ctx.obj["json"]:
+            print(format_json({"key": issue_key, "user": identifier, "added": True}))
+        elif ctx.obj["quiet"]:
+            print("ok")
+        else:
+            success(f"Added watcher to {issue_key}: {identifier}{suffix}")
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to add watcher: {e}")
+        sys.exit(1)
+```
+
+**Step 4: Run and verify PASS**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersAdd -v --no-header
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_watchers.py skills/jira-communication/scripts/utility/jira-watchers.py
+git commit -m "feat(watchers): implement add subcommand for self-watch default"
+```
+
+---
+
+### Task 6: `add` subcommand — specific user via `--user`
+
+**Files:**
+- Modify: `tests/test_watchers.py`
+
+**Step 1: Write failing tests**
+
+Add inside `class TestWatchersAdd`:
+
+```python
+    def test_add_user_by_username_dc(self):
+        mc = _make_mock_client(cloud=False)
+        mc.user_find_by_user_string.return_value = [
+            {"name": "asmith", "displayName": "Alice Smith"}
+        ]
+        result, _ = _run(["add", "TEST-1", "--user", "asmith"], mc)
+        assert result.exit_code == 0, result.output
+        assert "asmith" in result.output
+        assert "(you)" not in result.output
+        mc.issue_add_watcher.assert_called_once_with("TEST-1", "asmith")
+
+    def test_add_user_by_account_id_cloud(self):
+        """An account-id-shaped identifier bypasses user search."""
+        mc = _make_mock_client(cloud=True)
+        acct = "557058:d5765ebc-27de-4ce3-b520-a77a87e5e99a"
+        result, _ = _run(["add", "TEST-1", "--user", acct], mc)
+        assert result.exit_code == 0, result.output
+        mc.user_find_by_user_string.assert_not_called()
+        mc.issue_add_watcher.assert_called_once_with("TEST-1", acct)
+
+    def test_add_json_output(self):
+        mc = _make_mock_client()
+        mc.myself.return_value = {"name": "bwilson"}
+        result, _ = _run(["--json", "add", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data == {"key": "TEST-1", "user": "bwilson", "added": True}
+
+    def test_add_quiet_output(self):
+        mc = _make_mock_client()
+        mc.myself.return_value = {"name": "bwilson"}
+        result, _ = _run(["--quiet", "add", "TEST-1"], mc)
+        assert result.exit_code == 0
+        assert result.output.strip() == "ok"
+```
+
+**Step 2: Run and verify PASS**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersAdd -v --no-header
+```
+
+Expected: PASS — no code change needed; `resolve_assignee` + the existing `add` implementation cover all three paths.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_watchers.py
+git commit -m "test(watchers): cover add --user by name, accountId, and output modes"
+```
+
+---
+
+### Task 7: `add` — idempotent self-add and 403 error surfacing
+
+**Files:**
+- Modify: `tests/test_watchers.py`
+
+**Step 1: Write failing tests**
+
+Add inside `class TestWatchersAdd`:
+
+```python
+    def test_add_self_is_idempotent(self):
+        """Jira returns 204 for duplicate self-adds; script treats as success."""
+        mc = _make_mock_client()
+        mc.myself.return_value = {"name": "bwilson"}
+        # Simulate a second add — library returns None either way, no special
+        # handling needed. The test exists to pin the contract.
+        mc.issue_add_watcher.return_value = None
+        result, _ = _run(["add", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "Added watcher" in result.output
+
+    def test_add_manage_watchers_permission_error(self):
+        mc = _make_mock_client()
+        mc.user_find_by_user_string.return_value = [{"name": "asmith"}]
+        mc.issue_add_watcher.side_effect = Exception(
+            "403 Client Error: Forbidden — Manage Watchers permission required"
+        )
+        result, _ = _run(["add", "TEST-1", "--user", "asmith"], mc)
+        assert result.exit_code == 1
+        assert "Failed to add watcher" in result.output
+        assert "403" in result.output or "Forbidden" in result.output
+```
+
+**Step 2: Run and verify PASS**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersAdd -v --no-header
+```
+
+Expected: PASS. If the 403 message is truncated by `error()`, confirm the full exception `str(e)` is interpolated in the f-string (it is in the Task 5 implementation).
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_watchers.py
+git commit -m "test(watchers): verify idempotent self-add and 403 error surfacing"
+```
+
+---
+
+### Task 8: `remove` subcommand — self, `--user`, and `--dry-run`
+
+**Files:**
+- Modify: `tests/test_watchers.py`
+- Modify: `skills/jira-communication/scripts/utility/jira-watchers.py`
+
+**Step 1: Write failing tests**
+
+Append:
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: remove subcommand
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWatchersRemove:
+    def test_remove_self_default_dc(self):
+        mc = _make_mock_client(cloud=False)
+        mc.myself.return_value = {"name": "bwilson"}
+        result, _ = _run(["remove", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "Removed watcher" in result.output
+        assert "bwilson" in result.output
+        assert "(you)" in result.output
+        mc.issue_delete_watcher.assert_called_once_with("TEST-1", username="bwilson")
+
+    def test_remove_user_by_username_dc(self):
+        mc = _make_mock_client(cloud=False)
+        mc.user_find_by_user_string.return_value = [{"name": "asmith"}]
+        result, _ = _run(["remove", "TEST-1", "--user", "asmith"], mc)
+        assert result.exit_code == 0, result.output
+        assert "(you)" not in result.output
+        mc.issue_delete_watcher.assert_called_once_with("TEST-1", username="asmith")
+
+    def test_remove_dry_run_does_not_call_api(self):
+        mc = _make_mock_client()
+        mc.myself.return_value = {"name": "bwilson"}
+        result, _ = _run(["remove", "TEST-1", "--dry-run"], mc)
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        assert "Would remove" in result.output
+        assert "bwilson" in result.output
+        mc.issue_delete_watcher.assert_not_called()
+
+    def test_remove_json_output(self):
+        mc = _make_mock_client(cloud=False)
+        mc.myself.return_value = {"name": "bwilson"}
+        result, _ = _run(["--json", "remove", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data == {"key": "TEST-1", "user": "bwilson", "removed": True}
+
+    def test_remove_non_watcher_surfaces_error(self):
+        mc = _make_mock_client(cloud=False)
+        mc.myself.return_value = {"name": "bwilson"}
+        mc.issue_delete_watcher.side_effect = Exception("404 Not Found")
+        result, _ = _run(["remove", "TEST-1"], mc)
+        assert result.exit_code == 1
+        assert "Failed to remove watcher" in result.output
+        assert "404" in result.output
+```
+
+**Step 2: Run and verify FAIL**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersRemove -v --no-header
+```
+
+Expected: all FAIL with `NotImplementedError` from `remove`.
+
+**Step 3: Implement `remove`**
+
+Replace the `remove` stub:
+
+```python
+@cli.command()
+@click.argument("issue_key")
+@click.option("--user", default="me", help="Username, accountId, email, or 'me' (default: me)")
+@click.option("--dry-run", is_flag=True, help="Show what would be removed")
+@click.pass_context
+def remove(ctx, issue_key: str, user: str, dry_run: bool):
+    """Remove a watcher from an issue (default: yourself).
+
+    ISSUE_KEY: The Jira issue key (e.g. PROJ-123)
+
+    Removing yourself requires only Browse Projects; removing someone else
+    requires Manage Watchers. Removing a non-watcher returns 404 — surfaced
+    as a clean error, not a silent success.
+
+    Examples:
+
+      jira-watchers remove PROJ-123
+
+      jira-watchers remove PROJ-123 --user asmith --dry-run
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+
+    try:
+        identifier, is_acct = _resolve_watcher_identifier(client, user)
+        suffix = " (you)" if user.lower() == "me" else ""
+
+        if dry_run:
+            warning("DRY RUN - No watcher will be removed")
+            print(f"Would remove {identifier}{suffix} from {issue_key}")
+            return
+
+        kwargs = _watcher_api_arg(client, identifier, is_acct)
+        client.issue_delete_watcher(issue_key, **kwargs)
+
+        if ctx.obj["json"]:
+            print(format_json({"key": issue_key, "user": identifier, "removed": True}))
+        elif ctx.obj["quiet"]:
+            print("ok")
+        else:
+            success(f"Removed watcher from {issue_key}: {identifier}{suffix}")
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to remove watcher: {e}")
+        sys.exit(1)
+```
+
+Add the helper above `list_watchers` (Task 9 covers its own tests, but a minimal version is needed here so the remove tests pass). Add below `_resolve_watcher_identifier`:
+
+```python
+def _watcher_api_arg(client, identifier: str, is_account_id_value: bool) -> dict:
+    """Return the keyword arg dict for issue_delete_watcher.
+
+    DC takes ?username=...; Cloud takes ?accountId=.... atlassian-python-api
+    exposes both as keyword args; pick based on the resolved identifier
+    shape (an account-id-shaped string means Cloud/accountId).
+    """
+    if is_account_id_value:
+        return {"account_id": identifier}
+    return {"username": identifier}
+```
+
+> Note: `atlassian-python-api`'s `issue_delete_watcher` accepts `username=` and `account_id=` kwargs. If this signature is not verified in the installed version, fall back to raw REST: `client.delete(f"rest/api/2/issue/{issue_key}/watchers", params=kwargs_with_camelcase)` with `username` or `accountId` as the param key, and state the fallback explicitly in code review.
+
+**Step 4: Run and verify PASS**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatchersRemove -v --no-header
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_watchers.py skills/jira-communication/scripts/utility/jira-watchers.py
+git commit -m "feat(watchers): implement remove subcommand with --dry-run and error surfacing"
+```
+
+---
+
+### Task 9: `remove` — DC vs Cloud query-param helper isolation
+
+**Files:**
+- Modify: `tests/test_watchers.py`
+
+**Step 1: Write failing tests**
+
+Append:
+
+```python
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: _watcher_api_arg helper (pure)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWatcherApiArg:
+    def test_dc_username(self):
+        mc = _make_mock_client(cloud=False)
+        assert _watchers_mod._watcher_api_arg(mc, "jdoe", False) == {"username": "jdoe"}
+
+    def test_cloud_account_id(self):
+        mc = _make_mock_client(cloud=True)
+        acct = "557058:d5765ebc-27de-4ce3-b520-a77a87e5e99a"
+        assert _watchers_mod._watcher_api_arg(mc, acct, True) == {"account_id": acct}
+
+
+class TestWatchersRemoveCloud:
+    def test_remove_cloud_passes_account_id(self):
+        mc = _make_mock_client(cloud=True)
+        acct = "557058:d5765ebc-27de-4ce3-b520-a77a87e5e99a"
+        result, _ = _run(["remove", "TEST-1", "--user", acct], mc)
+        assert result.exit_code == 0, result.output
+        mc.issue_delete_watcher.assert_called_once_with("TEST-1", account_id=acct)
+```
+
+**Step 2: Run and verify PASS**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_watchers.py::TestWatcherApiArg tests/test_watchers.py::TestWatchersRemoveCloud -v --no-header
+```
+
+Expected: PASS (helper already added in Task 8). If FAIL, confirm `_watcher_api_arg` is exported at module scope and not nested inside `remove`.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_watchers.py
+git commit -m "test(watchers): pin DC vs Cloud watcher-delete param mapping"
+```
+
+---
+
+### Task 10: Register the script in the CLI smoke test
+
+**Files:**
+- Modify: `tests/test_cli_smoke.py`
+
+**Step 1: Add module load**
+
+In `tests/test_cli_smoke.py`, locate the block of `_load_script` calls near the top (around line 34–45 based on current file). Add one line at the end of that block:
+
+```python
+_watchers_mod = _load_script("jira-watchers", "utility")
+```
+
+**Step 2: Add help test**
+
+Inside `class TestHelpOutput` (which contains `test_weblink_help` around line 110), append a new method following the same shape:
+
+```python
+    def test_watchers_help(self):
+        output = self._run_help(_watchers_mod.cli)
+        assert "watcher" in output.lower()
+```
+
+**Step 3: Run smoke tests**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/test_cli_smoke.py -v --no-header
+```
+
+Expected: all pass including the new `test_watchers_help`.
+
+**Step 4: Commit**
+
+```bash
+git add tests/test_cli_smoke.py
+git commit -m "test(watchers): register jira-watchers in CLI smoke test"
+```
+
+---
+
+### Task 11: Update SKILL.md with the new script
+
+**Files:**
+- Modify: `skills/jira-communication/SKILL.md`
+
+**Step 1: Update the Utility scripts line**
+
+On line 25 of `SKILL.md`, the current line is:
+
+```
+**Utility**: `jira-user.py` (get/search/me), `jira-fields.py` (search/types), `jira-link.py`, `jira-weblink.py` (web link CRUD), `jira-worklog-query.py`
+```
+
+Change it to:
+
+```
+**Utility**: `jira-user.py` (get/search/me), `jira-fields.py` (search/types), `jira-link.py`, `jira-weblink.py` (web link CRUD), `jira-watchers.py` (watcher CRUD), `jira-worklog-query.py`
+```
+
+**Step 2: Add Common Tasks examples**
+
+In the Common Tasks section, after the `jira-weblink.py` block (around line 79), append:
+
+```bash
+# Watchers (self-subscribe, subscribe stakeholders, unsubscribe)
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py list PROJ-123
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py add PROJ-123
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py add PROJ-123 --user product.owner
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py remove PROJ-123
+```
+
+**Step 3: Commit**
+
+```bash
+git add skills/jira-communication/SKILL.md
+git commit -m "docs(watchers): document jira-watchers in SKILL.md"
+```
+
+---
+
+### Task 12: Full lint + security + test sweep
+
+**Files:** none modified by the task itself; may auto-fix lint findings in `jira-watchers.py` or `test_watchers.py`.
+
+Apply `@superpowers:verification-before-completion` — run each command and confirm output before claiming done.
+
+**Step 1: Pre-commit smoke check**
+
+```bash
+uv run skills/jira-communication/scripts/core/jira-validate.py --help
+uv run skills/jira-communication/scripts/utility/jira-watchers.py --help
+```
+
+Expected: both print their help banner with exit code 0.
+
+**Step 2: Ruff**
+
+```bash
+uv run --no-project --with ruff ruff check skills/jira-communication/scripts/utility/jira-watchers.py tests/test_watchers.py
+```
+
+Expected: `All checks passed!`. If fixes are reported, run `ruff check --fix` on the same files, re-run the check, and commit any resulting changes with `style(watchers): apply ruff autofixes`.
+
+**Step 3: Bandit**
+
+```bash
+uv run --no-project --with bandit bandit -r skills/jira-communication/scripts/ scripts/ -c pyproject.toml --severity-level medium
+```
+
+Expected: no issues identified at medium+ severity.
+
+**Step 4: Full pytest**
+
+```bash
+uv run --no-project --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/ -q
+```
+
+Expected: all tests pass (existing + new watcher suite + the CLI smoke registration).
+
+**Step 5: Commit any autofixes**
+
+```bash
+git status
+# If ruff made edits in Step 2, commit them:
+git add skills/jira-communication/scripts/utility/jira-watchers.py tests/test_watchers.py
+git commit -m "style(watchers): apply ruff autofixes"
+```
+
+If nothing changed, skip the commit — do not create an empty commit.
+
+---
+
+## Done criteria
+
+- `jira-watchers.py` exists under `scripts/utility/` with `list`, `add`, `remove` subcommands.
+- All new tests in `tests/test_watchers.py` pass.
+- `tests/test_cli_smoke.py` includes the watcher help test.
+- `SKILL.md` lists the script and gives at least three usage examples.
+- Ruff and Bandit are clean; full pytest suite is green.

--- a/evals/comprehensive-evals.json
+++ b/evals/comprehensive-evals.json
@@ -127,6 +127,27 @@
       "prompt": "Update the description of PROJ-123 using fields-json",
       "expected_output": "Agent reads references/issue-editing.md and runs jira-issue.py update PROJ-123 --fields-json '{\"description\": \"...\"}'",
       "ideal_tools": 2
+    },
+    {
+      "id": 19,
+      "name": "list-watchers",
+      "prompt": "List watchers on TEST-135",
+      "expected_output": "Agent reads references/watchers.md then runs jira-watchers.py list TEST-135",
+      "ideal_tools": 2
+    },
+    {
+      "id": 20,
+      "name": "add-watcher",
+      "prompt": "Add asmith as a watcher on TEST-135",
+      "expected_output": "Agent reads references/watchers.md then runs jira-watchers.py add TEST-135 --user asmith",
+      "ideal_tools": 2
+    },
+    {
+      "id": 21,
+      "name": "remove-self-watch",
+      "prompt": "Stop watching TEST-135",
+      "expected_output": "Agent reads references/watchers.md then runs jira-watchers.py remove TEST-135",
+      "ideal_tools": 2
     }
   ]
 }

--- a/evals/comprehensive-workspace/baseline-skill/SKILL.md
+++ b/evals/comprehensive-workspace/baseline-skill/SKILL.md
@@ -24,7 +24,7 @@ Under `${CLAUDE_SKILL_DIR}/scripts/{core,workflow,utility}/`.
 
 **Core**: `jira-issue.py`, `jira-search.py`, `jira-worklog.py`, `jira-attachment.py`, `jira-setup.py`, `jira-validate.py`
 **Workflow**: `jira-create.py`, `jira-transition.py`, `jira-comment.py`, `jira-move.py`, `jira-sprint.py`, `jira-board.py`
-**Utility**: `jira-user.py`, `jira-fields.py`, `jira-link.py`, `jira-weblink.py`, `jira-worklog-query.py`
+**Utility**: `jira-user.py`, `jira-fields.py`, `jira-link.py`, `jira-weblink.py`, `jira-worklog-query.py`, `jira-watchers.py`
 
 ## Execution Style
 
@@ -61,6 +61,7 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screensh
 - `references/links.md` — when working with issue or web links
 - `references/agile.md` — when working with sprints, boards, or `board --name`
 - `references/fields-and-users.md` — when looking up custom field IDs, users, or issue types
+- `references/watchers.md` — when the user asks to watch, subscribe, notify on, or list watchers of an issue
 
 ## Authentication
 

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -24,7 +24,7 @@ Under `${CLAUDE_SKILL_DIR}/scripts/{core,workflow,utility}/`.
 
 **Core**: `jira-issue.py`, `jira-search.py`, `jira-worklog.py`, `jira-attachment.py`, `jira-setup.py`, `jira-validate.py`
 **Workflow**: `jira-create.py`, `jira-transition.py`, `jira-comment.py`, `jira-move.py`, `jira-sprint.py`, `jira-board.py`
-**Utility**: `jira-user.py`, `jira-fields.py`, `jira-link.py`, `jira-weblink.py`, `jira-worklog-query.py`
+**Utility**: `jira-user.py`, `jira-fields.py`, `jira-link.py`, `jira-weblink.py`, `jira-worklog-query.py`, `jira-watchers.py`
 
 ## Execution Style
 
@@ -61,6 +61,7 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screensh
 - `references/links.md` — when working with issue or web links
 - `references/agile.md` — when working with sprints, boards, or `board --name`
 - `references/fields-and-users.md` — when looking up custom field IDs, users, or issue types
+- `references/watchers.md` — when the user asks to watch, subscribe, notify on, or list watchers of an issue
 
 ## Authentication
 

--- a/skills/jira-communication/references/watchers.md
+++ b/skills/jira-communication/references/watchers.md
@@ -1,0 +1,93 @@
+# Watchers
+
+## When to load
+
+Load this reference whenever the user asks about watchers — listing, adding,
+removing, or auto-subscribing themselves or a stakeholder when an issue
+changes state. Watchers are not exposed anywhere else in the skill, so any
+"watch", "subscribe", "notify me on", "unsubscribe", or "who is watching"
+request should land here.
+
+## Commands
+
+All commands are subcommands of `jira-watchers.py`. Global flags (`--json`,
+`--quiet`, `--profile`, `--env-file`, `--debug`) go **before** the subcommand.
+
+### list
+
+```bash
+# Default — header with count, one row per watcher
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py list PROJ-123
+
+# JSON — raw Jira response ({"watchCount", "isWatching", "watchers": [...]})
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py --json list PROJ-123
+
+# Quiet — one identifier per line
+# DC prints usernames; Cloud prints accountIds (pipeline-friendly)
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py --quiet list PROJ-123
+```
+
+### add
+
+```bash
+# Self-subscribe (default — requires only Browse Projects)
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py add PROJ-123
+
+# Subscribe someone else (requires Manage Watchers permission)
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py add PROJ-123 --user product.owner
+
+# Cloud: pass an accountId directly to skip user-search
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py add PROJ-123 --user 557058:d5765ebc-27de-4ce3-b520-a77a87e5e99a
+
+# JSON output → {"key": "PROJ-123", "user": "asmith", "added": true}
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py --json add PROJ-123
+```
+
+### remove
+
+```bash
+# Un-watch yourself
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py remove PROJ-123
+
+# Remove someone else (requires Manage Watchers)
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py remove PROJ-123 --user asmith
+
+# Preview without calling the API
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py remove PROJ-123 --user asmith --dry-run
+
+# JSON output → {"key": "PROJ-123", "user": "asmith", "removed": true}
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py --json remove PROJ-123
+```
+
+### Bulk patterns (no server-side bulk endpoint)
+
+```bash
+# Watch every child of an epic
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py --json query '"Epic Link" = PROJ-789' \
+  | jq -r '.issues[].key' \
+  | xargs -I{} uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-watchers.py add {}
+```
+
+## Gotchas
+
+- **DC vs Cloud identity.** DC uses usernames (`jdoe`); Cloud uses accountIds
+  (`557058:...`). The script auto-detects via `client.cloud` and `resolve_assignee()` —
+  pass whatever identifier you have; account-id-shaped strings bypass user search.
+- **`atlassian-python-api` kwarg is `user`, not `username`, on `issue_delete_watcher`.**
+  Actually, the library accepts `username=` (DC) and `account_id=` (Cloud) — the
+  script picks the correct kwarg based on identifier shape. If you ever drop to
+  raw REST, the query-param names are `?username=` / `?accountId=` (camelCase on
+  the wire).
+- **Self-watch is idempotent.** Adding yourself when already watching returns
+  HTTP 204, not an error — the script treats repeated self-adds as success.
+- **403 on someone-else add/remove.** Non-self watcher changes require the
+  Manage Watchers project permission. A 403 is surfaced verbatim as the
+  error message — do not silently swallow.
+- **404 on remove-non-watcher.** Removing a user who is not currently watching
+  returns HTTP 404 on both DC and Cloud. The script surfaces this as a clean
+  error (exit code 1), not a silent success.
+
+## See also
+
+`docs/plans/2026-04-20-watchers-design.md` for the full design trail
+(REST shapes, DC vs Cloud matrix, out-of-scope items).

--- a/skills/jira-communication/references/watchers.md
+++ b/skills/jira-communication/references/watchers.md
@@ -73,11 +73,11 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py --json query '"Epic Link"
 - **DC vs Cloud identity.** DC uses usernames (`jdoe`); Cloud uses accountIds
   (`557058:...`). The script auto-detects via `client.cloud` and `resolve_assignee()` —
   pass whatever identifier you have; account-id-shaped strings bypass user search.
-- **`atlassian-python-api` kwarg is `user`, not `username`, on `issue_delete_watcher`.**
-  Actually, the library accepts `username=` (DC) and `account_id=` (Cloud) — the
-  script picks the correct kwarg based on identifier shape. If you ever drop to
-  raw REST, the query-param names are `?username=` / `?accountId=` (camelCase on
-  the wire).
+- **`issue_delete_watcher` library kwargs differ from raw REST params.**
+  In `atlassian-python-api`, call `issue_delete_watcher(..., username=...)` on DC
+  and `issue_delete_watcher(..., account_id=...)` on Cloud; the script chooses the
+  correct kwarg based on deployment/identifier shape. If you ever drop to raw
+  REST, the query parameter names are `?username=` (DC) and `?accountId=` (Cloud).
 - **Self-watch is idempotent.** Adding yourself when already watching returns
   HTTP 204, not an error — the script treats repeated self-adds as success.
 - **403 on someone-else add/remove.** Non-self watcher changes require the

--- a/skills/jira-communication/scripts/utility/jira-watchers.py
+++ b/skills/jira-communication/scripts/utility/jira-watchers.py
@@ -55,11 +55,15 @@ def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str 
 def _resolve_watcher_identifier(client, identifier: str) -> tuple[str, bool]:
     """Return (value, is_account_id) suitable for issue_add_watcher / issue_delete_watcher.
 
-    Reuses resolve_assignee() for the hard part (me / accountId / user search) and
-    unwraps the dict into a flat string — the watchers REST API takes a bare
-    identifier, not {"name": ...} / {"accountId": ...}.
+    Reuses resolve_assignee() for 'me' / accountId / user-search handling and
+    unwraps the {"name": ...} / {"accountId": ...} dict into a flat string,
+    because the watchers REST API takes a bare identifier as its JSON body
+    (not an object). atlassian-python-api passes the string through verbatim.
     """
-    raise NotImplementedError
+    resolved = resolve_assignee(client, identifier)
+    if "accountId" in resolved:
+        return resolved["accountId"], True
+    return resolved["name"], False
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -119,8 +123,45 @@ def list_watchers(ctx, issue_key: str):
 @click.option("--user", default="me", help="Username, accountId, email, or 'me' (default: me)")
 @click.pass_context
 def add(ctx, issue_key: str, user: str):
-    """Add a watcher to an issue (default: yourself)."""
-    raise NotImplementedError
+    """Add a watcher to an issue (default: yourself).
+
+    ISSUE_KEY: The Jira issue key (e.g. PROJ-123)
+
+    Adding yourself requires only Browse Projects; adding someone else
+    requires the Manage Watchers permission. Self-adds are idempotent —
+    Jira silently accepts repeated adds.
+
+    Examples:
+
+      jira-watchers add PROJ-123
+
+      jira-watchers add PROJ-123 --user asmith
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+
+    try:
+        identifier, _is_acct = _resolve_watcher_identifier(client, user)
+
+        # POST body is a raw JSON-encoded string (e.g. '"jdoe"'), NOT
+        # {"name": "jdoe"}. atlassian-python-api's issue_add_watcher handles
+        # that correctly — do not wrap in a dict.
+        client.issue_add_watcher(issue_key, identifier)
+
+        suffix = " (you)" if user.lower() == "me" else ""
+
+        if ctx.obj["json"]:
+            print(format_json({"key": issue_key, "user": identifier, "added": True}))
+        elif ctx.obj["quiet"]:
+            print("ok")
+        else:
+            success(f"Added watcher to {issue_key}: {identifier}{suffix}")
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to add watcher: {e}")
+        sys.exit(1)
 
 
 @cli.command()

--- a/skills/jira-communication/scripts/utility/jira-watchers.py
+++ b/skills/jira-communication/scripts/utility/jira-watchers.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "atlassian-python-api>=3.41.0,<4",
+#     "click>=8.1.0,<9",
+# ]
+# ///
+"""Jira watcher operations — list, add, and remove issue watchers."""
+
+import sys
+from pathlib import Path
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Shared library import (TR1.1.1 - PYTHONPATH approach)
+# ═══════════════════════════════════════════════════════════════════════════════
+_script_dir = Path(__file__).parent
+_lib_path = _script_dir.parent / "lib"
+if _lib_path.exists():
+    sys.path.insert(0, str(_lib_path.parent))
+
+import click
+from lib.client import LazyJiraClient, is_account_id, resolve_assignee
+from lib.output import error, format_json, success, warning
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CLI Definition
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@click.group()
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.option("--quiet", "-q", is_flag=True, help="Minimal output")
+@click.option("--env-file", type=click.Path(), help="Environment file path")
+@click.option("--profile", "-P", help="Jira profile name from ~/.jira/profiles.json")
+@click.option("--debug", is_flag=True, help="Show debug information on errors")
+@click.pass_context
+def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str | None, debug: bool):
+    """Jira watcher operations.
+
+    List, add, and remove watchers on Jira issues.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj["json"] = output_json
+    ctx.obj["quiet"] = quiet
+    ctx.obj["debug"] = debug
+    ctx.obj["client"] = LazyJiraClient(env_file=env_file, profile=profile)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _resolve_watcher_identifier(client, identifier: str) -> tuple[str, bool]:
+    """Return (value, is_account_id) suitable for issue_add_watcher / issue_delete_watcher.
+
+    Reuses resolve_assignee() for the hard part (me / accountId / user search) and
+    unwraps the dict into a flat string — the watchers REST API takes a bare
+    identifier, not {"name": ...} / {"accountId": ...}.
+    """
+    raise NotImplementedError
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Subcommands
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@cli.command("list")
+@click.argument("issue_key")
+@click.pass_context
+def list_watchers(ctx, issue_key: str):
+    """List watchers on an issue.
+
+    ISSUE_KEY: The Jira issue key (e.g. PROJ-123)
+    """
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("issue_key")
+@click.option("--user", default="me", help="Username, accountId, email, or 'me' (default: me)")
+@click.pass_context
+def add(ctx, issue_key: str, user: str):
+    """Add a watcher to an issue (default: yourself)."""
+    raise NotImplementedError
+
+
+@cli.command()
+@click.argument("issue_key")
+@click.option("--user", default="me", help="Username, accountId, email, or 'me' (default: me)")
+@click.option("--dry-run", is_flag=True, help="Show what would be removed")
+@click.pass_context
+def remove(ctx, issue_key: str, user: str, dry_run: bool):
+    """Remove a watcher from an issue (default: yourself)."""
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    cli()

--- a/skills/jira-communication/scripts/utility/jira-watchers.py
+++ b/skills/jira-communication/scripts/utility/jira-watchers.py
@@ -74,8 +74,44 @@ def list_watchers(ctx, issue_key: str):
     """List watchers on an issue.
 
     ISSUE_KEY: The Jira issue key (e.g. PROJ-123)
+
+    Example:
+
+      jira-watchers list PROJ-123
     """
-    raise NotImplementedError
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+
+    try:
+        data = client.issue_get_watchers(issue_key)
+
+        if ctx.obj["json"]:
+            print(format_json(data))
+            return
+
+        watchers = data.get("watchers", []) or []
+        count = data.get("watchCount", len(watchers))
+
+        if ctx.obj["quiet"]:
+            for w in watchers:
+                print(w.get("accountId") or w.get("name", ""))
+            return
+
+        if not watchers:
+            print(f"(no watchers) for {issue_key}")
+            return
+
+        print(f"Watchers for {issue_key} ({count}):\n")
+        for w in watchers:
+            name = w.get("name") or w.get("accountId", "")
+            display = w.get("displayName", "")
+            print(f"  {name:<20} {display}")
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to list watchers: {e}")
+        sys.exit(1)
 
 
 @cli.command()

--- a/skills/jira-communication/scripts/utility/jira-watchers.py
+++ b/skills/jira-communication/scripts/utility/jira-watchers.py
@@ -20,7 +20,7 @@ if _lib_path.exists():
     sys.path.insert(0, str(_lib_path.parent))
 
 import click
-from lib.client import LazyJiraClient, is_account_id, resolve_assignee
+from lib.client import LazyJiraClient, resolve_assignee
 from lib.output import error, format_json, success, warning
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/skills/jira-communication/scripts/utility/jira-watchers.py
+++ b/skills/jira-communication/scripts/utility/jira-watchers.py
@@ -115,7 +115,7 @@ def list_watchers(ctx, issue_key: str):
             return
 
         if not watchers:
-            print(f"(no watchers) for {issue_key}")
+            print(f"No watchers for {issue_key}")
             return
 
         # Jira returns isWatching at the top level describing the caller —

--- a/skills/jira-communication/scripts/utility/jira-watchers.py
+++ b/skills/jira-communication/scripts/utility/jira-watchers.py
@@ -66,6 +66,18 @@ def _resolve_watcher_identifier(client, identifier: str) -> tuple[str, bool]:
     return resolved["name"], False
 
 
+def _watcher_api_arg(client, identifier: str, is_account_id_value: bool) -> dict:
+    """Return the keyword arg dict for issue_delete_watcher.
+
+    DC takes ?username=...; Cloud takes ?accountId=.... atlassian-python-api
+    exposes both as keyword args; pick based on the resolved identifier
+    shape (an account-id-shaped string means Cloud/accountId).
+    """
+    if is_account_id_value:
+        return {"account_id": identifier}
+    return {"username": identifier}
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Subcommands
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -170,8 +182,47 @@ def add(ctx, issue_key: str, user: str):
 @click.option("--dry-run", is_flag=True, help="Show what would be removed")
 @click.pass_context
 def remove(ctx, issue_key: str, user: str, dry_run: bool):
-    """Remove a watcher from an issue (default: yourself)."""
-    raise NotImplementedError
+    """Remove a watcher from an issue (default: yourself).
+
+    ISSUE_KEY: The Jira issue key (e.g. PROJ-123)
+
+    Removing yourself requires only Browse Projects; removing someone else
+    requires Manage Watchers. Removing a non-watcher returns 404 — surfaced
+    as a clean error, not a silent success.
+
+    Examples:
+
+      jira-watchers remove PROJ-123
+
+      jira-watchers remove PROJ-123 --user asmith --dry-run
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+
+    try:
+        identifier, is_acct = _resolve_watcher_identifier(client, user)
+        suffix = " (you)" if user.lower() == "me" else ""
+
+        if dry_run:
+            warning("DRY RUN - No watcher will be removed")
+            print(f"Would remove {identifier}{suffix} from {issue_key}")
+            return
+
+        kwargs = _watcher_api_arg(client, identifier, is_acct)
+        client.issue_delete_watcher(issue_key, **kwargs)
+
+        if ctx.obj["json"]:
+            print(format_json({"key": issue_key, "user": identifier, "removed": True}))
+        elif ctx.obj["quiet"]:
+            print("ok")
+        else:
+            success(f"Removed watcher from {issue_key}: {identifier}{suffix}")
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to remove watcher: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/skills/jira-communication/scripts/utility/jira-watchers.py
+++ b/skills/jira-communication/scripts/utility/jira-watchers.py
@@ -66,7 +66,7 @@ def _resolve_watcher_identifier(client, identifier: str) -> tuple[str, bool]:
     return resolved["name"], False
 
 
-def _watcher_api_arg(client, identifier: str, is_account_id_value: bool) -> dict:
+def _watcher_api_arg(identifier: str, is_account_id_value: bool) -> dict:
     """Return the keyword arg dict for issue_delete_watcher.
 
     DC takes ?username=...; Cloud takes ?accountId=.... atlassian-python-api
@@ -213,7 +213,7 @@ def remove(ctx, issue_key: str, user: str, dry_run: bool):
             print(f"Would remove {identifier}{suffix} from {issue_key}")
             return
 
-        kwargs = _watcher_api_arg(client, identifier, is_acct)
+        kwargs = _watcher_api_arg(identifier, is_acct)
         client.issue_delete_watcher(issue_key, **kwargs)
 
         if ctx.obj["json"]:

--- a/skills/jira-communication/scripts/utility/jira-watchers.py
+++ b/skills/jira-communication/scripts/utility/jira-watchers.py
@@ -107,6 +107,7 @@ def list_watchers(ctx, issue_key: str):
 
         watchers = data.get("watchers", []) or []
         count = data.get("watchCount", len(watchers))
+        is_watching = bool(data.get("isWatching"))
 
         if ctx.obj["quiet"]:
             for w in watchers:
@@ -117,7 +118,11 @@ def list_watchers(ctx, issue_key: str):
             print(f"(no watchers) for {issue_key}")
             return
 
-        print(f"Watchers for {issue_key} ({count}):\n")
+        # Jira returns isWatching at the top level describing the caller —
+        # surface it in the header so users know their own subscription state
+        # without a second client.myself() round-trip.
+        status = "you are watching" if is_watching else "you are not watching"
+        print(f"Watchers for {issue_key} ({count}) — {status}:\n")
         for w in watchers:
             name = w.get("name") or w.get("accountId", "")
             display = w.get("displayName", "")

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -43,6 +43,7 @@ _user_mod = _load_script("jira-user", "utility")
 _link_mod = _load_script("jira-link", "utility")
 _worklog_query_mod = _load_script("jira-worklog-query", "utility")
 _weblink_mod = _load_script("jira-weblink", "utility")
+_watchers_mod = _load_script("jira-watchers", "utility")
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -110,6 +111,10 @@ class TestHelpOutput:
     def test_weblink_help(self):
         output = self._run_help(_weblink_mod.cli)
         assert "web link" in output.lower() or "remote link" in output.lower()
+
+    def test_watchers_help(self):
+        output = self._run_help(_watchers_mod.cli)
+        assert "watcher" in output.lower()
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -144,3 +144,25 @@ class TestWatchersList:
         assert result.exit_code == 0
         lines = [ln for ln in result.output.splitlines() if ln.strip()]
         assert lines == ["jdoe", "asmith"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: add subcommand
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWatchersAdd:
+    def test_add_self_default(self):
+        mc = _make_mock_client()
+        # Default --user is "me", resolve_assignee calls client.myself()
+        mc.myself.return_value = {"name": "bwilson", "displayName": "Bob Wilson"}
+        mc.issue_add_watcher.return_value = None  # 204 No Content
+        result, _ = _run(["add", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "Added watcher" in result.output
+        assert "TEST-1" in result.output
+        assert "bwilson" in result.output
+        # Raw string identifier, not a dict — Jira's watchers POST body is
+        # a JSON-encoded string; atlassian-python-api passes this straight
+        # through as the request body.
+        mc.issue_add_watcher.assert_called_once_with("TEST-1", "bwilson")

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -102,3 +102,45 @@ class TestWatchersList:
         assert result.exit_code == 0, result.output
         assert "(no watchers)" in result.output
         assert "TEST-1" in result.output
+
+    def test_list_json_output(self):
+        mc = _make_mock_client()
+        payload = {
+            "watchCount": 1,
+            "isWatching": True,
+            "watchers": [_watcher("jdoe", "John Doe")],
+        }
+        mc.issue_get_watchers.return_value = payload
+        result, _ = _run(["--json", "list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["watchCount"] == 1
+        assert data["isWatching"] is True
+        assert data["watchers"][0]["name"] == "jdoe"
+
+    def test_list_quiet_cloud_prints_account_ids(self):
+        mc = _make_mock_client(cloud=True)
+        mc.issue_get_watchers.return_value = {
+            "watchCount": 2,
+            "isWatching": False,
+            "watchers": [
+                _watcher("a", "A", account_id="557058:aaa"),
+                _watcher("b", "B", account_id="557058:bbb"),
+            ],
+        }
+        result, _ = _run(["--quiet", "list", "TEST-1"], mc)
+        assert result.exit_code == 0
+        lines = [ln for ln in result.output.splitlines() if ln.strip()]
+        assert lines == ["557058:aaa", "557058:bbb"]
+
+    def test_list_quiet_dc_prints_usernames(self):
+        mc = _make_mock_client(cloud=False)
+        mc.issue_get_watchers.return_value = {
+            "watchCount": 2,
+            "isWatching": False,
+            "watchers": [_watcher("jdoe", "J"), _watcher("asmith", "A")],
+        }
+        result, _ = _run(["--quiet", "list", "TEST-1"], mc)
+        assert result.exit_code == 0
+        lines = [ln for ln in result.output.splitlines() if ln.strip()]
+        assert lines == ["jdoe", "asmith"]

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -1,0 +1,60 @@
+"""Tests for jira-watchers.py — list/add/remove issue watchers."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import click.testing
+import pytest
+
+# Add scripts to path for lib imports
+_test_dir = Path(__file__).parent
+_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
+sys.path.insert(0, str(_scripts_path))
+
+
+def _load_script(name: str, subdir: str = "utility"):
+    """Load a hyphenated CLI script via importlib."""
+    path = _scripts_path / subdir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_watchers_mod = _load_script("jira-watchers", "utility")
+
+
+def _make_mock_client(cloud: bool = False):
+    mc = mock.Mock()
+    mc.with_context = mock.Mock()
+    # Explicit attribute — LazyJiraClient exposes .cloud via atlassian.Jira
+    object.__setattr__(mc, "cloud", cloud)
+    return mc
+
+
+def _run(args, mock_client=None):
+    """Run jira-watchers CLI with a mocked LazyJiraClient."""
+    if mock_client is None:
+        mock_client = _make_mock_client()
+    runner = click.testing.CliRunner()
+    with mock.patch.object(_watchers_mod, "LazyJiraClient", return_value=mock_client):
+        result = runner.invoke(_watchers_mod.cli, args)
+    return result, mock_client
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: help / subcommand registration
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWatchersHelp:
+    def test_cli_help_shows_subcommands(self):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_watchers_mod.cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "list" in result.output
+        assert "add" in result.output
+        assert "remove" in result.output

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -322,13 +322,11 @@ class TestWatchersRemove:
 
 class TestWatcherApiArg:
     def test_dc_username(self):
-        mc = _make_mock_client(cloud=False)
-        assert _watchers_mod._watcher_api_arg(mc, "jdoe", False) == {"username": "jdoe"}
+        assert _watchers_mod._watcher_api_arg("jdoe", False) == {"username": "jdoe"}
 
     def test_cloud_account_id(self):
-        mc = _make_mock_client(cloud=True)
         acct = "557058:d5765ebc-27de-4ce3-b520-a77a87e5e99a"
-        assert _watchers_mod._watcher_api_arg(mc, acct, True) == {"account_id": acct}
+        assert _watchers_mod._watcher_api_arg(acct, True) == {"account_id": acct}
 
 
 class TestWatchersRemoveCloud:

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from unittest import mock
 
 import click.testing
-import pytest
 
 # Add scripts to path for lib imports
 _test_dir = Path(__file__).parent

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -166,3 +166,38 @@ class TestWatchersAdd:
         # a JSON-encoded string; atlassian-python-api passes this straight
         # through as the request body.
         mc.issue_add_watcher.assert_called_once_with("TEST-1", "bwilson")
+
+    def test_add_user_by_username_dc(self):
+        mc = _make_mock_client(cloud=False)
+        mc.user_find_by_user_string.return_value = [
+            {"name": "asmith", "displayName": "Alice Smith"}
+        ]
+        result, _ = _run(["add", "TEST-1", "--user", "asmith"], mc)
+        assert result.exit_code == 0, result.output
+        assert "asmith" in result.output
+        assert "(you)" not in result.output
+        mc.issue_add_watcher.assert_called_once_with("TEST-1", "asmith")
+
+    def test_add_user_by_account_id_cloud(self):
+        """An account-id-shaped identifier bypasses user search."""
+        mc = _make_mock_client(cloud=True)
+        acct = "557058:d5765ebc-27de-4ce3-b520-a77a87e5e99a"
+        result, _ = _run(["add", "TEST-1", "--user", acct], mc)
+        assert result.exit_code == 0, result.output
+        mc.user_find_by_user_string.assert_not_called()
+        mc.issue_add_watcher.assert_called_once_with("TEST-1", acct)
+
+    def test_add_json_output(self):
+        mc = _make_mock_client()
+        mc.myself.return_value = {"name": "bwilson"}
+        result, _ = _run(["--json", "add", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data == {"key": "TEST-1", "user": "bwilson", "added": True}
+
+    def test_add_quiet_output(self):
+        mc = _make_mock_client()
+        mc.myself.return_value = {"name": "bwilson"}
+        result, _ = _run(["--quiet", "add", "TEST-1"], mc)
+        assert result.exit_code == 0
+        assert result.output.strip() == "ok"

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -201,3 +201,25 @@ class TestWatchersAdd:
         result, _ = _run(["--quiet", "add", "TEST-1"], mc)
         assert result.exit_code == 0
         assert result.output.strip() == "ok"
+
+    def test_add_self_is_idempotent(self):
+        """Jira returns 204 for duplicate self-adds; script treats as success."""
+        mc = _make_mock_client()
+        mc.myself.return_value = {"name": "bwilson"}
+        # Simulate a second add — library returns None either way, no special
+        # handling needed. The test exists to pin the contract.
+        mc.issue_add_watcher.return_value = None
+        result, _ = _run(["add", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "Added watcher" in result.output
+
+    def test_add_manage_watchers_permission_error(self):
+        mc = _make_mock_client()
+        mc.user_find_by_user_string.return_value = [{"name": "asmith"}]
+        mc.issue_add_watcher.side_effect = Exception(
+            "403 Client Error: Forbidden — Manage Watchers permission required"
+        )
+        result, _ = _run(["add", "TEST-1", "--user", "asmith"], mc)
+        assert result.exit_code == 1
+        assert "Failed to add watcher" in result.output
+        assert "403" in result.output or "Forbidden" in result.output

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -92,3 +92,13 @@ class TestWatchersList:
         assert "asmith" in result.output
         assert "Alice Smith" in result.output
         mc.issue_get_watchers.assert_called_once_with("TEST-1")
+
+    def test_list_empty(self):
+        mc = _make_mock_client()
+        mc.issue_get_watchers.return_value = {
+            "watchCount": 0, "isWatching": False, "watchers": [],
+        }
+        result, _ = _run(["list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "(no watchers)" in result.output
+        assert "TEST-1" in result.output

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -144,6 +144,30 @@ class TestWatchersList:
         lines = [ln for ln in result.output.splitlines() if ln.strip()]
         assert lines == ["jdoe", "asmith"]
 
+    def test_list_text_shows_is_watching_when_true(self):
+        """Top-level isWatching=True surfaces in the header so callers see
+        their own subscription state without a second API call."""
+        mc = _make_mock_client()
+        mc.issue_get_watchers.return_value = {
+            "watchCount": 1,
+            "isWatching": True,
+            "watchers": [_watcher("bwilson", "Bob Wilson")],
+        }
+        result, _ = _run(["list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "you are watching" in result.output.lower()
+
+    def test_list_text_shows_not_watching_when_false(self):
+        mc = _make_mock_client()
+        mc.issue_get_watchers.return_value = {
+            "watchCount": 1,
+            "isWatching": False,
+            "watchers": [_watcher("jdoe", "John Doe")],
+        }
+        result, _ = _run(["list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "not watching" in result.output.lower()
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Tests: add subcommand

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -223,3 +223,55 @@ class TestWatchersAdd:
         assert result.exit_code == 1
         assert "Failed to add watcher" in result.output
         assert "403" in result.output or "Forbidden" in result.output
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: remove subcommand
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWatchersRemove:
+    def test_remove_self_default_dc(self):
+        mc = _make_mock_client(cloud=False)
+        mc.myself.return_value = {"name": "bwilson"}
+        result, _ = _run(["remove", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "Removed watcher" in result.output
+        assert "bwilson" in result.output
+        assert "(you)" in result.output
+        mc.issue_delete_watcher.assert_called_once_with("TEST-1", username="bwilson")
+
+    def test_remove_user_by_username_dc(self):
+        mc = _make_mock_client(cloud=False)
+        mc.user_find_by_user_string.return_value = [{"name": "asmith"}]
+        result, _ = _run(["remove", "TEST-1", "--user", "asmith"], mc)
+        assert result.exit_code == 0, result.output
+        assert "(you)" not in result.output
+        mc.issue_delete_watcher.assert_called_once_with("TEST-1", username="asmith")
+
+    def test_remove_dry_run_does_not_call_api(self):
+        mc = _make_mock_client()
+        mc.myself.return_value = {"name": "bwilson"}
+        result, _ = _run(["remove", "TEST-1", "--dry-run"], mc)
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        assert "Would remove" in result.output
+        assert "bwilson" in result.output
+        mc.issue_delete_watcher.assert_not_called()
+
+    def test_remove_json_output(self):
+        mc = _make_mock_client(cloud=False)
+        mc.myself.return_value = {"name": "bwilson"}
+        result, _ = _run(["--json", "remove", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data == {"key": "TEST-1", "user": "bwilson", "removed": True}
+
+    def test_remove_non_watcher_surfaces_error(self):
+        mc = _make_mock_client(cloud=False)
+        mc.myself.return_value = {"name": "bwilson"}
+        mc.issue_delete_watcher.side_effect = Exception("404 Not Found")
+        result, _ = _run(["remove", "TEST-1"], mc)
+        assert result.exit_code == 1
+        assert "Failed to remove watcher" in result.output
+        assert "404" in result.output

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -58,3 +58,37 @@ class TestWatchersHelp:
         assert "list" in result.output
         assert "add" in result.output
         assert "remove" in result.output
+
+
+def _watcher(name="jdoe", display="John Doe", account_id=None):
+    """Build a watcher dict matching the Jira API shape."""
+    w = {"name": name, "displayName": display, "active": True}
+    if account_id is not None:
+        w["accountId"] = account_id
+    return w
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: list subcommand
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWatchersList:
+    def test_list_text_output(self):
+        mc = _make_mock_client()
+        mc.issue_get_watchers.return_value = {
+            "watchCount": 2,
+            "isWatching": False,
+            "watchers": [
+                _watcher("jdoe", "John Doe"),
+                _watcher("asmith", "Alice Smith"),
+            ],
+        }
+        result, _ = _run(["list", "TEST-1"], mc)
+        assert result.exit_code == 0, result.output
+        assert "TEST-1" in result.output
+        assert "jdoe" in result.output
+        assert "John Doe" in result.output
+        assert "asmith" in result.output
+        assert "Alice Smith" in result.output
+        mc.issue_get_watchers.assert_called_once_with("TEST-1")

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 import click.testing
+import requests
 
 # Add scripts to path for lib imports
 _test_dir = Path(__file__).parent
@@ -237,10 +238,16 @@ class TestWatchersAdd:
         assert "Added watcher" in result.output
 
     def test_add_manage_watchers_permission_error(self):
+        """atlassian-python-api raises requests.HTTPError on 403; exercise
+        that concrete shape rather than a bare Exception."""
         mc = _make_mock_client()
         mc.user_find_by_user_string.return_value = [{"name": "asmith"}]
-        mc.issue_add_watcher.side_effect = Exception(
-            "403 Client Error: Forbidden — Manage Watchers permission required"
+        resp = requests.Response()
+        resp.status_code = 403
+        resp.reason = "Forbidden"
+        mc.issue_add_watcher.side_effect = requests.exceptions.HTTPError(
+            "403 Client Error: Forbidden for url: /rest/api/2/issue/TEST-1/watchers",
+            response=resp,
         )
         result, _ = _run(["add", "TEST-1", "--user", "asmith"], mc)
         assert result.exit_code == 1
@@ -291,9 +298,17 @@ class TestWatchersRemove:
         assert data == {"key": "TEST-1", "user": "bwilson", "removed": True}
 
     def test_remove_non_watcher_surfaces_error(self):
+        """Removing a user who is not watching returns 404; surface it as a
+        requests.HTTPError, not a silent success."""
         mc = _make_mock_client(cloud=False)
         mc.myself.return_value = {"name": "bwilson"}
-        mc.issue_delete_watcher.side_effect = Exception("404 Not Found")
+        resp = requests.Response()
+        resp.status_code = 404
+        resp.reason = "Not Found"
+        mc.issue_delete_watcher.side_effect = requests.exceptions.HTTPError(
+            "404 Client Error: Not Found for url: /rest/api/2/issue/TEST-1/watchers",
+            response=resp,
+        )
         result, _ = _run(["remove", "TEST-1"], mc)
         assert result.exit_code == 1
         assert "Failed to remove watcher" in result.output

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -100,8 +100,9 @@ class TestWatchersList:
         }
         result, _ = _run(["list", "TEST-1"], mc)
         assert result.exit_code == 0, result.output
-        assert "(no watchers)" in result.output
-        assert "TEST-1" in result.output
+        # Design doc (2026-04-20-watchers-design.md, "list" section): empty
+        # list renders as "No watchers for {key}".
+        assert "No watchers for TEST-1" in result.output
 
     def test_list_json_output(self):
         mc = _make_mock_client()

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -96,7 +96,9 @@ class TestWatchersList:
     def test_list_empty(self):
         mc = _make_mock_client()
         mc.issue_get_watchers.return_value = {
-            "watchCount": 0, "isWatching": False, "watchers": [],
+            "watchCount": 0,
+            "isWatching": False,
+            "watchers": [],
         }
         result, _ = _run(["list", "TEST-1"], mc)
         assert result.exit_code == 0, result.output
@@ -194,9 +196,7 @@ class TestWatchersAdd:
 
     def test_add_user_by_username_dc(self):
         mc = _make_mock_client(cloud=False)
-        mc.user_find_by_user_string.return_value = [
-            {"name": "asmith", "displayName": "Alice Smith"}
-        ]
+        mc.user_find_by_user_string.return_value = [{"name": "asmith", "displayName": "Alice Smith"}]
         result, _ = _run(["add", "TEST-1", "--user", "asmith"], mc)
         assert result.exit_code == 0, result.output
         assert "asmith" in result.output

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -275,3 +275,28 @@ class TestWatchersRemove:
         assert result.exit_code == 1
         assert "Failed to remove watcher" in result.output
         assert "404" in result.output
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: _watcher_api_arg helper (pure)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWatcherApiArg:
+    def test_dc_username(self):
+        mc = _make_mock_client(cloud=False)
+        assert _watchers_mod._watcher_api_arg(mc, "jdoe", False) == {"username": "jdoe"}
+
+    def test_cloud_account_id(self):
+        mc = _make_mock_client(cloud=True)
+        acct = "557058:d5765ebc-27de-4ce3-b520-a77a87e5e99a"
+        assert _watchers_mod._watcher_api_arg(mc, acct, True) == {"account_id": acct}
+
+
+class TestWatchersRemoveCloud:
+    def test_remove_cloud_passes_account_id(self):
+        mc = _make_mock_client(cloud=True)
+        acct = "557058:d5765ebc-27de-4ce3-b520-a77a87e5e99a"
+        result, _ = _run(["remove", "TEST-1", "--user", acct], mc)
+        assert result.exit_code == 0, result.output
+        mc.issue_delete_watcher.assert_called_once_with("TEST-1", account_id=acct)


### PR DESCRIPTION
## Summary

Adds `jira-watchers.py` — a new utility script that lists, adds, and removes watchers on a Jira issue. First feature to land on top of the progressive-disclosure refactor (#76), so it also demonstrates the pattern: one-line additions to `SKILL.md` + a dedicated `references/watchers.md` loaded on demand.

## Changes

- **Script**: `skills/jira-communication/scripts/utility/jira-watchers.py`
  - `list ISSUE_KEY` — list watchers with key/name/displayName, surfaces `isWatching` flag in the header
  - `add ISSUE_KEY [--user me|USER]` — self-watch by default; `me` resolves via `client.myself()`
  - `remove ISSUE_KEY [--user me|USER] [--dry-run]` — same `me` resolution; pins DC (`username`) vs Cloud (`accountId`) keyword mapping
  - Consistent with peer scripts (`LazyJiraClient`, `lib.output`, PEP 723 deps, `--json` / `--quiet` / default output modes)
- **Reference**: `skills/jira-communication/references/watchers.md` — `## When to load` header + commands + gotchas (raw-JSON-string body on add, DC vs Cloud identity, 204 on success, idempotent self-watch, no bulk endpoint)
- **SKILL.md**: one-line entry in `## Scripts` (Utility) and one-line cue in `## References`
- **Evals**: 3 new reference-load probes (list/add/remove variants) at IDs 19-21
- **Tests**: `tests/test_watchers.py` covers DC vs Cloud delete params, 403/404 error shapes, `--dry-run` paths, CLI smoke

Design + plan docs: `docs/plans/2026-04-20-watchers-design.md`, `docs/plans/2026-04-20-watchers-plan.md`.

## Test plan

- [x] `pytest tests/` — 412 pass
- [x] `ruff check skills/ tests/` — clean
- [x] `ruff format --check skills/ tests/` — clean (36 files)
- [x] `bandit -r skills/jira-communication/scripts/ scripts/ -c pyproject.toml --severity-level medium` — 0 findings
- [x] `bash scripts/verify-harness.sh --status` — Level 3 (Enforced) COMPLETE
- [x] `skill-repo validate-skill.sh` — SKILL.md 410 words (under 500 gate)

## Follow-ups

- Eval probe IDs 19-21 collide with the versions PR. First to merge keeps the IDs; the second will need to renumber to 22-24 in a small fix-up commit.