### PR TITLE
style: ruff format tests/test_cli_smoke.py

### DIFF
--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -616,9 +616,7 @@ class TestMockedCommands:
         """jira-worklog list must render extracted text from ADF comments (Cloud), not the raw dict."""
         adf_comment = {
             "type": "doc",
-            "content": [
-                {"type": "paragraph", "content": [{"type": "text", "text": "Implemented retry logic"}]}
-            ],
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Implemented retry logic"}]}],
         }
         mock_client = self._make_mock_client()
         mock_client.issue_get_worklog.return_value = {


### PR DESCRIPTION
## Summary

Lint workflow on `main` started failing right after #92 was merged: `ruff format --check` flagged `tests/test_cli_smoke.py` (the ADF-comment regression tests added in #92 had a single-element `content` list collapsed onto one line, which ruff format would split).

This PR runs `uv run ruff format tests/test_cli_smoke.py` to make Lint green again.

## Type of Change

- [x] CI / build / dependencies (formatting only — no behavior change)

## Test Plan

```
uv run ruff format --check tests/test_cli_smoke.py
```

Closes the lint regression introduced by 33261db4.