### PR TITLE
Fix list truncation, labels safety, move guardrails, and upload MIME

### DIFF
--- a/skills/jira-communication/references/issue-editing.md
+++ b/skills/jira-communication/references/issue-editing.md
@@ -2,7 +2,7 @@
 
 ## When to load
 
-Load this reference whenever the user wants to set `--fields-json`, set a custom `--reporter`, delete an issue (especially with sub-tasks), move an issue between projects, or change any field that is not assignee, priority, or labels.
+Load this reference whenever the user wants to set `--fields-json`, set a custom `--reporter`, delete an issue (especially with sub-tasks), attempt an unsupported cross-project move via CLI (see below), or change any field that is not assignee, priority, or labels.
 
 ## `--fields-json` for description and custom fields
 
@@ -26,6 +26,21 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py update PROJ-123 \
 The script merges `--fields-json` onto the typed-flag payload (`update_fields.update(extra_fields)`), so any key present in both is taken from `--fields-json`. Use typed flags for fields the CLI exposes directly, and reach for `--fields-json` only for the long tail.
 
 Look up custom field IDs with `jira-fields.py` — see `fields-and-users.md`.
+
+## Labels: replace vs incremental updates
+
+`jira-issue.py update` supports three modes:
+
+- `--labels a,b,c` replaces the full label set.
+- `--add-label` / `--remove-label` incrementally update labels without wiping unrelated tags.
+- Do **not** combine `--labels` with `--add-label` / `--remove-label` in one invocation.
+
+Each `--add-label` / `--remove-label` may be repeated and may contain comma-separated values. Matching for removals is **case-insensitive**, and additions **dedupe case-insensitively** while preserving the casing already stored in Jira when possible.
+
+```bash
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py update PROJ-123 \
+  --add-label backend --add-label urgent,frontend --remove-label stale
+```
 
 ## Setting a custom reporter
 
@@ -56,12 +71,16 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py delete PROJ-100 --delete-s
 
 ## Moving an issue between projects
 
+Cross-project moves are **not implemented** in `jira-move.py` because some Jira Server/DC versions accept `project` edits via the standard issue endpoint without actually moving the issue (silent partial updates / corruption risk). The command **refuses** cross-project targets for both real execution and `--dry-run`.
+
+Use the Jira UI **Move** action (or a bulk-move workflow your admins provide) for cross-project relocation.
+
+Within the **same** project, `jira-move.py` can change issue type:
+
 ```bash
-# Preview the move (destination project must accept the issue type)
-uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-move.py issue PROJ-100 TARGET --dry-run
+# Preview a same-project type change
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-move.py issue PROJ-100 PROJ --issue-type Task --dry-run
 
-# Execute the move
-uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-move.py issue PROJ-100 TARGET
+# Execute the type change (issue key stays the same)
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-move.py issue PROJ-100 PROJ --issue-type Task
 ```
-
-The issue key changes after the move; the script prints the new key.

--- a/skills/jira-communication/scripts/core/jira-attachment.py
+++ b/skills/jira-communication/scripts/core/jira-attachment.py
@@ -10,6 +10,7 @@
 """Jira attachment operations - download and upload attachments."""
 
 import json
+import mimetypes
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
@@ -270,7 +271,16 @@ def add(ctx, issue_key: str, file_path: str, dry_run: bool):
         return
 
     try:
-        result = client.add_attachment(issue_key, str(path))
+        mime_type, _ = mimetypes.guess_type(path.name)
+        mime_type = mime_type or "application/octet-stream"
+
+        url = f"{client.url}/rest/api/2/issue/{issue_key}/attachments"
+        headers = {"X-Atlassian-Token": "nocheck"}
+        with path.open("rb") as f:
+            files = {"file": (path.name, f, mime_type)}
+            response = client._session.post(url, files=files, headers=headers)
+        response.raise_for_status()
+        result = response.json()
 
         if ctx.obj["quiet"]:
             if isinstance(result, list) and result and isinstance(result[0], dict):
@@ -284,6 +294,11 @@ def add(ctx, issue_key: str, file_path: str, dry_run: bool):
 
     except CaptchaError:
         raise
+    except requests.HTTPError as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to upload attachment: {_sanitize_error(str(e))}")
+        sys.exit(1)
     except Exception as e:
         if ctx.obj["debug"]:
             raise

--- a/skills/jira-communication/scripts/core/jira-attachment.py
+++ b/skills/jira-communication/scripts/core/jira-attachment.py
@@ -25,7 +25,7 @@ if _lib_path.exists():
 
 import click
 import requests
-from lib.client import JIRA_TIMEOUT, CaptchaError, LazyJiraClient, _sanitize_error
+from lib.client import CaptchaError, LazyJiraClient, _sanitize_error
 from lib.config import load_config, normalize_netloc
 from lib.output import error, success, warning
 
@@ -34,6 +34,9 @@ CHUNK_SIZE = 1048576
 
 # Timeout for attachment downloads (connect_timeout, read_timeout)
 DOWNLOAD_TIMEOUT = (10, 300)
+
+# Uploads can be large — keep connect timeout low but allow long reads.
+UPLOAD_TIMEOUT = (10, 300)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -278,7 +281,7 @@ def add(ctx, issue_key: str, file_path: str, dry_run: bool):
         headers = {"X-Atlassian-Token": "nocheck"}
         with path.open("rb") as f:
             files = {"file": (path.name, f, mime_type)}
-            response = client._session.post(url, files=files, headers=headers, timeout=JIRA_TIMEOUT)
+            response = client._session.post(url, files=files, headers=headers, timeout=UPLOAD_TIMEOUT)
         response.raise_for_status()
         result = response.json()
 

--- a/skills/jira-communication/scripts/core/jira-attachment.py
+++ b/skills/jira-communication/scripts/core/jira-attachment.py
@@ -25,7 +25,7 @@ if _lib_path.exists():
 
 import click
 import requests
-from lib.client import CaptchaError, LazyJiraClient, _sanitize_error
+from lib.client import CaptchaError, JIRA_TIMEOUT, LazyJiraClient, _sanitize_error
 from lib.config import load_config, normalize_netloc
 from lib.output import error, success, warning
 
@@ -278,7 +278,7 @@ def add(ctx, issue_key: str, file_path: str, dry_run: bool):
         headers = {"X-Atlassian-Token": "nocheck"}
         with path.open("rb") as f:
             files = {"file": (path.name, f, mime_type)}
-            response = client._session.post(url, files=files, headers=headers)
+            response = client._session.post(url, files=files, headers=headers, timeout=JIRA_TIMEOUT)
         response.raise_for_status()
         result = response.json()
 

--- a/skills/jira-communication/scripts/core/jira-attachment.py
+++ b/skills/jira-communication/scripts/core/jira-attachment.py
@@ -25,7 +25,7 @@ if _lib_path.exists():
 
 import click
 import requests
-from lib.client import CaptchaError, JIRA_TIMEOUT, LazyJiraClient, _sanitize_error
+from lib.client import JIRA_TIMEOUT, CaptchaError, LazyJiraClient, _sanitize_error
 from lib.config import load_config, normalize_netloc
 from lib.output import error, success, warning
 

--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -480,6 +480,10 @@ def update(
     if priority:
         update_fields["priority"] = {"name": priority}
 
+    if labels and (add_label or remove_label):
+        error("Do not combine --labels with --add-label/--remove-label (choose replace or incremental update).")
+        sys.exit(1)
+
     if labels:
         update_fields["labels"] = [l.strip() for l in labels.split(",")]
 

--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -436,6 +436,8 @@ def _status_order(current_status: str, transitions: list) -> list[str]:
 @click.option("--summary", "-s", help="New summary")
 @click.option("--priority", "-p", help="Priority name")
 @click.option("--labels", "-l", help="Comma-separated labels (replaces existing)")
+@click.option("--add-label", multiple=True, help="Add a label (repeatable)")
+@click.option("--remove-label", multiple=True, help="Remove a label (repeatable)")
 @click.option("--assignee", "-a", help="Assignee username or email")
 @click.option("--fields-json", help="JSON string of additional fields to update")
 @click.option("--dry-run", is_flag=True, help="Show what would be updated without making changes")
@@ -446,6 +448,8 @@ def update(
     summary: str | None,
     priority: str | None,
     labels: str | None,
+    add_label: tuple[str, ...],
+    remove_label: tuple[str, ...],
     assignee: str | None,
     fields_json: str | None,
     dry_run: bool,
@@ -479,6 +483,14 @@ def update(
     if labels:
         update_fields["labels"] = [l.strip() for l in labels.split(",")]
 
+    if add_label or remove_label:
+        issue = client.issue(issue_key, fields="labels")
+        existing = set((issue.get("fields") or {}).get("labels") or [])
+        next_labels = set(existing)
+        next_labels.update(l for l in add_label if l)
+        next_labels.difference_update(l for l in remove_label if l)
+        update_fields["labels"] = sorted(next_labels)
+
     if assignee:
         update_fields["assignee"] = resolve_assignee(client, assignee)
 
@@ -492,7 +504,10 @@ def update(
 
     if not update_fields:
         error("No fields specified for update")
-        click.echo("\nUse one or more of: --summary, --priority, --labels, --assignee, --fields-json")
+        click.echo(
+            "\nUse one or more of: --summary, --priority, --labels, "
+            "--add-label, --remove-label, --assignee, --fields-json"
+        )
         sys.exit(1)
 
     if dry_run:

--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -31,6 +31,42 @@ from lib.changelog import (
 from lib.client import LazyJiraClient, _sanitize_error, resolve_assignee, resolve_status
 from lib.output import compact_json, error, extract_adf_text, format_output, success, warning
 
+
+def _expand_label_args(raw: tuple[str, ...]) -> list[str]:
+    """Split repeatable CLI args on commas and strip whitespace."""
+    out: list[str] = []
+    for entry in raw:
+        if not entry:
+            continue
+        for part in entry.split(","):
+            cleaned = part.strip()
+            if cleaned:
+                out.append(cleaned)
+    return out
+
+
+def _labels_after_add_remove(existing: list[str], add: list[str], remove: list[str]) -> list[str]:
+    """Merge labels case-insensitively while preserving first-seen casing from Jira."""
+    by_lower: dict[str, str] = {}
+    for lab in existing:
+        if not lab:
+            continue
+        low = lab.casefold()
+        if low not in by_lower:
+            by_lower[low] = lab
+
+    for lab in add:
+        low = lab.casefold()
+        if low not in by_lower:
+            by_lower[low] = lab
+
+    remove_lower = {lab.casefold() for lab in remove}
+    for low in remove_lower:
+        by_lower.pop(low, None)
+
+    return sorted(by_lower.values(), key=str.casefold)
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # CLI Definition
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -436,8 +472,16 @@ def _status_order(current_status: str, transitions: list) -> list[str]:
 @click.option("--summary", "-s", help="New summary")
 @click.option("--priority", "-p", help="Priority name")
 @click.option("--labels", "-l", help="Comma-separated labels (replaces existing)")
-@click.option("--add-label", multiple=True, help="Add a label (repeatable)")
-@click.option("--remove-label", multiple=True, help="Remove a label (repeatable)")
+@click.option(
+    "--add-label",
+    multiple=True,
+    help="Add label(s); repeatable and comma-separated (case-insensitive dedupe)",
+)
+@click.option(
+    "--remove-label",
+    multiple=True,
+    help="Remove label(s); repeatable and comma-separated (matches case-insensitively)",
+)
 @click.option("--assignee", "-a", help="Assignee username or email")
 @click.option("--fields-json", help="JSON string of additional fields to update")
 @click.option("--dry-run", is_flag=True, help="Show what would be updated without making changes")
@@ -489,13 +533,10 @@ def update(
 
     if add_label or remove_label:
         issue = client.issue(issue_key, fields="labels")
-        existing = set((issue.get("fields") or {}).get("labels") or [])
-        next_labels = set(existing)
-        add_clean = [l.strip() for l in add_label if l and l.strip()]
-        remove_clean = [l.strip() for l in remove_label if l and l.strip()]
-        next_labels.update(add_clean)
-        next_labels.difference_update(remove_clean)
-        update_fields["labels"] = sorted(next_labels)
+        existing = (issue.get("fields") or {}).get("labels") or []
+        add_clean = _expand_label_args(add_label)
+        remove_clean = _expand_label_args(remove_label)
+        update_fields["labels"] = _labels_after_add_remove(list(existing), add_clean, remove_clean)
 
     if assignee:
         update_fields["assignee"] = resolve_assignee(client, assignee)

--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -491,8 +491,10 @@ def update(
         issue = client.issue(issue_key, fields="labels")
         existing = set((issue.get("fields") or {}).get("labels") or [])
         next_labels = set(existing)
-        next_labels.update(l for l in add_label if l)
-        next_labels.difference_update(l for l in remove_label if l)
+        add_clean = [l.strip() for l in add_label if l and l.strip()]
+        remove_clean = [l.strip() for l in remove_label if l and l.strip()]
+        next_labels.update(add_clean)
+        next_labels.difference_update(remove_clean)
         update_fields["labels"] = sorted(next_labels)
 
     if assignee:

--- a/skills/jira-communication/scripts/core/jira-search.py
+++ b/skills/jira-communication/scripts/core/jira-search.py
@@ -94,7 +94,7 @@ def query(ctx, jql: str, max_results: int, fields: str, start_at: int, truncate:
         results = client.jql(jql, limit=max_results, start=start_at, fields=field_list)
         issues = results.get("issues", [])
         total = results.get("total")
-        if isinstance(total, int) and max_results > len(issues) and total > len(issues):
+        if isinstance(total, int) and max_results > len(issues) and (start_at + len(issues)) < total:
             warning(
                 f"Server capped results: requested --max-results {max_results}, "
                 f"received {len(issues)} (total matches: {total}). "

--- a/skills/jira-communication/scripts/core/jira-search.py
+++ b/skills/jira-communication/scripts/core/jira-search.py
@@ -21,7 +21,7 @@ if _lib_path.exists():
 
 import click
 from lib.client import LazyJiraClient
-from lib.output import error, format_output, format_table
+from lib.output import error, format_output, format_table, warning
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CLI Definition
@@ -93,6 +93,13 @@ def query(ctx, jql: str, max_results: int, fields: str, start_at: int, truncate:
         # Execute search
         results = client.jql(jql, limit=max_results, start=start_at, fields=field_list)
         issues = results.get("issues", [])
+        total = results.get("total")
+        if isinstance(total, int) and max_results > len(issues) and total > len(issues):
+            warning(
+                f"Server capped results: requested --max-results {max_results}, "
+                f"received {len(issues)} (total matches: {total}). "
+                "Use pagination with --start-at to fetch further pages."
+            )
 
         if ctx.obj["json"]:
             format_output(issues, as_json=True)
@@ -101,7 +108,6 @@ def query(ctx, jql: str, max_results: int, fields: str, start_at: int, truncate:
                 print(issue["key"])
         else:
             # Table output
-            total = results.get("total")
             if total is None:
                 total = len(issues)
             if not issues:

--- a/skills/jira-communication/scripts/lib/jql.py
+++ b/skills/jira-communication/scripts/lib/jql.py
@@ -8,4 +8,3 @@ f-string JQL snippets.
 def jql_escape(value: str) -> str:
     """Escape a value for use inside a double-quoted JQL string literal."""
     return value.replace("\\", "\\\\").replace('"', '\\"')
-

--- a/skills/jira-communication/scripts/lib/jql.py
+++ b/skills/jira-communication/scripts/lib/jql.py
@@ -1,0 +1,11 @@
+"""JQL helper utilities.
+
+Keep all escaping/quoting logic centralized so callers don't hand-roll
+f-string JQL snippets.
+"""
+
+
+def jql_escape(value: str) -> str:
+    """Escape a value for use inside a double-quoted JQL string literal."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+

--- a/skills/jira-communication/scripts/utility/jira-qa-gather.py
+++ b/skills/jira-communication/scripts/utility/jira-qa-gather.py
@@ -30,6 +30,7 @@ if _lib_path.exists():
 
 import click
 from lib.client import LazyJiraClient, _sanitize_error
+from lib.jql import jql_escape
 from lib.output import error, extract_adf_text, format_output, warning
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -254,9 +255,9 @@ def cli(
     if not no_siblings and summary:
         keywords = _summary_keywords(summary)
         if keywords:
-            kw_clause = " OR ".join(f'summary ~ "{k}"' for k in keywords)
+            kw_clause = " OR ".join(f'summary ~ "{jql_escape(k)}"' for k in keywords)
             jql = (
-                f'project = "{project_key}" AND key != "{issue_key}" '
+                f'project = "{jql_escape(project_key)}" AND key != "{jql_escape(issue_key)}" '
                 f"AND ({kw_clause}) AND updated >= -{sibling_window}d "
                 f"ORDER BY updated DESC"
             )

--- a/skills/jira-communication/scripts/utility/jira-worklog-query.py
+++ b/skills/jira-communication/scripts/utility/jira-worklog-query.py
@@ -23,16 +23,15 @@ from datetime import date, timedelta
 
 import click
 from lib.client import LazyJiraClient
+from lib.jql import jql_escape
 from lib.output import comment_to_text, error, format_json, warning
+
+# Backwards-compatible alias (older code paths/tests refer to the private name)
+_jql_escape = jql_escape
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Query building
 # ═══════════════════════════════════════════════════════════════════════════════
-
-
-def _jql_escape(value: str) -> str:
-    """Escape a value for use in a double-quoted JQL string."""
-    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def build_jql(
@@ -46,23 +45,23 @@ def build_jql(
 ) -> str:
     """Build JQL query from worklog filters."""
     clauses = [
-        f'worklogDate >= "{_jql_escape(from_date)}"',
-        f'worklogDate <= "{_jql_escape(to_date)}"',
+        f'worklogDate >= "{jql_escape(from_date)}"',
+        f'worklogDate <= "{jql_escape(to_date)}"',
     ]
     if user:
-        clauses.append(f'worklogAuthor = "{_jql_escape(user)}"')
+        clauses.append(f'worklogAuthor = "{jql_escape(user)}"')
     if project:
-        clauses.append(f'project = "{_jql_escape(project)}"')
+        clauses.append(f'project = "{jql_escape(project)}"')
     if issues:
-        quoted = ", ".join(f'"{_jql_escape(k)}"' for k in issues)
+        quoted = ", ".join(f'"{jql_escape(k)}"' for k in issues)
         clauses.append(f"issueKey in ({quoted})")
     if epic:
-        clauses.append(f'"Epic Link" = "{_jql_escape(epic)}"')
+        clauses.append(f'"Epic Link" = "{jql_escape(epic)}"')
     if sprint:
         if sprint.isdigit():
             clauses.append(f"sprint = {sprint}")
         else:
-            clauses.append(f'sprint = "{_jql_escape(sprint)}"')
+            clauses.append(f'sprint = "{jql_escape(sprint)}"')
     return " AND ".join(clauses)
 
 

--- a/skills/jira-communication/scripts/workflow/jira-board.py
+++ b/skills/jira-communication/scripts/workflow/jira-board.py
@@ -76,8 +76,18 @@ def list_boards(ctx, project: str | None, board_type: str | None, name_pattern: 
         if name_pattern:
             params["name"] = name_pattern
 
-        response = client.get("rest/agile/1.0/board", params=params)
-        boards = response.get("values", [])
+        boards: list[dict] = []
+        start_at = 0
+        while True:
+            page_params = dict(params)
+            page_params["startAt"] = start_at
+            response = client.get("rest/agile/1.0/board", params=page_params) or {}
+            values = response.get("values", []) or []
+            boards.extend(values)
+            is_last = bool(response.get("isLast"))
+            if is_last or not values:
+                break
+            start_at += len(values)
 
         if ctx.obj["json"]:
             format_output(boards, as_json=True)

--- a/skills/jira-communication/scripts/workflow/jira-comment.py
+++ b/skills/jira-communication/scripts/workflow/jira-comment.py
@@ -257,7 +257,7 @@ def delete(ctx, issue_key: str, comment_id: str, dry_run: bool):
 
 @cli.command("list")
 @click.argument("issue_key")
-@click.option("--limit", "-n", default=10, help="Max comments to show")
+@click.option("--limit", "-n", default=10, show_default=True, help="Max comments to show (0 = all)")
 @click.option("--truncate", type=int, metavar="N", help="Truncate comment body to N characters")
 @click.pass_context
 def list_comments(ctx, issue_key: str, limit: int, truncate: int | None):
@@ -277,22 +277,29 @@ def list_comments(ctx, issue_key: str, limit: int, truncate: int | None):
     try:
         # Get issue with comments
         issue = client.issue(issue_key, fields="comment")
-        comments = issue.get("fields", {}).get("comment", {}).get("comments", [])
+        comment_block = (issue.get("fields") or {}).get("comment") or {}
+        comments = comment_block.get("comments", []) or []
+        total = comment_block.get("total")
 
         # Limit and reverse (newest first)
-        comments = list(reversed(comments))[:limit]
+        comments = list(reversed(comments))
+        show_all = limit == 0
+        shown = comments if show_all else comments[:limit]
 
         if ctx.obj["json"]:
-            format_output(comments, as_json=True)
+            format_output(shown, as_json=True)
         elif ctx.obj["quiet"]:
-            for c in comments:
+            for c in shown:
                 print(c.get("id", ""))
         else:
-            if not comments:
+            if not shown:
                 print(f"No comments on {issue_key}")
             else:
-                print(f"Comments on {issue_key} ({len(comments)} shown):\n")
-                for c in comments:
+                if total is not None and not show_all and len(shown) < total:
+                    print(f"Comments on {issue_key} ({len(shown)} of {total} shown — use --limit 0 to show all):\n")
+                else:
+                    print(f"Comments on {issue_key} ({len(shown)} shown):\n")
+                for c in shown:
                     author = c.get("author", {}).get("displayName", "Unknown")
                     created = c.get("created", "")[:16].replace("T", " ") if c.get("created") else "N/A"
                     body = c.get("body", "")

--- a/skills/jira-communication/scripts/workflow/jira-comment.py
+++ b/skills/jira-communication/scripts/workflow/jira-comment.py
@@ -28,6 +28,32 @@ from lib.output import error, extract_adf_text, format_output, success, warning
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
+def _fetch_comments_paginated(client, issue_key: str) -> tuple[list[dict], int | None]:
+    comments: list[dict] = []
+    start_at = 0
+    page_size = 100
+    total: int | None = None
+    while True:
+        payload = (
+            client.get(
+                f"rest/api/2/issue/{issue_key}/comment",
+                params={"startAt": start_at, "maxResults": page_size},
+            )
+            or {}
+        )
+        values = payload.get("comments", []) or []
+        if total is None:
+            raw_total = payload.get("total")
+            total = raw_total if isinstance(raw_total, int) else None
+        comments.extend(values)
+        if not values:
+            break
+        if total is not None and (start_at + len(values)) >= total:
+            break
+        start_at += len(values)
+    return comments, total
+
+
 @click.group()
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output")
@@ -275,15 +301,17 @@ def list_comments(ctx, issue_key: str, limit: int, truncate: int | None):
     client = ctx.obj["client"]
 
     try:
-        # Get issue with comments
-        issue = client.issue(issue_key, fields="comment")
-        comment_block = (issue.get("fields") or {}).get("comment") or {}
-        comments = comment_block.get("comments", []) or []
-        total = comment_block.get("total")
+        show_all = limit == 0
+        if show_all:
+            comments, total = _fetch_comments_paginated(client, issue_key)
+        else:
+            issue = client.issue(issue_key, fields="comment")
+            comment_block = (issue.get("fields") or {}).get("comment") or {}
+            comments = comment_block.get("comments", []) or []
+            total = comment_block.get("total")
 
         # Limit and reverse (newest first)
         comments = list(reversed(comments))
-        show_all = limit == 0
         shown = comments if show_all else comments[:limit]
 
         if ctx.obj["json"]:

--- a/skills/jira-communication/scripts/workflow/jira-comment.py
+++ b/skills/jira-communication/scripts/workflow/jira-comment.py
@@ -283,7 +283,14 @@ def delete(ctx, issue_key: str, comment_id: str, dry_run: bool):
 
 @cli.command("list")
 @click.argument("issue_key")
-@click.option("--limit", "-n", default=10, show_default=True, help="Max comments to show (0 = all)")
+@click.option(
+    "--limit",
+    "-n",
+    default=10,
+    show_default=True,
+    type=click.IntRange(min=0),
+    help="Max comments to show (0 = all)",
+)
 @click.option("--truncate", type=int, metavar="N", help="Truncate comment body to N characters")
 @click.pass_context
 def list_comments(ctx, issue_key: str, limit: int, truncate: int | None):

--- a/skills/jira-communication/scripts/workflow/jira-move.py
+++ b/skills/jira-communication/scripts/workflow/jira-move.py
@@ -60,7 +60,7 @@ def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str 
 @click.option("--dry-run", is_flag=True, help="Show what would happen without making changes")
 @click.pass_context
 def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None, dry_run: bool):
-    """Move an issue to a different project or change its type.
+    """Change an issue's type within the same project.
 
     ISSUE_KEY: The Jira issue key to move (e.g., NRS-4301)
 

--- a/skills/jira-communication/scripts/workflow/jira-move.py
+++ b/skills/jira-communication/scripts/workflow/jira-move.py
@@ -149,10 +149,7 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
                 )
                 sys.exit(1)
             if refreshed_type and refreshed_type != target_type:
-                error(
-                    f"Type verification failed: issue is type {refreshed_type} "
-                    f"(expected {target_type})"
-                )
+                error(f"Type verification failed: issue is type {refreshed_type} (expected {target_type})")
                 sys.exit(1)
             if same_project:
                 # Type change within same project — key stays the same

--- a/skills/jira-communication/scripts/workflow/jira-move.py
+++ b/skills/jira-communication/scripts/workflow/jira-move.py
@@ -113,11 +113,22 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
             print(f"  Status:   {status}")
             return
 
-        # Use the REST API directly — atlassian-python-api doesn't have a move method
-        # PUT /rest/api/2/issue/{issueKey} with project + issuetype change
-        update_fields = {"fields": {"issuetype": {"name": target_type}}}
+        # Use the REST API directly — atlassian-python-api doesn't have a move method.
+        #
+        # IMPORTANT: Cross-project moves are NOT safely supported via the standard
+        # issue edit endpoint. Some Jira Server/DC versions silently ignore
+        # `project` updates, which looks like success but leaves the issue in the
+        # old project with a changed issue type (data corruption).
         if not same_project:
-            update_fields["fields"]["project"] = {"key": target_project.upper()}
+            error(
+                "Cross-project move is not supported safely by this command yet. "
+                "Refusing to proceed to avoid partial moves. "
+                "Use the Jira UI Move action (or implement bulk move API support)."
+            )
+            sys.exit(1)
+
+        # PUT /rest/api/2/issue/{issueKey} with issuetype change (same project)
+        update_fields = {"fields": {"issuetype": {"name": target_type}}}
 
         url = f"{client.url}/rest/api/2/issue/{issue_key}"
         # atlassian-python-api has no public method for issue move/edit.
@@ -126,6 +137,23 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
         response = client._session.put(url, json=update_fields)
 
         if response.status_code == 204:
+            # Verify the update actually applied (defense against silent failures)
+            refreshed = client.issue(issue_key, fields="issuetype,project")
+            refreshed_fields = refreshed.get("fields") or {}
+            refreshed_type = (refreshed_fields.get("issuetype") or {}).get("name")
+            refreshed_project = (refreshed_fields.get("project") or {}).get("key")
+            if refreshed_project and refreshed_project.upper() != current_project.upper():
+                error(
+                    f"Move verification failed: issue ended up in unexpected project "
+                    f"{refreshed_project} (expected {current_project})"
+                )
+                sys.exit(1)
+            if refreshed_type and refreshed_type != target_type:
+                error(
+                    f"Type verification failed: issue is type {refreshed_type} "
+                    f"(expected {target_type})"
+                )
+                sys.exit(1)
             if same_project:
                 # Type change within same project — key stays the same
                 if ctx.obj["quiet"]:
@@ -143,29 +171,6 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
                     )
                 else:
                     success(f"Changed {issue_key} type: {current_type} → {target_type}")
-                    print(f"  Summary:    {summary}")
-            else:
-                # Cross-project move — fetch new key (Jira may reassign it)
-                moved = client.issue(issue_key, fields="project")
-                new_key = moved["key"]
-
-                if ctx.obj["quiet"]:
-                    print(new_key)
-                elif ctx.obj["json"]:
-                    format_output(
-                        {
-                            "old_key": issue_key,
-                            "new_key": new_key,
-                            "project": target_project.upper(),
-                            "issue_type": target_type,
-                            "summary": summary,
-                        },
-                        as_json=True,
-                    )
-                else:
-                    success(f"Moved {issue_key} → {new_key}")
-                    print(f"  Project:    {target_project.upper()}")
-                    print(f"  Type:       {target_type}")
                     print(f"  Summary:    {summary}")
         elif response.status_code == 400:
             # Common: issue type not available in target project

--- a/skills/jira-communication/scripts/workflow/jira-move.py
+++ b/skills/jira-communication/scripts/workflow/jira-move.py
@@ -71,7 +71,7 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
 
       jira-move issue NRS-4301 PROJ --issue-type Task  (change type, same project)
 
-      jira-move issue NRS-4301 SRVUC --dry-run
+      jira-move issue NRS-4301 NRS --issue-type Task --dry-run
     """
     ctx.obj["client"].with_context(issue_key=issue_key)
     client = ctx.obj["client"]
@@ -97,19 +97,24 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
             error(f"{issue_key} is already type {current_type} in project {target_project}")
             sys.exit(1)
 
-        # Dry run
+        # IMPORTANT: Cross-project moves are NOT safely supported via the standard
+        # issue edit endpoint. Refuse even for --dry-run so we never preview an
+        # operation this command will not execute.
+        if not same_project:
+            error(
+                "Cross-project move is not supported safely by this command yet. "
+                "Refusing to proceed to avoid partial moves. "
+                "Use the Jira UI Move action (or implement bulk move API support)."
+            )
+            sys.exit(1)
+
+        # Dry run (same project only — cross-project moves are refused above)
         if dry_run:
             warning("DRY RUN - No changes will be made")
-            if same_project:
-                print(f"\nWould change type of {issue_key}:")
-                print(f"  Summary:  {summary}")
-                print(f"  From:     {current_type}")
-                print(f"  To:       {target_type}")
-            else:
-                print(f"\nWould move {issue_key}:")
-                print(f"  Summary:  {summary}")
-                print(f"  From:     {current_project} ({current_type})")
-                print(f"  To:       {target_project} ({target_type})")
+            print(f"\nWould change type of {issue_key}:")
+            print(f"  Summary:  {summary}")
+            print(f"  From:     {current_type}")
+            print(f"  To:       {target_type}")
             print(f"  Status:   {status}")
             return
 
@@ -119,14 +124,6 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
         # issue edit endpoint. Some Jira Server/DC versions silently ignore
         # `project` updates, which looks like success but leaves the issue in the
         # old project with a changed issue type (data corruption).
-        if not same_project:
-            error(
-                "Cross-project move is not supported safely by this command yet. "
-                "Refusing to proceed to avoid partial moves. "
-                "Use the Jira UI Move action (or implement bulk move API support)."
-            )
-            sys.exit(1)
-
         # PUT /rest/api/2/issue/{issueKey} with issuetype change (same project)
         update_fields = {"fields": {"issuetype": {"name": target_type}}}
 
@@ -151,24 +148,23 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
             if refreshed_type and refreshed_type != target_type:
                 error(f"Type verification failed: issue is type {refreshed_type} (expected {target_type})")
                 sys.exit(1)
-            if same_project:
-                # Type change within same project — key stays the same
-                if ctx.obj["quiet"]:
-                    print(issue_key)
-                elif ctx.obj["json"]:
-                    format_output(
-                        {
-                            "key": issue_key,
-                            "old_type": current_type,
-                            "new_type": target_type,
-                            "project": current_project,
-                            "summary": summary,
-                        },
-                        as_json=True,
-                    )
-                else:
-                    success(f"Changed {issue_key} type: {current_type} → {target_type}")
-                    print(f"  Summary:    {summary}")
+            # Type change within same project — key stays the same
+            if ctx.obj["quiet"]:
+                print(issue_key)
+            elif ctx.obj["json"]:
+                format_output(
+                    {
+                        "key": issue_key,
+                        "old_type": current_type,
+                        "new_type": target_type,
+                        "project": current_project,
+                        "summary": summary,
+                    },
+                    as_json=True,
+                )
+            else:
+                success(f"Changed {issue_key} type: {current_type} → {target_type}")
+                print(f"  Summary:    {summary}")
         elif response.status_code == 400:
             # Common: issue type not available in target project
             detail = response.json() if response.headers.get("content-type", "").startswith("application/json") else {}

--- a/skills/jira-communication/scripts/workflow/jira-move.py
+++ b/skills/jira-communication/scripts/workflow/jira-move.py
@@ -40,7 +40,11 @@ from lib.output import error, format_output, success, warning
 def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str | None, debug: bool):
     """Jira issue move.
 
-    Move issues between projects, preserving fields where possible.
+    Change issue type within the same project.
+
+    Cross-project moves are intentionally refused by this command because
+    they are not safely supported via the standard issue edit endpoint
+    (some Jira versions ignore project changes without error).
     """
     ctx.ensure_object(dict)
     ctx.obj["json"] = output_json
@@ -60,14 +64,10 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
 
     ISSUE_KEY: The Jira issue key to move (e.g., NRS-4301)
 
-    TARGET_PROJECT: Target project key (e.g., SRVUC). Use the same project
-    key to change issue type without moving.
+    TARGET_PROJECT: Target project key (e.g., SRVUC). Use the same project key
+    to change issue type. Cross-project moves are refused.
 
     Examples:
-
-      jira-move issue NRS-4301 SRVUC
-
-      jira-move issue NRS-4301 SRVUC --issue-type Bug
 
       jira-move issue NRS-4301 PROJ --issue-type Task  (change type, same project)
 

--- a/skills/jira-communication/scripts/workflow/jira-sprint.py
+++ b/skills/jira-communication/scripts/workflow/jira-sprint.py
@@ -72,9 +72,18 @@ def list_sprints(ctx, board_id: int, state: str | None):
         if state:
             params["state"] = state
 
-        # Use the Jira agile API
-        response = client.get(f"rest/agile/1.0/board/{board_id}/sprint", params=params)
-        sprints = response.get("values", [])
+        sprints: list[dict] = []
+        start_at = 0
+        while True:
+            page_params = dict(params)
+            page_params["startAt"] = start_at
+            response = client.get(f"rest/agile/1.0/board/{board_id}/sprint", params=page_params) or {}
+            values = response.get("values", []) or []
+            sprints.extend(values)
+            is_last = bool(response.get("isLast"))
+            if is_last or not values:
+                break
+            start_at += len(values)
 
         if ctx.obj["json"]:
             format_output(sprints, as_json=True)
@@ -181,9 +190,9 @@ def current(ctx, board_id: int):
     client = ctx.obj["client"]
 
     try:
-        # Get active sprints
-        response = client.get(f"rest/agile/1.0/board/{board_id}/sprint", params={"state": "active"})
-        sprints = response.get("values", [])
+        # Get active sprints (first page is enough for "current")
+        response = client.get(f"rest/agile/1.0/board/{board_id}/sprint", params={"state": "active"}) or {}
+        sprints = response.get("values", []) or []
 
         if not sprints:
             print(f"No active sprint for board {board_id}")

--- a/tests/test_attachment_security.py
+++ b/tests/test_attachment_security.py
@@ -3,6 +3,9 @@
 import importlib.util
 import sys
 from pathlib import Path
+from unittest import mock
+
+import click.testing
 
 # Add scripts to path for lib imports
 _test_dir = Path(__file__).parent
@@ -125,3 +128,54 @@ class TestValidateOutputPath:
         # The output path resolves to sibling dir — must be rejected
         result = jira_attachment.validate_output_path(str(payload), str(tmp_path))
         assert result is None
+
+
+class TestAttachmentUploadMimeType:
+    def test_add_sets_mime_type_and_timeout(self, tmp_path):
+        fpath = tmp_path / "report.pdf"
+        fpath.write_bytes(b"%PDF-1.4\n")
+
+        mc = mock.Mock()
+        mc.url = "https://jira.example.com"
+        mc.with_context = mock.Mock()
+
+        response = mock.Mock()
+        response.raise_for_status = mock.Mock()
+        response.json.return_value = [{"id": "123"}]
+        mc._session.post.return_value = response
+
+        runner = click.testing.CliRunner()
+        with mock.patch.object(jira_attachment, "LazyJiraClient", return_value=mc):
+            result = runner.invoke(jira_attachment.cli, ["--json", "add", "TEST-1", str(fpath)])
+        assert result.exit_code == 0, result.output
+
+        mc._session.post.assert_called_once()
+        _, kwargs = mc._session.post.call_args
+        files = kwargs["files"]
+        assert "file" in files
+        name, _fh, mime = files["file"]
+        assert name == "report.pdf"
+        assert mime == "application/pdf"
+        assert kwargs.get("timeout") == jira_attachment.JIRA_TIMEOUT
+
+    def test_add_falls_back_to_octet_stream(self, tmp_path):
+        fpath = tmp_path / "blob.unknownext"
+        fpath.write_bytes(b"data")
+
+        mc = mock.Mock()
+        mc.url = "https://jira.example.com"
+        mc.with_context = mock.Mock()
+
+        response = mock.Mock()
+        response.raise_for_status = mock.Mock()
+        response.json.return_value = [{"id": "123"}]
+        mc._session.post.return_value = response
+
+        runner = click.testing.CliRunner()
+        with mock.patch.object(jira_attachment, "LazyJiraClient", return_value=mc):
+            result = runner.invoke(jira_attachment.cli, ["--json", "add", "TEST-1", str(fpath)])
+        assert result.exit_code == 0, result.output
+
+        _, kwargs = mc._session.post.call_args
+        _name, _fh, mime = kwargs["files"]["file"]
+        assert mime == "application/octet-stream"

--- a/tests/test_attachment_security.py
+++ b/tests/test_attachment_security.py
@@ -156,7 +156,8 @@ class TestAttachmentUploadMimeType:
         name, _fh, mime = files["file"]
         assert name == "report.pdf"
         assert mime == "application/pdf"
-        assert kwargs.get("timeout") == jira_attachment.JIRA_TIMEOUT
+        assert kwargs.get("timeout") == jira_attachment.UPLOAD_TIMEOUT
+        assert kwargs.get("headers", {}).get("X-Atlassian-Token") == "nocheck"
 
     def test_add_falls_back_to_octet_stream(self, tmp_path):
         fpath = tmp_path / "blob.unknownext"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -319,6 +319,32 @@ class TestMockedCommands:
         assert "total: 234" in result.output
         assert "--start-at" in result.output
 
+    def test_search_query_warns_when_capped_and_more_pages_exist(self):
+        """If server caps page size below requested and more results exist, warn on stderr."""
+        mock_client = self._make_mock_client()
+        mock_client.jql.return_value = {
+            "issues": [{"key": "A-1"}],
+            "total": 100,
+        }
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_search_mod.cli, ["query", "project=A", "--max-results", "50", "--start-at", "0"])
+        assert result.exit_code == 0, result.output
+        assert "Server capped results" in result.output
+
+    def test_search_query_does_not_warn_on_final_page(self):
+        """Don't warn when fewer results is explained by being on the final page."""
+        mock_client = self._make_mock_client()
+        mock_client.jql.return_value = {
+            "issues": [{"key": "A-99"}],
+            "total": 100,
+        }
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_search_mod.cli, ["query", "project=A", "--max-results", "50", "--start-at", "99"])
+        assert result.exit_code == 0, result.output
+        assert "Server capped results" not in result.output
+
     def test_create_issue_dry_run(self):
         """jira-create issue with --dry-run must not call API."""
         mock_client = self._make_mock_client()
@@ -420,6 +446,59 @@ class TestMockedCommands:
         assert isatty_pos != -1, "isatty() guard missing from add command"
         assert read_pos != -1, "stdin.read() missing from add command"
         assert isatty_pos < read_pos, "isatty() guard must come before stdin.read()"
+
+    def test_comment_list_rejects_negative_limit(self):
+        """jira-comment list --limit -1 must be rejected by Click before API calls."""
+        mc = self._make_mock_client()
+        mc.issue = mock.Mock()
+        result, mc = self._run_comment_cmd(["list", "PROJ-123", "--limit", "-1"], mock_client=mc)
+        assert result.exit_code != 0
+        mc.issue.assert_not_called()
+
+    def test_comment_list_header_shows_total_when_limited(self):
+        """jira-comment list must show 'N of M' when Jira reports more than shown."""
+        mc = self._make_mock_client()
+        mc.issue.return_value = {
+            "fields": {
+                "comment": {
+                    "comments": [
+                        {
+                            "id": "1",
+                            "author": {"displayName": "A"},
+                            "created": "2026-01-01T00:00:00.000+0000",
+                            "body": "a",
+                        },
+                        {
+                            "id": "2",
+                            "author": {"displayName": "B"},
+                            "created": "2026-01-02T00:00:00.000+0000",
+                            "body": "b",
+                        },
+                    ],
+                    "total": 5,
+                }
+            }
+        }
+        result, mc = self._run_comment_cmd(["list", "PROJ-123", "--limit", "2"], mock_client=mc)
+        assert result.exit_code == 0, result.output
+        assert "2 of 5 shown" in result.output
+
+    def test_comment_list_limit_zero_uses_paginated_endpoint(self):
+        """jira-comment list --limit 0 should paginate via /issue/{key}/comment."""
+        mc = self._make_mock_client()
+        mc.issue = mock.Mock()
+        mc.get = mock.Mock()
+        mc.get.side_effect = [
+            {"comments": [{"id": "1"}, {"id": "2"}], "total": 3},
+            {"comments": [{"id": "3"}], "total": 3},
+        ]
+        result, mc = self._run_comment_cmd(["--json", "list", "PROJ-123", "--limit", "0"], mock_client=mc)
+        assert result.exit_code == 0, result.output
+        # issue endpoint should not be used in this mode
+        mc.issue.assert_not_called()
+        assert mc.get.call_count == 2
+        first_call = mc.get.call_args_list[0]
+        assert "rest/api/2/issue/PROJ-123/comment" in first_call.args[0]
 
     def test_comment_add_stdin_oversized_fails(self):
         """stdin input exceeding size limit must fail."""

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -46,6 +46,7 @@ _weblink_mod = _load_script("jira-weblink", "utility")
 _watchers_mod = _load_script("jira-watchers", "utility")
 _version_mod = _load_script("jira-version", "workflow")
 _qa_gather_mod = _load_script("jira-qa-gather", "utility")
+_move_mod = _load_script("jira-move", "workflow")
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -554,6 +555,95 @@ class TestMockedCommands:
         _, kwargs = mock_client.get.call_args
         params = kwargs.get("params", {})
         assert params.get("name") == "Lithium"
+
+    def test_board_list_paginates_until_last_page(self):
+        """jira-board list must follow agile pagination when isLast is false."""
+        mock_client = self._make_mock_client()
+        mock_client.get.side_effect = [
+            {"values": [{"id": 1, "name": "A", "type": "scrum", "location": {"projectKey": "P"}}], "isLast": False},
+            {"values": [{"id": 2, "name": "B", "type": "kanban", "location": {"projectKey": "P"}}], "isLast": True},
+        ]
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_board_mod.cli, ["list"])
+        assert result.exit_code == 0, result.output
+        assert mock_client.get.call_count == 2
+        starts = [call.kwargs.get("params", {}).get("startAt") for call in mock_client.get.call_args_list]
+        assert starts == [0, 1]
+
+    def test_sprint_list_paginates_until_last_page(self):
+        """jira-sprint list must follow agile pagination when isLast is false."""
+        mock_client = self._make_mock_client()
+        mock_client.get.side_effect = [
+            {"values": [{"id": 10, "name": "S1", "state": "closed"}], "isLast": False},
+            {"values": [{"id": 11, "name": "S2", "state": "active"}], "isLast": True},
+        ]
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_sprint_mod.cli, ["list", "42"])
+        assert result.exit_code == 0, result.output
+        assert mock_client.get.call_count == 2
+        paths = [call.args[0] for call in mock_client.get.call_args_list]
+        assert all("rest/agile/1.0/board/42/sprint" in p for p in paths)
+        starts = [call.kwargs.get("params", {}).get("startAt") for call in mock_client.get.call_args_list]
+        assert starts == [0, 1]
+
+    def test_issue_update_add_labels_splits_commas_and_dedupes_casefold(self):
+        """--add-label should accept comma-separated tokens and avoid case-duplicates."""
+        mock_client = self._make_mock_client()
+        mock_client.issue.return_value = {"fields": {"labels": ["Foo", "bar"]}}
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _issue_mod.cli,
+                ["update", "TEST-1", "--add-label", "foo,Baz", "--add-label", "baz"],
+            )
+        assert result.exit_code == 0, result.output
+        mock_client.update_issue_field.assert_called_once()
+        args, _kwargs = mock_client.update_issue_field.call_args
+        assert args[0] == "TEST-1"
+        payload = args[1]
+        assert payload["labels"] == ["bar", "Baz", "Foo"]
+
+    def test_issue_update_remove_labels_matches_case_insensitively(self):
+        mock_client = self._make_mock_client()
+        mock_client.issue.return_value = {"fields": {"labels": ["Foo", "BAR"]}}
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_issue_mod.cli, ["update", "TEST-1", "--remove-label", "foo,bar"])
+        assert result.exit_code == 0, result.output
+        mock_client.update_issue_field.assert_called_once()
+        args, _kwargs = mock_client.update_issue_field.call_args
+        assert args[1]["labels"] == []
+
+    def test_issue_update_rejects_labels_with_incremental_flags(self):
+        mock_client = self._make_mock_client()
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _issue_mod.cli,
+                ["update", "TEST-1", "--labels", "a,b", "--add-label", "c"],
+            )
+        assert result.exit_code != 0
+        mock_client.issue.assert_not_called()
+        mock_client.update_issue_field.assert_not_called()
+
+    def test_move_issue_cross_project_refused_even_for_dry_run(self):
+        mock_client = self._make_mock_client()
+        mock_client.issue.return_value = {
+            "fields": {
+                "summary": "Hi",
+                "issuetype": {"name": "Task"},
+                "status": {"name": "Open"},
+                "project": {"key": "SRC"},
+            }
+        }
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_move_mod.cli, ["issue", "SRC-1", "DST", "--dry-run"])
+        assert result.exit_code != 0
+        mock_client.issue.assert_called_once()
+        mock_client._session.put.assert_not_called()
 
     def test_issue_get_json_compact_by_default(self):
         """jira-issue --json get must strip null/empty fields by default."""


### PR DESCRIPTION
## Summary
- Fix #84: Upload attachments with explicit Content-Type so Jira stores `mimeType` and browser/UI previews work.
- Fix #86: Remove silent truncation by paginating agile board/sprint listing, surfacing comment totals (and `--limit 0` for all), and warning when `jira-search --max-results` is capped server-side.
- Fix #89: Add safer `jira-issue update --add-label/--remove-label` options to avoid accidental label replacement.
- Fix #90: Centralize JQL escaping and apply it to `jira-qa-gather` sibling search.
- Fix #85: Refuse unsafe cross-project moves; verify same-project issue-type changes actually applied.

## Notes
- This PR supersedes #101 (which had review threads resolved, but got stuck after a history rewrite needed to satisfy DCO).

## Test plan
- [x] `python -m pytest -q`
- [ ] Manual (Jira Server/DC): `jira-attachment add KEY file.pdf` -> attachment shows `mimeType=application/pdf` via REST and renders inline
- [ ] Manual: `jira-comment list KEY` shows "N of M" when limited; `--limit 0` paginates
- [ ] Manual: `jira-board list` and `jira-sprint list` return full set beyond 50 when applicable
- [ ] Manual: `jira-issue update KEY --add-label foo` preserves existing labels
- [ ] Manual: `jira-move issue KEY OTHERPROJ` errors clearly; `jira-move issue KEY SAMEPROJ --issue-type ...` succeeds