### PR TITLE
chore: release v3.13.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -560,7 +560,11 @@ First stable release providing comprehensive Jira integration through Claude Cod
 - [Claude Code Marketplace](https://github.com/netresearch/claude-code-marketplace)
 - [Jira Wiki Markup Reference](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
 
-[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.10.1...HEAD
+[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.13.1...HEAD
+[3.13.1]: https://github.com/netresearch/jira-skill/compare/v3.13.0...v3.13.1
+[3.13.0]: https://github.com/netresearch/jira-skill/compare/v3.12.0...v3.13.0
+[3.12.0]: https://github.com/netresearch/jira-skill/compare/v3.11.0...v3.12.0
+[3.11.0]: https://github.com/netresearch/jira-skill/compare/v3.10.1...v3.11.0
 [3.10.1]: https://github.com/netresearch/jira-skill/compare/v3.10.0...v3.10.1
 [3.10.0]: https://github.com/netresearch/jira-skill/compare/v3.9.0...v3.10.0
 [3.9.0]: https://github.com/netresearch/jira-skill/compare/v3.8.0...v3.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.13.1] - 2026-04-30
+
+### Added
+
+- `jira-syntax`: validator now flags `{code:LANG}` whose `LANG` is not in the Jira Server source-code formatter set, mirroring the server-side error and pointing at `{code:none}`. Quick reference replaces the vague "many more — check Jira documentation" line with the authoritative formatter list grouped by category, calls out the literal `c#`/`c++` form, and lists common identifiers that look valid but are not (typescript, rust, shell, yml, typoscript). ([#94](https://github.com/netresearch/jira-skill/pull/94))
+
+### Fixed
+
+- `jira-syntax` validator: switch ERRORS/WARNINGS counters to pre-increment so `(( ))` returns the new (non-zero) value — the post-increment form returned 0 on first call and tripped `set -e`, aborting the script before the summary printed and making warning-only runs exit with code 1.
+- `jira-syntax` validator: treat `{code:language}` as a placeholder warning rather than a hard error so the bundled templates (which intentionally ship the literal word "language" as a fill-in) still run cleanly.
+- `jira-syntax` validator: use Bash built-in `[[ ]]` pattern matching for the `{code:LANG}` membership test — avoids spawning `printf`+`grep` per unique language and keeps shell-significant identifiers (`c#`, `c++`) literal.
+- `jira-syntax` quick reference: backtick the `<name>` token in the reference blockquote so Markdown renderers don't strip it as an HTML tag.
+
+### Changed
+
+- CI/release: grant the reusable release workflow `id-token: write` and `attestations: write` (required by `actions/attest-build-provenance` for SLSA build-provenance attestations on release archives); drop unused `pull-requests: write`. Drop the deprecated `with: { bump, attest }` inputs and the `workflow_dispatch` trigger from `.github/workflows/release.yml` — both inputs are ignored upstream and the manual trigger did nothing useful since releases ship via signed tag-push only. ([#91](https://github.com/netresearch/jira-skill/pull/91), [#93](https://github.com/netresearch/jira-skill/pull/93))
+
 ## [3.13.0] - 2026-04-27
 
 ### Added

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.13.0"
+  version: "3.13.1"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.13.0"
+  version: "3.13.1"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
## Summary

Patch release rolling up the work merged since [v3.13.0](https://github.com/netresearch/jira-skill/releases/tag/v3.13.0):

- **`jira-syntax` validator** — fix `set -e` early-exit when warnings/errors are reported (pre-increment counters), tighten `{code:LANG}` membership check to a Bash built-in `[[ ]]` pattern, treat `{code:language}` as a placeholder warning, add a check that flags `{code:LANG}` whose `LANG` is not in the Jira Server source-code formatter set.
- **`jira-syntax` quick reference** — replace the vague "many more" line with the authoritative formatter list grouped by category, call out `c#`/`c++`, list common identifiers that look valid but aren't (typescript, rust, shell, yml, typoscript), backtick `<name>` so Markdown renderers don't strip it.
- **CI/release** — grant `id-token: write` and `attestations: write` for SLSA build-provenance, drop unused `pull-requests: write`, drop deprecated `with: { bump, attest }` inputs and the `workflow_dispatch` trigger from `release.yml`.

Bumped:
- `.claude-plugin/plugin.json` 3.13.0 → 3.13.1
- `skills/jira-communication/SKILL.md` metadata.version
- `skills/jira-syntax/SKILL.md` metadata.version
- `CHANGELOG.md` — new `[3.13.1]` section

## Test plan

- [ ] CI green on `release/v3.13.1`
- [ ] After merge: tag `v3.13.1` (signed annotated) and verify the release workflow publishes the 3 archives with SLSA attestations