### PR TITLE
chore(release): drop deprecated `with:` block and `workflow_dispatch.bump`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,22 +4,10 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: 'Version bump type'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
 
 jobs:
   release:
     uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main
-    with:
-      bump: ${{ inputs.bump }}
     permissions:
       contents: write          # release upload
       id-token: write          # OIDC for sigstore (required by the attest job)


### PR DESCRIPTION
## Summary

Drops the now-deprecated bits from this caller's release workflow:

- The `workflow_dispatch:` trigger and its `bump` input. The upstream reusable workflow's `bump` input has been documented `DEPRECATED — ignored` since the auto-bump job was removed; clicking "Run workflow" in the GitHub UI was a no-op.
- The `with:` block (`bump:` only, or `bump:` + `attest:` for matrix-skill). `attest` was deprecated in [netresearch/skill-repo-skill#79](https://github.com/netresearch/skill-repo-skill/pull/79) when SLSA build provenance flipped from opt-in to always-on; `bump` has been deprecated for longer.
- Stale comments on the `id-token`/`attestations` permission lines that referenced the old "when attest: true" phrasing.

```diff
 on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: 'Version bump type'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major

 jobs:
   release:
     uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main
-    with:
-      bump: ${{ inputs.bump }}
     permissions:
       contents: write          # release upload
-      id-token: write          # OIDC for sigstore (required when attest: true)
-      attestations: write      # GitHub native attestation API (required when attest: true)
+      id-token: write          # OIDC for sigstore (required by the attest job)
+      attestations: write      # GitHub native attestation API (required by the attest job)
```

## Behaviour change

**None.** Releases still trigger on signed tag-push and produce SLSA-attested archives. The `workflow_dispatch` UI button did nothing functional already; this just removes the dead button.

## Test plan

- [ ] CI green on this PR
- [ ] Next release of this repo continues to publish to the GitHub releases page with SLSA attestation, verifiable via `gh attestation verify <archive>.zip --owner netresearch`