### PR TITLE
fix(worklog): extract ADF text from worklog comments in list command

### DIFF
--- a/skills/jira-communication/scripts/core/jira-worklog.py
+++ b/skills/jira-communication/scripts/core/jira-worklog.py
@@ -24,7 +24,7 @@ import re
 
 import click
 from lib.client import LazyJiraClient
-from lib.output import error, extract_adf_text, format_output, success
+from lib.output import comment_to_text, error, format_output, success
 
 
 def normalize_iso_timestamp(timestamp: str) -> str:
@@ -196,9 +196,7 @@ def list_worklogs(ctx, issue_key: str, limit: int, truncate: int | None):
                     author = wl.get("author", {}).get("displayName", "Unknown")
                     time_spent = wl.get("timeSpent", "N/A")
                     started = wl.get("started", "N/A")[:10] if wl.get("started") else "N/A"
-                    comment = wl.get("comment", "")
-                    if isinstance(comment, dict):
-                        comment = extract_adf_text(comment)
+                    comment = comment_to_text(wl.get("comment"))
 
                     print(f"  [{started}] {author}: {time_spent}")
                     if comment:

--- a/skills/jira-communication/scripts/core/jira-worklog.py
+++ b/skills/jira-communication/scripts/core/jira-worklog.py
@@ -24,7 +24,7 @@ import re
 
 import click
 from lib.client import LazyJiraClient
-from lib.output import error, format_output, success
+from lib.output import error, extract_adf_text, format_output, success
 
 
 def normalize_iso_timestamp(timestamp: str) -> str:
@@ -197,6 +197,8 @@ def list_worklogs(ctx, issue_key: str, limit: int, truncate: int | None):
                     time_spent = wl.get("timeSpent", "N/A")
                     started = wl.get("started", "N/A")[:10] if wl.get("started") else "N/A"
                     comment = wl.get("comment", "")
+                    if isinstance(comment, dict):
+                        comment = extract_adf_text(comment)
 
                     print(f"  [{started}] {author}: {time_spent}")
                     if comment:

--- a/skills/jira-communication/scripts/lib/output.py
+++ b/skills/jira-communication/scripts/lib/output.py
@@ -219,4 +219,22 @@ def _extract_text_recursive(node) -> list:
     return parts
 
 
+def comment_to_text(comment) -> str:
+    """Normalize a Jira comment field to plain text.
+
+    Comments come in three shapes:
+      - None / missing on the issue → empty string
+      - Server/DC: plain string (already plain text)
+      - Cloud: ADF dictionary → extracted via extract_adf_text()
+
+    Used by callers that render worklog/issue comments for terminal output,
+    where a raw ADF dict would print as ``{'type': 'doc', ...}``.
+    """
+    if comment is None:
+        return ""
+    if isinstance(comment, dict):
+        return extract_adf_text(comment) or ""
+    return str(comment)
+
+
 # === INLINE_END: output ===

--- a/skills/jira-communication/scripts/utility/jira-worklog-query.py
+++ b/skills/jira-communication/scripts/utility/jira-worklog-query.py
@@ -23,7 +23,7 @@ from datetime import date, timedelta
 
 import click
 from lib.client import LazyJiraClient
-from lib.output import error, format_json, warning
+from lib.output import comment_to_text, error, format_json, warning
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Query building
@@ -167,12 +167,7 @@ def format_detail(worklogs: list[dict]) -> str:
         if len(author) > 20:
             author = author[:17] + "..."
         time_str = seconds_to_human(wl.get("timeSpentSeconds", 0))
-        comment = wl.get("comment", "")
-        if isinstance(comment, dict):
-            # ADF format — extract text
-            from lib.output import extract_adf_text
-
-            comment = extract_adf_text(comment)
+        comment = comment_to_text(wl.get("comment"))
         if len(comment) > 50:
             comment = comment[:47] + "..."
         lines.append(f"{key:<14} {date_str:<12} {author:<20} {time_str:>8} {comment}")

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -611,3 +611,61 @@ class TestMockedCommands:
         assert payload["key"] == "TEST-1"
         assert payload["current_status"] == "Open"
         assert "Open" in payload["time_in_status"]
+
+    def test_worklog_list_renders_adf_comment(self):
+        """jira-worklog list must render extracted text from ADF comments (Cloud), not the raw dict."""
+        adf_comment = {
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "Implemented retry logic"}]}
+            ],
+        }
+        mock_client = self._make_mock_client()
+        mock_client.issue_get_worklog.return_value = {
+            "worklogs": [
+                {
+                    "id": "1",
+                    "author": {"displayName": "Alice"},
+                    "timeSpent": "2h",
+                    "started": "2026-04-30T08:00:00.000+0000",
+                    "comment": adf_comment,
+                }
+            ]
+        }
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_worklog_mod.cli, ["list", "TEST-1"])
+        assert result.exit_code == 0, result.output
+        assert "Implemented retry logic" in result.output
+        # Regression guard: a raw ADF dict would render as repr() starting with "{'type'"
+        assert "{'type'" not in result.output
+
+    def test_worklog_list_truncate_does_not_raise_on_adf(self):
+        """--truncate must not raise TypeError when comment is an ADF dict (Cloud regression)."""
+        adf_comment = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "A long worklog comment that exceeds twenty characters"}],
+                }
+            ],
+        }
+        mock_client = self._make_mock_client()
+        mock_client.issue_get_worklog.return_value = {
+            "worklogs": [
+                {
+                    "id": "1",
+                    "author": {"displayName": "Alice"},
+                    "timeSpent": "1h",
+                    "started": "2026-04-30T08:00:00.000+0000",
+                    "comment": adf_comment,
+                }
+            ]
+        }
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_worklog_mod.cli, ["list", "TEST-1", "--truncate", "20"])
+        # Pre-fix this raised TypeError ("unhashable type: 'slice'"-style on dict slicing).
+        assert result.exit_code == 0, result.output
+        assert "..." in result.output

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,4 +1,4 @@
-"""Tests for output.py — extract_adf_text() function."""
+"""Tests for output.py — extract_adf_text() and comment_to_text() helpers."""
 
 import sys
 from pathlib import Path
@@ -8,7 +8,7 @@ _test_dir = Path(__file__).parent
 _scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
 sys.path.insert(0, str(_scripts_path))
 
-from lib.output import compact_json, extract_adf_text
+from lib.output import comment_to_text, compact_json, extract_adf_text
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Tests: extract_adf_text()
@@ -196,3 +196,45 @@ class TestCompactJson:
         assert compact_json("hello") == "hello"
         assert compact_json(42) == 42
         assert compact_json(None) is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: comment_to_text()
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCommentToText:
+    """comment_to_text() must normalize Server-string and Cloud-ADF comments to plain text."""
+
+    def test_none_returns_empty(self):
+        assert comment_to_text(None) == ""
+
+    def test_missing_field_returns_empty(self):
+        # Typical caller: comment_to_text(wl.get("comment")) where the key is absent
+        assert comment_to_text({}.get("comment")) == ""
+
+    def test_empty_string(self):
+        assert comment_to_text("") == ""
+
+    def test_plain_string_passthrough(self):
+        # Server/DC: comment is already a plain string
+        assert comment_to_text("Worked on bugfix") == "Worked on bugfix"
+
+    def test_adf_dict_extracted(self):
+        # Cloud: comment is an ADF document
+        adf = {
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Hello world"}]}],
+        }
+        assert comment_to_text(adf) == "Hello world"
+
+    def test_empty_adf_returns_empty(self):
+        adf = {"type": "doc", "content": []}
+        assert comment_to_text(adf) == ""
+
+    def test_adf_dict_never_returns_repr(self):
+        # Regression guard for the original bug: a raw dict.__repr__ would start with "{'type'..."
+        adf = {"type": "doc", "content": [{"type": "text", "text": "real text"}]}
+        result = comment_to_text(adf)
+        assert "{'type'" not in result
+        assert "real text" in result


### PR DESCRIPTION
## Summary

Fixes worklog comment rendering for Jira Cloud ADF comments.

'jira-worklog.py' list now converts dict-based ADF comments with the existing `extract_adf_text` helper before truncation/rendering. This prevents raw ADF dictionaries from being printed in the user facing output and avoids truncation errors on dict comments.

Closes #87 

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring / code quality
- [ ] CI / build / dependencies

## Checklist

- [ ] Commits are signed (`-S`) and signed-off (`--signoff`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Tests added/updated for changed behavior
- [ ] Documentation updated (README, AGENTS.md, CHANGELOG, or inline docs)
- [ ] CI passes (lint, tests, static analysis)

## Test Plan

Ran:

```bash
uv run skills/jira-communication/scripts/core/jira-worklog.py --help
```
Verified the command displays help successfully.

Also verified that ADF dict comments are converted before the existing truncation/rendering logic.