### PR TITLE
feat(jira-syntax): catch {} inside {{...}} + document cross-project ref convention

### DIFF
--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -81,7 +81,7 @@ ${CLAUDE_SKILL_DIR}/scripts/validate-jira-syntax.sh path/to/content.txt
 ## References
 
 - `references/jira-syntax-quick-reference.md` - Complete syntax documentation
-- `references/cross-project-refs.md` - GitLab cross-project ref convention (`project!N`, `project#N`, `project@tag`) when linking to GitLab from Jira
+- `references/cross-project-refs.md` - GitLab cross-project ref convention (`group/project!N`, `group/project#N`, `group/project@tag`) when linking to GitLab from Jira
 - `templates/bug-report-template.md` - Bug report template
 - `templates/feature-request-template.md` - Feature request template
 - `${CLAUDE_SKILL_DIR}/scripts/validate-jira-syntax.sh` - Automated syntax checker

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -81,6 +81,7 @@ ${CLAUDE_SKILL_DIR}/scripts/validate-jira-syntax.sh path/to/content.txt
 ## References
 
 - `references/jira-syntax-quick-reference.md` - Complete syntax documentation
+- `references/cross-project-refs.md` - GitLab cross-project ref convention (`project!N`, `project#N`, `project@tag`) when linking to GitLab from Jira
 - `templates/bug-report-template.md` - Bug report template
 - `templates/feature-request-template.md` - Feature request template
 - `${CLAUDE_SKILL_DIR}/scripts/validate-jira-syntax.sh` - Automated syntax checker

--- a/skills/jira-syntax/references/cross-project-refs.md
+++ b/skills/jira-syntax/references/cross-project-refs.md
@@ -1,0 +1,40 @@
+# Cross-Project References to GitLab Resources
+
+When referencing GitLab merge requests, issues, tags, or commits **from a Jira description, comment, or worklog**, prefer the GitLab cross-project autolink syntax — even though Jira itself doesn't autolink GitLab paths, the cross-project form removes ambiguity for human readers and matches the convention used in GitLab itself.
+
+## Convention
+
+| GitLab resource | Short form (single-project context) | Cross-project form (use this in Jira) |
+|---|---|---|
+| Merge request | `!42` | `group/project!42` |
+| Issue | `#123` | `group/project#123` |
+| Tag / commit / branch | `vX.Y.Z` | `group/project@vX.Y.Z` |
+
+The same prefix characters (`!`, `#`, `@`) are what GitLab itself recognises for cross-project autolinks in markdown, commit messages, and MR descriptions — so a reader who pastes the reference into a GitLab UI will get a working link automatically.
+
+## In Jira wiki markup
+
+Wrap the cross-project text inside the standard Jira link syntax `[text|url]`:
+
+```
+[jira/jira!25|https://git.netresearch.de/jira/jira/-/merge_requests/25]
+[jira/jira@v9.12.3-2|https://git.netresearch.de/jira/jira/-/tags/v9.12.3-2]
+[jira/jira#42|https://git.netresearch.de/jira/jira/-/issues/42]
+```
+
+## Why not just `!25`?
+
+A bare `!25` in a Jira issue forces the reader to guess which GitLab project it lives in — and to *click* to find out. A bare `v9.12.3-2` is even worse: tag names are reused across many repos.
+
+When an issue references multiple repos in the same group (e.g. `jira/jira` for the image build and `jira/app` for the deploy stack), the cross-project form is essential — `!3` could be either repo's MR.
+
+## Inside `{{...}}` monospace
+
+`!`, `#`, and `@` all work inside `{{...}}`, but **literal `{` and `}` inside a `{{...}}` block break Jira's parser** and render the whole block as raw text. If a reference contains brace expansion or set notation, split it:
+
+```
+✗ {{compose.example.{yml,override.pga.yml}}}
+✓ {{compose.example.yml}} and {{compose.example.override.pga.yml}}
+```
+
+The `validate-jira-syntax.sh` script catches this collision.

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -81,6 +81,17 @@ validate_file() {
         warning "Found Markdown inline code (\`code\`). Consider Jira format: {{code}}"
     fi
 
+    # Check for literal { or } inside {{...}} monospace blocks. The Jira parser
+    # is greedy and breaks on inner braces, rendering the block as raw text
+    # (e.g. {{compose.example.{yml,override.pga.yml}}} renders verbatim).
+    # Pattern: an opening {{, followed by content containing { or } (other than
+    # the closing }}), followed by }}. Skip the trivial {{}} case.
+    if grep -qE '\{\{[^}]*[{][^}]*\}\}|\{\{[^{]*\}[^{]*\}\}' <<< "$content"; then
+        error "Found literal { or } inside {{...}} monospace block — Jira parser will render it as raw text. Split the reference or escape the braces."
+        echo "   Examples found:"
+        grep -oE '\{\{[^}]*[{][^}]*\}\}|\{\{[^{]*\}[^{]*\}\}' <<< "$content" | head -3
+    fi
+
     # Check for Markdown-style links ([text](url) instead of [text|url])
     if echo "$content" | grep -qE "\[([^\]]+)\]\(([^)]+)\)"; then
         error "Found Markdown-style links ([text](url)). Use Jira format: [text|url]"

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -84,12 +84,16 @@ validate_file() {
     # Check for literal { or } inside {{...}} monospace blocks. The Jira parser
     # is greedy and breaks on inner braces, rendering the block as raw text
     # (e.g. {{compose.example.{yml,override.pga.yml}}} renders verbatim).
-    # Pattern: an opening {{, followed by content containing { or } (other than
-    # the closing }}), followed by }}. Skip the trivial {{}} case.
-    if grep -qE '\{\{[^}]*[{][^}]*\}\}|\{\{[^{]*\}[^{]*\}\}' <<< "$content"; then
+    # Two failure modes:
+    #   1. {{ followed by another { before any } — e.g. {{path/{a,b}.txt}}
+    #      or {{a{b}c}}.
+    #   2. A {{ block with an extra } before the closing }} — e.g. {{a}b}}.
+    # ERE alternation: the first branch catches mode 1 robustly without needing
+    # to span the closing }}; the second branch catches mode 2.
+    if grep -qE '\{\{[^}]*\{|\{\{[^{]*\}[^{]*\}\}' <<< "$content"; then
         error "Found literal { or } inside {{...}} monospace block — Jira parser will render it as raw text. Split the reference or escape the braces."
-        echo "   Examples found:"
-        grep -oE '\{\{[^}]*[{][^}]*\}\}|\{\{[^{]*\}[^{]*\}\}' <<< "$content" | head -3
+        echo "   Lines with issue:"
+        grep -nE '\{\{[^}]*\{|\{\{[^{]*\}[^{]*\}\}' <<< "$content" | head -3
     fi
 
     # Check for Markdown-style links ([text](url) instead of [text|url])


### PR DESCRIPTION
Two related improvements surfaced from a session retrospective on a real Jira ticket ([NRS-4415](https://jira.netresearch.de/browse/NRS-4415)):

## 1. Validator: detect literal `{` or `}` inside `{{...}}`

Jira's parser is greedy on `}}` and renders the whole block as raw text when the inner content contains braces — `{{compose.example.{yml,override.pga.yml}}}` literally appeared verbatim in a real ticket. The new check catches this:

```sh
$ ./validate-jira-syntax.sh bad.txt
❌ ERROR: Found literal { or } inside {{...}} monospace block — Jira parser will render it as raw text. Split the reference or escape the braces.
   Examples found:
{{compose.example.{yml,override.pga.yml}}
```

Negative case (normal `{{...}}` blocks) stays clean.

## 2. New reference: cross-project ref convention

`references/cross-project-refs.md` documents the GitLab autolink convention:

| Resource | Cross-project form |
|---|---|
| MR | `group/project!N` |
| Issue | `group/project#N` |
| Tag / commit / ref | `group/project@tag` |

When a Jira ticket references multiple GitLab repos in the same group (e.g. `jira/jira` and `jira/app`), bare `!25` and `v9.12.3-2` are ambiguous; the cross-project form removes that ambiguity for human readers and matches what GitLab itself autolinks.

The reference also points back at the brace-collision rule for inline `{{...}}` use.

## Test plan

- [x] `validate-jira-syntax.sh` errors on the collision pattern
- [x] `validate-jira-syntax.sh` stays clean on normal `{{normal}}` and `{{compose.yml}}`
- [x] All existing checks unaffected (re-ran the validator on the existing templates — no regression)