### PR TITLE
fix(client): centralize response validation for auth + session-expiry HTML

### DIFF
--- a/skills/jira-communication/scripts/core/jira-attachment.py
+++ b/skills/jira-communication/scripts/core/jira-attachment.py
@@ -25,7 +25,14 @@ if _lib_path.exists():
 
 import click
 import requests
-from lib.client import CaptchaError, LazyJiraClient, _sanitize_error
+from lib.client import (
+    AuthenticationError,
+    CaptchaError,
+    LazyJiraClient,
+    SessionExpiredError,
+    _handle_response,
+    _sanitize_error,
+)
 from lib.config import load_config, normalize_netloc
 from lib.output import error, success, warning
 
@@ -212,6 +219,9 @@ def download(ctx, attachment_url: str, output_file: str):
             error(f"Download failed: unexpected redirect (status {response.status_code})")
             sys.exit(1)
 
+        # _handle_response() raises typed errors for 401/403/session-expiry;
+        # raise_for_status() handles the remaining 4xx/5xx.
+        _handle_response(response, jira_url, url=getattr(response, "url", url))
         response.raise_for_status()
 
         # Write to file
@@ -230,6 +240,16 @@ def download(ctx, attachment_url: str, output_file: str):
         if ctx.obj["debug"]:
             raise
         error(f"Missing required configuration: {e}")
+        sys.exit(1)
+    except SessionExpiredError as e:
+        if ctx.obj["debug"]:
+            raise
+        error(str(e))
+        sys.exit(1)
+    except AuthenticationError as e:
+        if ctx.obj["debug"]:
+            raise
+        error(str(e))
         sys.exit(1)
     except requests.exceptions.RequestException as e:
         if ctx.obj["debug"]:

--- a/skills/jira-communication/scripts/core/jira-setup.py
+++ b/skills/jira-communication/scripts/core/jira-setup.py
@@ -26,7 +26,13 @@ import json
 import click
 import requests
 from atlassian import Jira
-from lib.client import JIRA_TIMEOUT, _sanitize_error
+from lib.client import (
+    JIRA_TIMEOUT,
+    AuthenticationError,
+    SessionExpiredError,
+    _patch_session_for_response_validation,
+    _sanitize_error,
+)
 from lib.config import DEFAULT_ENV_FILE, PROFILES_FILE, is_cloud_url, load_env
 from lib.output import error, success, warning
 
@@ -110,30 +116,37 @@ def validate_credentials(url: str, auth_type: str, **kwargs) -> tuple[bool, str]
                 timeout=JIRA_TIMEOUT,
             )
 
+        _patch_session_for_response_validation(client, url)
+
         user = client.myself()
         if isinstance(user, dict):
             display_name = user.get("displayName", user.get("name", "Unknown"))
             email = user.get("emailAddress", "")
         else:
             user_str = str(user) if user else ""
-            # Detect HTML response (2FA/Secure Login intercept)
+            # Defensive fallback for mocked/unpatched clients where an HTML
+            # 2FA/Secure Login page reaches this point instead of raising
+            # SessionExpiredError from the response-validation hook.
             if user_str.lstrip().startswith(("<!DOCTYPE", "<html", "<HTML")):
                 return False, (
-                    "Two-factor authentication (2FA/Secure Login) intercepted the API call. "
-                    "Your PAT may not bypass 2FA on this instance. "
+                    "Two-factor authentication (2FA/Secure Login) intercepted the API call "
+                    "or the session expired. Your PAT may not bypass 2FA on this instance. "
                     "Check Jira admin settings or create a new PAT with API access."
                 )
             display_name = user_str or "Unknown"
             email = ""
         return True, f"{display_name}" + (f" ({email})" if email else "")
 
+    except SessionExpiredError:
+        return False, (
+            "Two-factor authentication (2FA/Secure Login) intercepted the API call "
+            "or the session expired. Your PAT may not bypass 2FA on this instance. "
+            "Check Jira admin settings or create a new PAT with API access."
+        )
+    except AuthenticationError:
+        return False, "Authentication failed - invalid credentials or insufficient permissions"
     except Exception as e:
-        error_msg = _sanitize_error(str(e))
-        if "401" in error_msg or "Unauthorized" in error_msg:
-            return False, "Authentication failed - invalid credentials"
-        if "403" in error_msg or "Forbidden" in error_msg:
-            return False, "Access denied - check permissions"
-        return False, f"Connection error: {error_msg}"
+        return False, f"Connection error: {_sanitize_error(str(e))}"
 
 
 def write_env_file(path: Path, config: dict) -> None:

--- a/skills/jira-communication/scripts/core/jira-validate.py
+++ b/skills/jira-communication/scripts/core/jira-validate.py
@@ -26,7 +26,7 @@ import json as json_module
 
 import click
 import requests
-from lib.client import LazyJiraClient, _sanitize_error
+from lib.client import AuthenticationError, LazyJiraClient, SessionExpiredError, _sanitize_error
 from lib.config import (
     DEFAULT_ENV_FILE,
     PROFILES_FILE,
@@ -172,6 +172,12 @@ def check_connectivity(
         if verbose:
             success(f"Authenticated as: {display_name} ({email})")
 
+    except SessionExpiredError as e:
+        error("Authentication failed", str(e))
+        return False, info
+    except AuthenticationError as e:
+        error("Authentication failed", str(e))
+        return False, info
     except Exception as e:
         error(
             "Authentication failed",

--- a/skills/jira-communication/scripts/lib/client.py
+++ b/skills/jira-communication/scripts/lib/client.py
@@ -232,6 +232,24 @@ class CaptchaError(Exception):
         self.login_url = login_url
 
 
+class SessionExpiredError(Exception):
+    """Raised when a 200 OK response carries an HTML session-expiry or login page.
+
+    Jira Server/DC redirects expired sessions to a login page that returns
+    200 OK with Content-Type: text/html and no Content-Disposition: attachment.
+    Without this check the HTML body would be silently written to disk as if it
+    were the requested file.
+    """
+
+
+class AuthenticationError(Exception):
+    """Raised when Jira returns 401 or 403 on an authenticated request.
+
+    Provides a typed alternative to inspecting raw HTTP status codes or
+    string-matching error messages for authentication failures.
+    """
+
+
 def _check_captcha_challenge(response: Response, jira_url: str) -> None:
     """Check response for CAPTCHA challenge and raise exception if found.
 
@@ -276,11 +294,86 @@ def _check_captcha_challenge(response: Response, jira_url: str) -> None:
     )
 
 
-def _patch_session_for_captcha(client: Jira, jira_url: str) -> None:
-    """Patch the Jira client session to detect CAPTCHA challenges.
+def _check_session_expiry(response: Response, url: str) -> None:
+    """Check whether a 200 OK response is actually an HTML session-expiry page.
 
-    The atlassian-python-api library doesn't check for CAPTCHA responses,
-    so we patch the session's request method to add this check.
+    Jira Server/DC returns 200 OK with Content-Type: text/html when the session
+    has expired and the request is redirected to a login page. Real HTML file
+    attachments are distinguished by the presence of Content-Disposition: attachment.
+
+    Args:
+        response: HTTP response to check
+        url: Effective URL of the response, used in the error message
+
+    Raises:
+        SessionExpiredError: If the response looks like a login/session-expiry page
+    """
+    if response.status_code != 200:
+        return
+    ct = response.headers.get("Content-Type", "").split(";")[0].strip().lower()
+    if not ct.startswith("text/html"):
+        return
+    cd = response.headers.get("Content-Disposition", "").lower()
+    if "attachment" in cd:
+        return
+    raise SessionExpiredError(
+        f"Request failed: response is HTML without an attachment disposition "
+        f"(Content-Type: {ct}, URL: {url}). "
+        "The session may have expired or the URL redirected to a login page."
+    )
+
+
+def _check_authentication(response: Response) -> None:
+    """Check whether the response signals an authentication failure.
+
+    Raises AuthenticationError for 401 and 403 responses. Must be called
+    after _check_captcha_challenge so that CAPTCHA-flavoured 401s (which carry
+    the X-Authentication-Denied-Reason header) are attributed to CaptchaError
+    rather than the more generic AuthenticationError.
+
+    Args:
+        response: HTTP response to check
+
+    Raises:
+        AuthenticationError: If the response status is 401 or 403
+    """
+    if response.status_code in (401, 403):
+        raise AuthenticationError(
+            f"Authentication failed (HTTP {response.status_code}). Check your credentials or token."
+        )
+
+
+def _handle_response(response: Response, jira_url: str, url: str | None = None) -> None:
+    """Run all response-level validation checks.
+
+    Centralises CAPTCHA detection, authentication failure detection, and
+    session-expiry detection so every request path benefits from the same
+    guards regardless of whether it goes through the patched Jira session
+    or a bare requests.get call.
+
+    Call order matters:
+    1. CAPTCHA — fires on 401 carrying X-Authentication-Denied-Reason header
+    2. Authentication — fires on any remaining 401/403
+    3. Session expiry — fires on 200 + text/html without attachment disposition
+
+    Args:
+        response: HTTP response to validate
+        jira_url: Base Jira URL, used for CAPTCHA login URL construction
+        url: Effective request URL for error messages; falls back to
+             response.url when not supplied
+    """
+    _check_captcha_challenge(response, jira_url)
+    _check_authentication(response)
+    _check_session_expiry(response, url or getattr(response, "url", ""))
+
+
+def _patch_session_for_response_validation(client: Jira, jira_url: str) -> None:
+    """Patch the Jira client session to run response validation on every request.
+
+    The atlassian-python-api library doesn't inspect responses for CAPTCHA
+    challenges, authentication failures, or session-expiry HTML pages, so we
+    wrap the session's request method to call _handle_response after each
+    response is received.
 
     Args:
         client: Jira client instance to patch
@@ -290,7 +383,7 @@ def _patch_session_for_captcha(client: Jira, jira_url: str) -> None:
 
     def patched_request(method: str, url: str, **kwargs) -> Response:
         response = original_request(method, url, **kwargs)
-        _check_captcha_challenge(response, jira_url)
+        _handle_response(response, jira_url, url=url)
         return response
 
     client._session.request = patched_request
@@ -553,8 +646,8 @@ def get_jira_client(
         client._session.mount("https://", adapter)
         client._session.mount("http://", adapter)
 
-        # Patch session to detect CAPTCHA challenges (primarily for Server/DC)
-        _patch_session_for_captcha(client, jira_url)
+        # Patch session to run response validation (CAPTCHA, authentication failures, session-expiry HTML pages)
+        _patch_session_for_response_validation(client, jira_url)
 
         return client
     except CaptchaError:

--- a/skills/jira-communication/scripts/workflow/jira-move.py
+++ b/skills/jira-communication/scripts/workflow/jira-move.py
@@ -22,7 +22,7 @@ if _lib_path.exists():
 
 import click
 import requests
-from lib.client import LazyJiraClient, _sanitize_error
+from lib.client import AuthenticationError, LazyJiraClient, SessionExpiredError, _sanitize_error
 from lib.output import error, format_output, success, warning
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -178,6 +178,16 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
         else:
             response.raise_for_status()
 
+    except SessionExpiredError as e:
+        if ctx.obj["debug"]:
+            raise
+        error(str(e))
+        sys.exit(1)
+    except AuthenticationError as e:
+        if ctx.obj["debug"]:
+            raise
+        error(str(e))
+        sys.exit(1)
     except requests.HTTPError as e:
         if ctx.obj["debug"]:
             raise

--- a/skills/jira-communication/scripts/workflow/jira-version.py
+++ b/skills/jira-communication/scripts/workflow/jira-version.py
@@ -21,7 +21,7 @@ if _lib_path.exists():
     sys.path.insert(0, str(_lib_path.parent))
 
 import click
-from lib.client import LazyJiraClient
+from lib.client import AuthenticationError, LazyJiraClient, SessionExpiredError
 from lib.output import error, format_output, format_table, success, warning
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -382,6 +382,16 @@ def create(ctx, project_key, name, description, start_date, release_date, releas
             extra = f" (release {release_date})" if release_date else ""
             success(f'Created version {vid} "{name}" in {project_key}{extra}')
 
+    except SessionExpiredError as e:
+        if ctx.obj["debug"]:
+            raise
+        error(str(e))
+        sys.exit(1)
+    except AuthenticationError as e:
+        if ctx.obj["debug"]:
+            raise
+        error(str(e))
+        sys.exit(1)
     except Exception as e:
         if ctx.obj["debug"]:
             raise

--- a/tests/test_attachment_security.py
+++ b/tests/test_attachment_security.py
@@ -6,11 +6,14 @@ from pathlib import Path
 from unittest import mock
 
 import click.testing
+import pytest
 
 # Add scripts to path for lib imports
 _test_dir = Path(__file__).parent
 _scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
 sys.path.insert(0, str(_scripts_path))
+
+import lib.client as _lib_client
 
 # Import jira-attachment.py (hyphenated filename requires importlib)
 _core_path = _scripts_path / "core"
@@ -180,3 +183,159 @@ class TestAttachmentUploadMimeType:
         _, kwargs = mc._session.post.call_args
         _name, _fh, mime = kwargs["files"]["file"]
         assert mime == "application/octet-stream"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Shared helpers for response-level tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+_FAKE_CONFIG = {
+    "JIRA_URL": "https://jira.example.com",
+    "JIRA_USERNAME": "user@example.com",
+    "JIRA_API_TOKEN": "fake-token",
+}
+
+_JIRA_URL = "https://jira.example.com"
+
+
+def _make_mock_response(
+    content_type: str,
+    body: bytes = b"data",
+    status_code: int = 200,
+    content_disposition: str = "",
+):
+    resp = mock.Mock()
+    resp.status_code = status_code
+    resp.url = "https://jira.example.com/rest/api/2/attachment/content/1"
+    headers = {"Content-Type": content_type}
+    if content_disposition:
+        headers["Content-Disposition"] = content_disposition
+    resp.headers = headers
+    resp.raise_for_status = mock.Mock()
+    resp.iter_content = mock.Mock(return_value=iter([body]))
+    return resp
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: _handle_response helper - pure function, no CliRunner needed
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestHandleResponse:
+    """_handle_response must raise typed exceptions for session-expiry and CAPTCHA."""
+
+    def test_html_without_attachment_disposition_raises(self):
+        """200 text/html with no Content-Disposition must raise SessionExpiredError."""
+        resp = _make_mock_response("text/html; charset=utf-8")
+        with pytest.raises(_lib_client.SessionExpiredError):
+            _lib_client._handle_response(resp, _JIRA_URL)
+
+    def test_html_with_attachment_disposition_allowed(self):
+        """200 text/html with Content-Disposition: attachment must pass (real HTML file)."""
+        resp = _make_mock_response(
+            "text/html; charset=utf-8",
+            content_disposition='attachment; filename="page.html"',
+        )
+        _lib_client._handle_response(resp, _JIRA_URL)  # must not raise
+
+    def test_non_html_allowed(self):
+        """200 application/pdf must pass without raising."""
+        resp = _make_mock_response("application/pdf")
+        _lib_client._handle_response(resp, _JIRA_URL)  # must not raise
+
+    def test_captcha_header_still_raises(self):
+        """X-Authentication-Denied-Reason: CAPTCHA_CHALLENGE must raise CaptchaError."""
+        resp = _make_mock_response("application/json")
+        resp.headers["X-Authentication-Denied-Reason"] = "CAPTCHA_CHALLENGE"
+        with pytest.raises(_lib_client.CaptchaError):
+            _lib_client._handle_response(resp, _JIRA_URL)
+
+    def test_non_200_html_not_session_expiry(self):
+        """401 text/html must raise AuthenticationError, not SessionExpiredError.
+
+        Directly proves authentication handling runs before the 200-only session-expiry guard.
+        """
+        resp = _make_mock_response("text/html; charset=utf-8", status_code=401)
+        with pytest.raises(_lib_client.AuthenticationError):
+            _lib_client._handle_response(resp, _JIRA_URL)
+
+    def test_401_raises_authentication_error(self):
+        """401 response without CAPTCHA header must raise AuthenticationError."""
+        resp = _make_mock_response("application/json", status_code=401)
+        with pytest.raises(_lib_client.AuthenticationError):
+            _lib_client._handle_response(resp, _JIRA_URL)
+
+    def test_403_raises_authentication_error(self):
+        """403 response must raise AuthenticationError."""
+        resp = _make_mock_response("application/json", status_code=403)
+        with pytest.raises(_lib_client.AuthenticationError):
+            _lib_client._handle_response(resp, _JIRA_URL)
+
+    def test_captcha_on_401_raises_captcha_not_auth_error(self):
+        """401 with CAPTCHA header must raise CaptchaError, not AuthenticationError.
+
+        Validates that _check_captcha_challenge runs before _check_authentication
+        so CAPTCHA-flavoured 401s are attributed to the more specific exception.
+        """
+        resp = _make_mock_response("text/html", status_code=401)
+        resp.headers["X-Authentication-Denied-Reason"] = "CAPTCHA_CHALLENGE"
+        with pytest.raises(_lib_client.CaptchaError):
+            _lib_client._handle_response(resp, _JIRA_URL)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: CLI-level regression - HTML responses rejected before writing to disk
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDownloadContentTypeGuard:
+    """End-to-end CLI regression: HTML session-expiry pages must not be written to disk."""
+
+    def _run_download(self, tmp_path, content_type, content_disposition=""):
+        out_file = str(tmp_path / "out.bin")
+        runner = click.testing.CliRunner()
+        with (
+            mock.patch.object(jira_attachment, "load_config", return_value=_FAKE_CONFIG),
+            mock.patch.object(
+                jira_attachment.requests,
+                "get",
+                return_value=_make_mock_response(content_type, b"fake", content_disposition=content_disposition),
+            ),
+            mock.patch.object(jira_attachment.Path, "cwd", return_value=tmp_path),
+        ):
+            result = runner.invoke(
+                jira_attachment.cli,
+                ["download", "https://jira.example.com/rest/api/2/attachment/content/1", out_file],
+            )
+        return result, tmp_path / "out.bin"
+
+    def test_html_content_type_rejected(self, tmp_path):
+        """text/html with no Content-Disposition must be rejected; file must not be written."""
+        result, out = self._run_download(tmp_path, "text/html; charset=utf-8")
+        assert result.exit_code != 0
+        assert "HTML" in result.output
+        assert not out.exists()
+
+    def test_html_content_type_case_insensitive(self, tmp_path):
+        """Content-Type header matching must be case-insensitive (Text/Html, TEXT/HTML)."""
+        result, out = self._run_download(tmp_path, "Text/Html")
+        assert result.exit_code != 0
+        assert "HTML" in result.output
+        assert not out.exists()
+
+    def test_html_attachment_disposition_accepted(self, tmp_path):
+        """text/html with Content-Disposition: attachment must be accepted (real HTML file)."""
+        result, out = self._run_download(
+            tmp_path, "text/html; charset=utf-8", content_disposition='attachment; filename="report.html"'
+        )
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        assert out.read_bytes() == b"fake"
+
+    def test_valid_content_type_accepted(self, tmp_path):
+        """application/pdf response must be accepted and the file written."""
+        result, out = self._run_download(tmp_path, "application/pdf")
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        assert out.read_bytes() == b"fake"


### PR DESCRIPTION
## Summary

Centralizes Jira response validation in `lib/client.py` so authentication failures and session-expiry HTML responses are handled consistently across request paths.

Adds typed `AuthenticationError` handling for 401/403 responses and typed `SessionExpiredError` handling for 200 HTML login/session-expiry pages without `Content-Disposition: attachment`. This keeps legitimate HTML attachments allowed while preventing Jira login pages from being saved as corrupted attachment downloads.

Closes #88 

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring / code quality
- [ ] CI / build / dependencies

## Checklist

- [x] Commits are signed (`-S`) and signed-off (`--signoff`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for changed behavior
- [ ] Documentation updated (README, AGENTS.md, CHANGELOG, or inline docs)
- [x] CI passes (lint, tests, static analysis)

## Test Plan

Ran:

```bash
uv run --with pytest --with atlassian-python-api --with requests --with click pytest tests/test_attachment_security.py -v
```
Result: 26  passed

Ran:

```bash
uv run --with pytest --with atlassian-python-api --with requests --with click pytest tests/test_jira_setup.py -v
```
Result: 15  passed