### PR TITLE
fix(jira-communication): port 5 upstream fixes from tgreat1 fork

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -2,12 +2,12 @@
 name: jira-communication
 description: "Use when interacting with Jira issues - searching, creating, updating, moving, transitioning, commenting, logging work, downloading attachments, managing sprints, boards, issue links, web links, fields, or users. Auto-triggers on Jira URLs and issue keys (PROJ-123). Also use when MCP Atlassian tools fail or are unavailable for Jira Server/DC."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
-compatibility: "Requires python 3.10+, uv, curl. Jira Server/DC or Cloud instance with API access."
+compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
   version: "3.12.0"
   repository: https://github.com/netresearch/jira-skill
-allowed-tools: Bash(python:*) Bash(uv:*) Bash(curl:*) Read Write
+allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---
 
 # Jira Communication

--- a/skills/jira-communication/scripts/core/jira-search.py
+++ b/skills/jira-communication/scripts/core/jira-search.py
@@ -51,9 +51,10 @@ def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str 
 @click.argument("jql")
 @click.option("--max-results", "-n", default=50, help="Maximum results to return")
 @click.option("--fields", "-f", default="key,summary,status,assignee,priority", help="Comma-separated fields to return")
+@click.option("--start-at", default=0, type=int, help="Starting index for pagination (0-based)")
 @click.option("--truncate", type=int, metavar="N", help="Truncate field values to N characters")
 @click.pass_context
-def query(ctx, jql: str, max_results: int, fields: str, truncate: int | None):
+def query(ctx, jql: str, max_results: int, fields: str, start_at: int, truncate: int | None):
     """Search issues using JQL.
 
     JQL: Jira Query Language query string (passed directly to Jira API — treat as trusted input)
@@ -85,7 +86,7 @@ def query(ctx, jql: str, max_results: int, fields: str, truncate: int | None):
         field_list = [f.strip() for f in fields.split(",")]
 
         # Execute search
-        results = client.jql(jql, limit=max_results, fields=field_list)
+        results = client.jql(jql, limit=max_results, start=start_at, fields=field_list)
         issues = results.get("issues", [])
 
         if ctx.obj["json"]:
@@ -99,7 +100,8 @@ def query(ctx, jql: str, max_results: int, fields: str, truncate: int | None):
                 print("No issues found")
             else:
                 _print_results_table(issues, field_list, truncate=truncate)
-                print(f"\n({len(issues)} issue{'s' if len(issues) != 1 else ''} found)")
+                total = results.get("total", len(issues))
+                print(f"\n(showing {start_at + 1}-{start_at + len(issues)} of {total} issues)")
 
     except Exception as e:
         if ctx.obj["debug"]:

--- a/skills/jira-communication/scripts/core/jira-search.py
+++ b/skills/jira-communication/scripts/core/jira-search.py
@@ -51,7 +51,12 @@ def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str 
 @click.argument("jql")
 @click.option("--max-results", "-n", default=50, help="Maximum results to return")
 @click.option("--fields", "-f", default="key,summary,status,assignee,priority", help="Comma-separated fields to return")
-@click.option("--start-at", default=0, type=int, help="Starting index for pagination (0-based)")
+@click.option(
+    "--start-at",
+    default=0,
+    type=click.IntRange(min=0),
+    help="Starting index for pagination (0-based)",
+)
 @click.option("--truncate", type=int, metavar="N", help="Truncate field values to N characters")
 @click.pass_context
 def query(ctx, jql: str, max_results: int, fields: str, start_at: int, truncate: int | None):
@@ -96,12 +101,18 @@ def query(ctx, jql: str, max_results: int, fields: str, start_at: int, truncate:
                 print(issue["key"])
         else:
             # Table output
+            total = results.get("total")
+            if total is None:
+                total = len(issues)
             if not issues:
-                print("No issues found")
+                if total > 0:
+                    print(f"No issues on this page (total: {total}). Try a smaller --start-at.")
+                else:
+                    print("No issues found")
             else:
                 _print_results_table(issues, field_list, truncate=truncate)
-                total = results.get("total", len(issues))
-                print(f"\n(showing {start_at + 1}-{start_at + len(issues)} of {total} issues)")
+                issue_label = "issue" if total == 1 else "issues"
+                print(f"\n(showing {start_at + 1}-{start_at + len(issues)} of {total} {issue_label})")
 
     except Exception as e:
         if ctx.obj["debug"]:

--- a/skills/jira-communication/scripts/core/jira-validate.py
+++ b/skills/jira-communication/scripts/core/jira-validate.py
@@ -98,12 +98,13 @@ def check_environment(env_file: str | None, profile: str | None = None, verbose:
                 error(f"Configuration error: {err}")
             return None
 
+        if env_file and profile:
+            warning("--profile is ignored because --env-file was provided")
+
         if verbose:
             if env_file:
                 path = Path(env_file)
                 success(f"Environment file: {path}")
-                if profile:
-                    warning("--profile is ignored because --env-file was provided")
             elif profile:
                 success(f"Profile: {profile} (from {PROFILES_FILE})")
             else:

--- a/skills/jira-communication/scripts/core/jira-validate.py
+++ b/skills/jira-communication/scripts/core/jira-validate.py
@@ -26,7 +26,7 @@ import json as json_module
 
 import click
 import requests
-from lib.client import _sanitize_error, get_jira_client
+from lib.client import LazyJiraClient, _sanitize_error
 from lib.config import (
     DEFAULT_ENV_FILE,
     PROFILES_FILE,
@@ -162,7 +162,7 @@ def check_connectivity(
 
     # Test authentication
     try:
-        client = get_jira_client(env_file=env_file, profile=profile)
+        client = LazyJiraClient(env_file=env_file, profile=profile)
         user = client.myself()
         display_name = user.get("displayName", user.get("name", "Unknown"))
         email = user.get("emailAddress", "N/A")

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -199,7 +199,10 @@ def do_transition(ctx, issue_key: str, status_name: str, comment: str | None, re
             success(f"Transitioned {issue_key}")
             print(f"  Status: {_get_to_status(matching)}")
             if comment:
-                print(f"  Comment added: {comment[:50]}...")
+                if len(comment) > 50:
+                    print(f"  Comment added: {comment[:50]}...")
+                else:
+                    print(f"  Comment added: {comment}")
 
     except Exception as e:
         if ctx.obj["debug"]:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -262,6 +262,48 @@ class TestMockedCommands:
         # Verify the pagination range is rendered in the output
         assert "showing 51-52 of 234" in result.output
 
+    def test_search_query_start_at_rejects_negative(self):
+        """jira-search --start-at must reject negative values via click.IntRange."""
+        mock_client = self._make_mock_client()
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _search_mod.cli,
+                ["query", "project=A", "--start-at", "-1"],
+            )
+        assert result.exit_code != 0
+        # click.IntRange rejection happens before the API is hit
+        mock_client.jql.assert_not_called()
+
+    def test_search_query_singular_pluralization(self):
+        """jira-search must say '1 issue' (singular) when total == 1."""
+        mock_client = self._make_mock_client()
+        mock_client.jql.return_value = {
+            "issues": [{"key": "A-1", "fields": {"summary": "only"}}],
+            "total": 1,
+        }
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_search_mod.cli, ["query", "project=A"])
+        assert result.exit_code == 0, result.output
+        assert "of 1 issue)" in result.output
+        assert "of 1 issues)" not in result.output
+
+    def test_search_query_empty_page_shows_total(self):
+        """Empty issues + total > 0 must hint about --start-at, not 'No issues found'."""
+        mock_client = self._make_mock_client()
+        mock_client.jql.return_value = {"issues": [], "total": 234}
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _search_mod.cli,
+                ["query", "project=A", "--start-at", "500"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "No issues on this page" in result.output
+        assert "total: 234" in result.output
+        assert "--start-at" in result.output
+
     def test_create_issue_dry_run(self):
         """jira-create issue with --dry-run must not call API."""
         mock_client = self._make_mock_client()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -240,6 +240,28 @@ class TestMockedCommands:
         assert "A-1" in result.output
         assert "A-2" in result.output
 
+    def test_search_query_start_at_forwarded(self):
+        """jira-search --start-at must be forwarded to client.jql(start=...)."""
+        mock_client = self._make_mock_client()
+        mock_client.jql.return_value = {
+            "issues": [{"key": "A-51"}, {"key": "A-52"}],
+            "total": 234,
+        }
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _search_mod.cli,
+                ["query", "project=A", "--start-at", "50", "--max-results", "50"],
+            )
+        assert result.exit_code == 0, result.output
+        # Verify the pagination kwarg was forwarded to jql()
+        mock_client.jql.assert_called_once()
+        _, kwargs = mock_client.jql.call_args
+        assert kwargs.get("start") == 50
+        assert kwargs.get("limit") == 50
+        # Verify the pagination range is rendered in the output
+        assert "showing 51-52 of 234" in result.output
+
     def test_create_issue_dry_run(self):
         """jira-create issue with --dry-run must not call API."""
         mock_client = self._make_mock_client()


### PR DESCRIPTION
## Summary

Ports five small upstream fixes for the `jira-communication` skill from
[`tgreat1/jira-skill`](https://github.com/tgreat1/jira-skill) into a single
thematic PR, plus an extra test to lock in the new pagination behavior.

Fork attribution preserved via `git cherry-pick -x` trailers
(`(cherry picked from commit <SHA>)` on every commit).

## Fixes (in apply order)

1. **`fix(jira-communication): fix hardcoded comment truncation in jira-transition`**
   - File: `skills/jira-communication/scripts/workflow/jira-transition.py:202`
   - Removes the unconditional `[:50]...` ellipsis on short comments.
   - Upstream: [`7da5874`](https://github.com/tgreat1/jira-skill/commit/7da58740c7908b26bcce4df769834dfabaa19d6f)
   - Local SHA: `c68aea5`

2. **`fix(jira-communication): always show --profile ignored warning in jira-validate`**
   - File: `skills/jira-communication/scripts/core/jira-validate.py` (~line 101)
   - Hoists the `--profile is ignored…` warning out of `if verbose:` so it always shows when both `--env-file` and `--profile` are passed.
   - Upstream: [`fb0cda0`](https://github.com/tgreat1/jira-skill/commit/fb0cda02a6218a415710b898f5228f136fafa75e)
   - Local SHA: `f7a40f3`

3. **`fix(jira-communication): use LazyJiraClient in jira-validate check_connectivity`**
   - File: `skills/jira-communication/scripts/core/jira-validate.py` (~line 164)
   - Replaces a direct `get_jira_client(...)` call with `LazyJiraClient(...)` for consistency with the rest of the file.
   - Upstream: [`fb87f31`](https://github.com/tgreat1/jira-skill/commit/fb87f31eabfdba98be0f18829a6613e0e2760f31)
   - Local SHA: `c0b9e50`

4. **`fix(jira-communication): add --start-at pagination to jira-search.py`**
   - File: `skills/jira-communication/scripts/core/jira-search.py`
   - Adds `--start-at` flag (default `0`), forwards it to `client.jql(start=…)`, and renders `showing N-M of K issues` in the human-readable output.
   - Upstream: [`71c8b97`](https://github.com/tgreat1/jira-skill/commit/71c8b9739de62728643daeb9c7ef4f31970706ef)
   - Local SHA: `27afbb7`

5. **`fix(jira-communication): remove curl from SKILL.md dependencies`**
   - File: `skills/jira-communication/SKILL.md`
   - Drops `curl` from the compatibility line and `allowed-tools`. No script uses `curl` (all HTTP goes through `requests`).
   - No version bump (releases are tag-driven per root AGENTS.md).
   - Upstream: [`2795338`](https://github.com/tgreat1/jira-skill/commit/27953382cdddcf5f650f3a046aa60aebc431c3e6)
   - Local SHA: `c3eebe3`

## Extra tests (not in fork)

- **`test(search): cover --start-at forwarding in CLI smoke`** (local SHA `7b823c8`)
  - Adds `TestMockedCommands::test_search_query_start_at_forwarded` — asserts `--start-at 50 --max-results 50` is forwarded as `client.jql(start=50, limit=50, …)` and the output contains `showing 51-52 of 234`.
- **`fix(jira-communication): harden jira-search pagination output and validation`** (local SHA `5554b66`, round-2 review fixes) adds three more tests to `tests/test_cli_smoke.py`:
  - `test_search_query_start_at_rejects_negative` — `click.IntRange(min=0)` rejects `--start-at -1`.
  - `test_search_query_singular_pluralization` — `total=1` prints `1 issue` (not `1 issues`).
  - `test_search_query_empty_page_shows_total` — empty `issues[]` with non-zero `total` prints `No issues on this page (total: N). Try a smaller --start-at.` instead of the misleading `No issues found`.

## 5-gate status

| Gate | Result |
|------|--------|
| `pytest tests/ -q` | 511 passed |
| `ruff check .` | All checks passed |
| `ruff format --check .` | 39 files already formatted |
| `bandit -r skills/jira-communication/scripts/ scripts/ -c pyproject.toml --severity-level medium` | 0 issues (medium+) |
| `bash scripts/verify-harness.sh --format=text --status` | Level 3 (Enforced) — COMPLETE (10/10) |

`SKILL.md` word count after change: **423** (well under the 500 limit).

## Test plan

- [x] All 5 gates green locally
- [x] All 4 new tests pass in isolation
- [x] `uv run skills/jira-communication/scripts/core/jira-validate.py --help` still loads (pre-commit smoke check from root AGENTS.md)
- [x] CI green on PR

