### PR TITLE
feat(jira-issue): add work/qa/qa-fail/act intent verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `qa KEY` — description + handover bundle (comments around the most recent INTO_QA transition, before-or-after agnostic — empirically 80% of handover comments precede the transition click)
   - `qa-fail KEY` — description + reviewer rejection comment + implementer scope/clarification context from the same QA window
   - `act KEY` — meta + available transitions (one call before transitioning, replaces meta-fetch + transition-list)
-  - All verbs support `--json`, `--quiet`, `--truncate N` and the standard global flags
+  - All verbs support `--json`, `--quiet` and the standard global flags; `work`, `qa`, `qa-fail` also support `--truncate N` (act has no body to truncate)
   - Status-set classification configurable per profile via `qa_status_names` / `working_status_names` / `resolved_status_names` (or env vars). Defaults cover common single-stage and multi-stage QA workflows. Multi-stage progressions (`QA→QA2`, `Review→UAT`, `QA→Acceptance`) are correctly classified as forward, not as fail.
   - SKILL.md `## Auto-Trigger` rewritten as an intent-routing table; `references/intent-verbs.md` documents the heuristics, status sets, and configuration.
 - `lib/changelog.py`: `extract_status_transitions_with_authors()`, `classify_transition()`, `find_transition_window()` helpers used by the intent verbs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- `jira-link create`: success message and `--dry-run` preview now print the link in natural language using the link type's *outward* verb fetched from `get_issue_link_types()`. `create FROM TO --type X` POSTs `{outwardIssue: FROM, inwardIssue: TO}` — per Atlassian's convention `TO` is the source/active actor, so the new output is `Created: <to> <outward verb> <from> (link-type: <name>)` (e.g. `Created: ROOT-2 causes EFFECT-1`). The previous `Created link: FROM --[type]--> TO` arrow read in the opposite direction and led at least one agent to create ~30 backwards Jira links. Dry-run now errors out if the link type cannot be resolved instead of degrading to the misleading arrow form. Technically a behavior change but no known parser depended on the arrow format.
-- `references/links.md`: the link-direction table and prose were rewritten — the previous `Outward (PROJ-A → PROJ-B)` header implied `FROM` was the active party. The doc now leads with a clear DIRECTION RULE callout, agent/patient mnemonic, three worked examples (Blockade, Cause, Side effect) showing both endpoints' Jira-UI display, and a cross-link to the `netresearch-jira` skill's `linking-conventions.md` as a real-world reference.
-
 ### Added
 
+- `jira-issue work / qa / qa-fail / act`: four single-call intent verbs that compose existing API endpoints (issue + comments + changelog + remote_links + transitions) into the right bundle for one specific intent — replacing the common `jira-issue get` + `jira-comment list` 2-call (or worse, with shell-side filtering, 5–6-call) pattern.
+  - `work KEY` — description + all comments + attachments + links (use when starting work on a ticket)
+  - `qa KEY` — description + handover bundle (comments around the most recent INTO_QA transition, before-or-after agnostic — empirically 80% of handover comments precede the transition click)
+  - `qa-fail KEY` — description + reviewer rejection comment + implementer scope/clarification context from the same QA window
+  - `act KEY` — meta + available transitions (one call before transitioning, replaces meta-fetch + transition-list)
+  - All verbs support `--json`, `--quiet`, `--truncate N` and the standard global flags
+  - Status-set classification configurable per profile via `qa_status_names` / `working_status_names` / `resolved_status_names` (or env vars). Defaults cover common single-stage and multi-stage QA workflows. Multi-stage progressions (`QA→QA2`, `Review→UAT`, `QA→Acceptance`) are correctly classified as forward, not as fail.
+  - SKILL.md `## Auto-Trigger` rewritten as an intent-routing table; `references/intent-verbs.md` documents the heuristics, status sets, and configuration.
+- `lib/changelog.py`: `extract_status_transitions_with_authors()`, `classify_transition()`, `find_transition_window()` helpers used by the intent verbs.
+- `lib/config.py`: `load_status_sets(profile=...)` resolves the three status sets from profile fields, env vars, or built-in defaults.
 - `jira-link create`: `--source` / `--target` named aliases for `FROM_KEY` / `TO_KEY`. `--source S --target T --type X` is equivalent to `create T S --type X`. Mixing positional with named forms is rejected. The named form is recommended when the direction matters (it always does) so the call-site reads as English instead of relying on positional convention.
 - `jira-link bulk-create`: read a CSV (`--from-csv PATH`, or `-` for stdin) with header `from,to,type` and create one link per row, mirroring the same direction convention as `create` ("TO does X to FROM"). `--dry-run` previews each resolved sentence without POSTing. `--skip-existing` checks the FROM ticket's `issuelinks` and skips rows where a link of the same type already connects FROM and TO (either direction) — useful because Jira Server is not idempotent on link creation. `--abort-on-error` (default) halts on the first failed row; `--continue-on-error` logs and keeps going. Per-row output uses `[N/M]` indices, ends with a `created: K, skipped: S, failed: F` summary, and the `--json` mode emits one JSON object per line plus a final `summary: true` object (JSONL). Link types are resolved once via a single `get_issue_link_types()` call regardless of how many rows reference them.
 - `jira-link bulk-delete`: delete many issue links by ID, either from a comma-separated `--ids` list or a file (`--ids-file PATH`, `-` for stdin). Each ID is fetched first so per-row output shows the affected issues (`[101] TEST-2 ↔ TEST-1 (Blocks)`). Same `--dry-run`, `--abort-on-error / --continue-on-error`, and JSONL summary semantics as `bulk-create`.

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -16,20 +16,18 @@ CLI scripts via `uv run`. All support `--help`, `--json`, `--quiet`, `--debug`.
 
 ## Auto-Trigger
 
-On Jira URL or issue key (PROJ-123), pick by **intent** — each is a single call:
+On Jira URL or issue key (PROJ-123), pick by **intent** — each is one call:
 
-| Intent / phrase | Tool |
+| Intent | Tool |
 |---|---|
-| "schau dir X an" / "lies X" / triage / work on a ticket | `jira-issue.py work KEY` |
-| "QA für X starten" / "review X" | `jira-issue.py qa KEY` |
-| "warum failed X" / "QA fail follow-up" | `jira-issue.py qa-fail KEY` |
-| "wer ist Assignee" / "welche Priority" / field-only | `jira-issue.py get KEY --fields ...` |
-| "status auf Y ändern" / "transition X" | `jira-issue.py act KEY` → `jira-transition.py do` |
-| comprehensive audit, sibling discovery | `jira-qa-gather.py KEY` |
+| triage / work on ticket | `jira-issue.py work KEY` |
+| start QA review | `jira-issue.py qa KEY` |
+| QA-fail follow-up | `jira-issue.py qa-fail KEY` |
+| field-only lookup | `jira-issue.py get KEY --fields ...` |
+| change status | `jira-issue.py act KEY` → `jira-transition.py do` |
+| audit / sibling discovery | `jira-qa-gather.py KEY` |
 
-Auth issues → `jira-setup.py`.
-
-**Anti-pattern:** `jira-issue get` followed by `jira-comment list` for the same key. Use the matching intent verb instead — single call, right bundle. See `references/intent-verbs.md`.
+Auth issues → `jira-setup.py`. **Anti-pattern:** `get` + `comment list` for the same key — use the matching verb. See `references/intent-verbs.md`.
 
 ## Scripts
 
@@ -62,22 +60,21 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screensh
 
 ## References
 
-- `references/jql-quick-reference.md` — when JQL goes beyond simple filters
-- `references/jql-cookbook.md` — when translating natural-language requests into JQL
-- `references/multi-profile.md` — when using multiple Jira instances or `--profile`
-- `references/troubleshooting.md` — when hitting auth, SSL, 401, 403, or connection failures
-- `references/issue-editing.md` — when using `--fields-json`, reporter changes, deletes, or moves
-- `references/creation.md` — when creating with `--parent`, reporter, components, or custom fields
-- `references/comments.md` — when editing, deleting, or listing comments
-- `references/worklog.md` — when using `--started`, date ranges, or `jira-worklog-query.py`
-- `references/attachments.md` — when uploading, downloading, or inspecting attachments
-- `references/links.md` — when working with issue or web links
-- `references/agile.md` — when working with sprints, boards, or `board --name`
-- `references/fields-and-users.md` — when looking up custom field IDs, users, or issue types
-- `references/watchers.md` — when the user asks to watch, subscribe, notify on, or list watchers of an issue
-- `references/versions.md` — when the user asks about fix/affects versions, releases, or version CRUD
-- `references/qa-gather.md` — when reviewing tickets in QA / "ready for review", or when a peer-review style runbook needs single-call context discovery
-- `references/intent-verbs.md` — when using `jira-issue.py work / qa / qa-fail / act` (single-call intent bundles); covers the QA-handover heuristic and the qa/working/resolved status-set configuration
+- `references/jql-quick-reference.md`, `references/jql-cookbook.md` — JQL beyond simple filters
+- `references/multi-profile.md` — multiple Jira instances, `--profile`
+- `references/troubleshooting.md` — auth, SSL, 401, 403, connection
+- `references/issue-editing.md` — `--fields-json`, reporter, deletes, moves
+- `references/creation.md` — `--parent`, components, custom fields
+- `references/comments.md` — edit, delete, list comments
+- `references/worklog.md` — `--started`, date ranges, `jira-worklog-query.py`
+- `references/attachments.md` — upload, download, inspect attachments
+- `references/links.md` — issue and web links
+- `references/agile.md` — sprints, boards, `board --name`
+- `references/fields-and-users.md` — custom field IDs, users, issue types
+- `references/watchers.md` — watch, subscribe, list watchers
+- `references/versions.md` — fix/affects versions, releases, version CRUD
+- `references/qa-gather.md` — comprehensive audit bundle (siblings, prose URLs)
+- `references/intent-verbs.md` — `work / qa / qa-fail / act`: heuristic + status-set config
 
 ## Authentication
 

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -16,7 +16,20 @@ CLI scripts via `uv run`. All support `--help`, `--json`, `--quiet`, `--debug`.
 
 ## Auto-Trigger
 
-On Jira URL or issue key (PROJ-123) → run `jira-issue.py get`. Auth issues → `jira-setup.py`.
+On Jira URL or issue key (PROJ-123), pick by **intent** — each is a single call:
+
+| Intent / phrase | Tool |
+|---|---|
+| "schau dir X an" / "lies X" / triage / work on a ticket | `jira-issue.py work KEY` |
+| "QA für X starten" / "review X" | `jira-issue.py qa KEY` |
+| "warum failed X" / "QA fail follow-up" | `jira-issue.py qa-fail KEY` |
+| "wer ist Assignee" / "welche Priority" / field-only | `jira-issue.py get KEY --fields ...` |
+| "status auf Y ändern" / "transition X" | `jira-issue.py act KEY` → `jira-transition.py do` |
+| comprehensive audit, sibling discovery | `jira-qa-gather.py KEY` |
+
+Auth issues → `jira-setup.py`.
+
+**Anti-pattern:** `jira-issue get` followed by `jira-comment list` for the same key. Use the matching intent verb instead — single call, right bundle. See `references/intent-verbs.md`.
 
 ## Scripts
 
@@ -64,6 +77,7 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screensh
 - `references/watchers.md` — when the user asks to watch, subscribe, notify on, or list watchers of an issue
 - `references/versions.md` — when the user asks about fix/affects versions, releases, or version CRUD
 - `references/qa-gather.md` — when reviewing tickets in QA / "ready for review", or when a peer-review style runbook needs single-call context discovery
+- `references/intent-verbs.md` — when using `jira-issue.py work / qa / qa-fail / act` (single-call intent bundles); covers the QA-handover heuristic and the qa/working/resolved status-set configuration
 
 ## Authentication
 

--- a/skills/jira-communication/references/intent-verbs.md
+++ b/skills/jira-communication/references/intent-verbs.md
@@ -15,7 +15,7 @@ jira-issue.py qa-fail KEY   # description + reviewer rejection + implementer sco
 jira-issue.py act     KEY   # meta + available transitions
 ```
 
-`jira-issue.py get KEY` stays minimal (meta only) — backwards compatible.
+`jira-issue.py get KEY` is unchanged — it still prints the full issue (description, attachments, links) by default. Use `--fields summary,status,assignee,…` for a meta-only lookup.
 
 ## QA-handover heuristic (`qa` verb)
 
@@ -94,7 +94,7 @@ All verbs support the standard global flags:
 - `--json` Structured payload (`comments` is always a list of comment dicts; verb-specific keys like `reject_transition`, `handover_transition`, `implementer` for context)
 - `--quiet` Issue key only (after successful fetch — validates connectivity)
 
-Each verb also has `--truncate N` to cap description and per-comment body length.
+`work`, `qa`, `qa-fail` also accept `--truncate N` to cap description and per-comment body length. `act` has no body content so the flag is omitted there.
 
 ## Example: NRS-4412-style QA-fail follow-up
 

--- a/skills/jira-communication/references/intent-verbs.md
+++ b/skills/jira-communication/references/intent-verbs.md
@@ -1,0 +1,111 @@
+# Intent verbs
+
+`jira-issue.py work / qa / qa-fail / act` — single-call context bundles for the four common intents.
+
+## When to load
+
+Whenever you have a Jira issue key and need more than just meta. Each verb composes the right bundle for one intent. Empirically replaces 3–6 separate calls.
+
+## The four verbs
+
+```bash
+jira-issue.py work    KEY   # description + all comments + attachments + links
+jira-issue.py qa      KEY   # description + handover bundle (comments around INTO_QA transition)
+jira-issue.py qa-fail KEY   # description + reviewer rejection + implementer scope context
+jira-issue.py act     KEY   # meta + available transitions
+```
+
+`jira-issue.py get KEY` stays minimal (meta only) — backwards compatible.
+
+## QA-handover heuristic (`qa` verb)
+
+The handover comment is *not* always written after the transition. Empirical sample (10 tickets, 41 transitions): 80% of handover comments come **before** the transition click.
+
+The verb finds the most recent INTO_QA transition (by classification, see below) and includes:
+
+1. All comments by the **transition author** in `[T_prev, min(T_next, T_transition + 1h)]` — captures the handover whether written before or after the click. `T_prev` and `T_next` bracket the transition between adjacent status changes.
+2. All comments by **any author** in `[T_transition, T_next)` — the QA discussion that follows.
+
+Deduplicated, chronologically sorted. Fallback if no INTO_QA in changelog: last 5 comments + warning.
+
+## QA-fail heuristic (`qa-fail` verb)
+
+Symmetric to `qa`:
+
+1. Find the most recent **REJECT** transition.
+2. Include all comments by the **reviewer** (transition author) in `[T_prev_into_qa, T_transition + 1h]`.
+3. Include all comments by **any author** in `[T_transition, T_next)`.
+4. Include all comments by the **implementer** (= author of the most recent INTO_QA before the reject) in `[T_prev_into_qa - 1h, T_transition]` — this captures the implementer's scope/clarification context that the rejection is reacting to. The 1h backward extension catches handover comments written just before the INTO_QA click.
+
+Fallback if no REJECT in changelog: last 5 comments + warning.
+
+## Status-set classification
+
+Transitions are classified using three configurable status sets:
+
+| Set | Default | Meaning |
+|---|---|---|
+| `qa_status_names` | `QA, Review, In Review, Code Review, Ready for QA, QA2, UAT, Acceptance, Testing` | Where the work goes for review |
+| `working_status_names` | `In Progress, Open, Reopened, To Do, In Development, Backlog, QA failed` | Where rejected work lands. **Note:** `QA failed` is in this set, not `qa`, because it's functionally a reject-target (review verdict: send back to dev), not a review stage. |
+| `resolved_status_names` | `Closed, Resolved, Done, Won't Fix, Cancelled` | Terminal states |
+
+A transition is classified as:
+
+- `into_qa` — `from ∉ qa AND to ∈ qa` (handover)
+- `reject` — `from ∈ qa AND to ∈ working` (fail)
+- `forward` — `from ∈ qa AND to ∈ qa AND from ≠ to` (multi-stage progression: `QA→QA2`, `Review→UAT`, `QA→Acceptance` — **NOT** a fail)
+- `resolved` — `to ∈ resolved`
+- `out` — `from ∈ qa AND to ∉ qa` (uncategorised QA exit)
+- `other` — neither side touches QA
+
+Forward-progression detection is what lets a multi-stage QA workflow (Review → UAT → Acceptance → Closed) work identically to a single-stage one without code changes.
+
+## Configuring status sets per Jira instance
+
+Per profile in `~/.jira/profiles.json`:
+
+```json
+{
+  "profiles": {
+    "myinstance": {
+      "url": "https://jira.example.com",
+      "token": "...",
+      "qa_status_names": ["Review", "UAT", "Acceptance"],
+      "working_status_names": ["In Progress", "Backlog", "Reject"],
+      "resolved_status_names": ["Done", "Cancelled"]
+    }
+  }
+}
+```
+
+Or via env vars (comma-separated):
+
+```bash
+JIRA_QA_STATUS_NAMES="Review,UAT,Acceptance"
+JIRA_WORKING_STATUS_NAMES="In Progress,Backlog,Reject"
+JIRA_RESOLVED_STATUS_NAMES="Done,Cancelled"
+```
+
+## Output formats
+
+All verbs support the standard global flags:
+
+- (default) Human-readable text bundle
+- `--json` Structured payload (`comments` is always a list of comment dicts; verb-specific keys like `reject_transition`, `handover_transition`, `implementer` for context)
+- `--quiet` Issue key only (after successful fetch — validates connectivity)
+
+Each verb also has `--truncate N` to cap description and per-comment body length.
+
+## Example: NRS-4412-style QA-fail follow-up
+
+The motivating case: "what did Björn reject, and what was Sebastian's scope context?"
+
+Before (6 calls): `jira-issue get`, `jira-comment list`, `jira-comment list | tail`, `jira-comment list | head`, etc.
+
+After (1 call):
+
+```bash
+jira-issue.py qa-fail NRS-4412
+```
+
+Returns: description + Sebastian's scope-setting handover comment + Björn's full AC review with rejection + Sebastian's response + subsequent resolution. Chronologically sorted, ready to read.

--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -23,12 +23,16 @@ if _lib_path.exists():
 
 import click
 from lib.changelog import (
+    classify_transition,
     compute_time_in_status,
     extract_status_transitions,
+    extract_status_transitions_with_authors,
+    find_transition_window,
     format_timedelta,
     parse_jira_datetime,
 )
 from lib.client import LazyJiraClient, _sanitize_error, resolve_assignee, resolve_status
+from lib.config import load_status_sets
 from lib.output import compact_json, error, extract_adf_text, format_output, success, warning
 
 
@@ -639,6 +643,418 @@ def delete(ctx, issue_key: str, delete_subtasks: bool, dry_run: bool):
         if ctx.obj["debug"]:
             raise
         error(f"Failed to delete {issue_key}: {_sanitize_error(str(e))}")
+        sys.exit(1)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Intent verbs: work / qa / qa-fail / act
+#
+# Each verb is a single-call composition that returns the *minimal* bundle a
+# user actually needs for one specific intent — instead of forcing them to
+# stitch together `get` + `comment list` + `transition list` themselves.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+INTENT_FIELDS = "summary,status,assignee,reporter,priority,issuetype,description,comment,attachment,issuelinks,labels,created,updated"
+
+
+def _author_matches(author: dict, key: str, name: str) -> bool:
+    """True if a comment/transition author matches by Server name or Cloud accountId."""
+    if not author:
+        return False
+    a_key = author.get("name") or author.get("accountId") or ""
+    a_name = author.get("displayName", "")
+    return bool((key and a_key == key) or (name and a_name == name))
+
+
+def _comments_in_range(comments: list, start, end, author_filter: tuple[str, str] | None = None) -> list:
+    """Filter comments by created in [start, end], optionally by author key+name."""
+    out = []
+    for c in comments:
+        try:
+            created = parse_jira_datetime(c.get("created", ""))
+        except (ValueError, TypeError):
+            continue
+        if start is not None and created < start:
+            continue
+        if end is not None and created > end:
+            continue
+        if author_filter is not None:
+            if not _author_matches(c.get("author") or {}, *author_filter):
+                continue
+        out.append(c)
+    return out
+
+
+def _dedupe_comments(comments: list) -> list:
+    """Deduplicate by comment ID, preserving order."""
+    seen: set[str] = set()
+    out: list = []
+    for c in comments:
+        cid = c.get("id", "")
+        if cid in seen:
+            continue
+        seen.add(cid)
+        out.append(c)
+    return sorted(out, key=lambda c: c.get("created", ""))
+
+
+def _collect_handover_bundle(issue: dict, status_sets: dict) -> dict:
+    """Compose the qa (handover) bundle. See PLAN-context-fetch-optimization.md."""
+    comments = (issue.get("fields", {}).get("comment") or {}).get("comments") or []
+    transitions = extract_status_transitions_with_authors(issue)
+
+    # Find the most recent INTO_QA transition
+    into_qa_indices = [i for i, t in enumerate(transitions) if classify_transition(t, status_sets) == "into_qa"]
+    if not into_qa_indices:
+        return {"fallback": True, "comments": list(reversed(comments[-5:])), "transition": None}
+
+    target_idx = into_qa_indices[-1]
+    target = transitions[target_idx]
+    t_transition = target["created"]
+    t_prev, t_next = find_transition_window(transitions, target_idx)
+    one_hour = timedelta(hours=1)
+    end_for_author = t_next or (t_transition + one_hour)
+    if t_next is None:
+        end_for_author = t_transition + one_hour
+    else:
+        end_for_author = min(t_next, t_transition + one_hour)
+
+    handover = _comments_in_range(
+        comments, t_prev, end_for_author, author_filter=(target["author_key"], target["author_name"])
+    )
+    after = _comments_in_range(comments, t_transition, t_next)
+    return {
+        "fallback": False,
+        "comments": _dedupe_comments(handover + after),
+        "transition": target,
+        "transitions": transitions,
+    }
+
+
+def _collect_reject_bundle(issue: dict, status_sets: dict) -> dict:
+    """Compose the qa-fail (reject) bundle. See PLAN-context-fetch-optimization.md."""
+    comments = (issue.get("fields", {}).get("comment") or {}).get("comments") or []
+    transitions = extract_status_transitions_with_authors(issue)
+
+    reject_indices = [i for i, t in enumerate(transitions) if classify_transition(t, status_sets) == "reject"]
+    if not reject_indices:
+        return {"fallback": True, "comments": list(reversed(comments[-5:])), "transition": None}
+
+    target_idx = reject_indices[-1]
+    target = transitions[target_idx]
+    t_transition = target["created"]
+    _, t_next = find_transition_window(transitions, target_idx)
+
+    # Find the most recent INTO_QA before the reject (= QA window start, implementer)
+    implementer = None
+    t_prev_into_qa = None
+    for i in range(target_idx - 1, -1, -1):
+        if classify_transition(transitions[i], status_sets) == "into_qa":
+            t_prev_into_qa = transitions[i]["created"]
+            implementer = (transitions[i]["author_key"], transitions[i]["author_name"])
+            break
+
+    one_hour = timedelta(hours=1)
+    reviewer_filter = (target["author_key"], target["author_name"])
+    reviewer_comments = _comments_in_range(
+        comments, t_prev_into_qa, t_transition + one_hour, author_filter=reviewer_filter
+    )
+    after = _comments_in_range(comments, t_transition, t_next)
+    impl_comments = []
+    if implementer is not None:
+        # Extend backwards by 1h to catch the implementer's handover comment when
+        # written just before the INTO_QA transition (same pre-transition pattern
+        # as the handover bundle — empirically 80% of comments precede the click).
+        impl_start = (t_prev_into_qa - one_hour) if t_prev_into_qa else None
+        impl_comments = _comments_in_range(
+            comments, impl_start, t_transition, author_filter=implementer
+        )
+    return {
+        "fallback": False,
+        "comments": _dedupe_comments(reviewer_comments + after + impl_comments),
+        "transition": target,
+        "implementer": implementer,
+        "transitions": transitions,
+    }
+
+
+def _print_comment(c: dict, *, truncate: int | None = None) -> None:
+    author = (c.get("author") or {}).get("displayName", "Unknown")
+    created = c.get("created", "")[:16].replace("T", " ")
+    body = c.get("body", "") or ""
+    if isinstance(body, dict):
+        body = extract_adf_text(body)
+    if truncate and len(body) > truncate:
+        body = body[: truncate].rsplit(" ", 1)[0] + " …[truncated]"
+    print(f"\n--- [{created}] {author} ---")
+    for line in body.split("\n"):
+        print(line)
+
+
+def _print_intent_header(issue: dict) -> None:
+    fields = issue.get("fields", {})
+    summary = fields.get("summary", "")
+    status = (fields.get("status") or {}).get("name", "")
+    assignee = (fields.get("assignee") or {}).get("displayName", "Unassigned")
+    print(f"\n{issue['key']}: {summary}")
+    print("=" * 60)
+    print(f"Status: {status} | Assignee: {assignee}")
+
+
+def _print_intent_description(issue: dict) -> None:
+    description = issue.get("fields", {}).get("description")
+    if not description:
+        return
+    if isinstance(description, dict):
+        description = extract_adf_text(description)
+    print("\nDescription:")
+    for line in str(description).split("\n"):
+        print(f"  {line}")
+
+
+def _intent_bundle_payload(issue: dict, comments: list, *, extras: dict | None = None) -> dict:
+    """Build the JSON payload for an intent verb."""
+    fields = issue.get("fields", {})
+    payload = {
+        "key": issue.get("key"),
+        "summary": fields.get("summary"),
+        "status": (fields.get("status") or {}).get("name"),
+        "assignee": (fields.get("assignee") or {}).get("displayName"),
+        "description": fields.get("description"),
+        "comments": comments,
+    }
+    if extras:
+        payload.update(extras)
+    return payload
+
+
+def _resolve_status_sets_for_ctx(ctx, issue_key: str) -> dict:
+    """Load status sets, honoring --profile when set."""
+    profile = None
+    client_obj = ctx.obj.get("client")
+    if client_obj is not None:
+        profile = getattr(client_obj, "_profile", None)
+    return load_status_sets(profile=profile)
+
+
+@cli.command()
+@click.argument("issue_key")
+@click.option("--truncate", type=int, metavar="N", help="Truncate description and each comment to N chars")
+@click.pass_context
+def work(ctx, issue_key: str, truncate: int | None):
+    """Fetch full working context: description + all comments + attachments + links.
+
+    Use when starting work on a ticket or doing triage. Single call.
+
+    Example:
+
+      jira-issue work NRS-4412
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+    try:
+        issue = client.issue(issue_key, fields=INTENT_FIELDS)
+        web_links = []
+        try:
+            web_links = client.get_issue_remote_links(issue_key)
+        except Exception:
+            if ctx.obj["debug"]:
+                raise
+            warning("Failed to fetch web links")
+        comments = (issue.get("fields", {}).get("comment") or {}).get("comments") or []
+
+        if ctx.obj["json"]:
+            issue["webLinks"] = web_links
+            payload = _intent_bundle_payload(issue, comments, extras={"webLinks": web_links})
+            format_output(payload, as_json=True)
+            return
+        if ctx.obj["quiet"]:
+            print(issue["key"])
+            return
+
+        issue["webLinks"] = web_links
+        _print_issue(issue, truncate=truncate, web_links=web_links)
+        if comments:
+            print("=" * 60)
+            print(f"COMMENTS ({len(comments)} total — chronological)")
+            print("=" * 60)
+            for c in comments:
+                _print_comment(c, truncate=truncate)
+            print()
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to fetch work context for {issue_key}: {_sanitize_error(str(e))}")
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument("issue_key")
+@click.option("--truncate", type=int, metavar="N", help="Truncate description and each comment to N chars")
+@click.pass_context
+def qa(ctx, issue_key: str, truncate: int | None):
+    """Fetch QA review context: description + handover comments since transition into QA.
+
+    Use when starting a QA review. Returns the implementer's handover comment
+    (regardless of whether written before or after the transition click) plus
+    any subsequent QA discussion.
+
+    Example:
+
+      jira-issue qa NRS-4412
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+    try:
+        issue = client.issue(issue_key, fields=INTENT_FIELDS, expand="changelog")
+        sets = _resolve_status_sets_for_ctx(ctx, issue_key)
+        bundle = _collect_handover_bundle(issue, sets)
+
+        if ctx.obj["json"]:
+            extras = {"handover_fallback": bundle["fallback"]}
+            if bundle["transition"]:
+                extras["handover_transition"] = {
+                    "created": bundle["transition"]["created"].isoformat(),
+                    "from": bundle["transition"]["from"],
+                    "to": bundle["transition"]["to"],
+                    "author": bundle["transition"]["author_name"],
+                }
+            format_output(_intent_bundle_payload(issue, bundle["comments"], extras=extras), as_json=True)
+            return
+        if ctx.obj["quiet"]:
+            print(issue["key"])
+            return
+
+        _print_intent_header(issue)
+        _print_intent_description(issue)
+        if bundle["fallback"]:
+            print("\n[no INTO-QA transition found — falling back to last 5 comments]")
+        else:
+            t = bundle["transition"]
+            print(f"\nHandover: {t['created'].isoformat()} by {t['author_name']} ({t['from']} → {t['to']})")
+        print("\n" + "=" * 60)
+        print(f"HANDOVER COMMENTS ({len(bundle['comments'])})")
+        print("=" * 60)
+        for c in bundle["comments"]:
+            _print_comment(c, truncate=truncate)
+        print()
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to fetch QA context for {issue_key}: {_sanitize_error(str(e))}")
+        sys.exit(1)
+
+
+@cli.command("qa-fail")
+@click.argument("issue_key")
+@click.option("--truncate", type=int, metavar="N", help="Truncate description and each comment to N chars")
+@click.pass_context
+def qa_fail(ctx, issue_key: str, truncate: int | None):
+    """Fetch QA-fail follow-up context: description + reviewer rejection + implementer scope.
+
+    Use when continuing work after a QA reject. Returns the reviewer's rejection
+    comment (regardless of order vs. transition), the implementer's scope/clarification
+    comments from the same QA window, and any subsequent discussion.
+
+    Example:
+
+      jira-issue qa-fail NRS-4412
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+    try:
+        issue = client.issue(issue_key, fields=INTENT_FIELDS, expand="changelog")
+        sets = _resolve_status_sets_for_ctx(ctx, issue_key)
+        bundle = _collect_reject_bundle(issue, sets)
+
+        if ctx.obj["json"]:
+            extras = {"reject_fallback": bundle["fallback"]}
+            if bundle["transition"]:
+                extras["reject_transition"] = {
+                    "created": bundle["transition"]["created"].isoformat(),
+                    "from": bundle["transition"]["from"],
+                    "to": bundle["transition"]["to"],
+                    "reviewer": bundle["transition"]["author_name"],
+                }
+            if bundle.get("implementer"):
+                extras["implementer"] = bundle["implementer"][1]
+            format_output(_intent_bundle_payload(issue, bundle["comments"], extras=extras), as_json=True)
+            return
+        if ctx.obj["quiet"]:
+            print(issue["key"])
+            return
+
+        _print_intent_header(issue)
+        _print_intent_description(issue)
+        if bundle["fallback"]:
+            print("\n[no REJECT transition found — falling back to last 5 comments]")
+        else:
+            t = bundle["transition"]
+            print(f"\nReject: {t['created'].isoformat()} by {t['author_name']} ({t['from']} → {t['to']})")
+            if bundle.get("implementer"):
+                print(f"Implementer (for scope context): {bundle['implementer'][1]}")
+        print("\n" + "=" * 60)
+        print(f"QA-FAIL COMMENTS ({len(bundle['comments'])})")
+        print("=" * 60)
+        for c in bundle["comments"]:
+            _print_comment(c, truncate=truncate)
+        print()
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to fetch QA-fail context for {issue_key}: {_sanitize_error(str(e))}")
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument("issue_key")
+@click.pass_context
+def act(ctx, issue_key: str):
+    """Fetch meta + available transitions in one call (use before changing status).
+
+    Example:
+
+      jira-issue act NRS-4412
+      jira-issue act NRS-4412 --json | jq '.transitions[].name'
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+    try:
+        issue = client.issue(issue_key, fields="summary,status,assignee,priority,issuetype")
+        try:
+            transitions = client.get_issue_transitions(issue_key) or []
+        except Exception:
+            if ctx.obj["debug"]:
+                raise
+            warning("Failed to fetch available transitions")
+            transitions = []
+
+        if ctx.obj["json"]:
+            payload = {
+                "key": issue.get("key"),
+                "summary": issue.get("fields", {}).get("summary"),
+                "status": (issue.get("fields", {}).get("status") or {}).get("name"),
+                "assignee": (issue.get("fields", {}).get("assignee") or {}).get("displayName"),
+                "transitions": [{"id": t.get("id"), "name": t.get("name") or t.get("to", {}).get("name")} for t in transitions],
+            }
+            format_output(payload, as_json=True)
+            return
+        if ctx.obj["quiet"]:
+            print(issue["key"])
+            return
+
+        _print_intent_header(issue)
+        print("\nAvailable transitions:")
+        if not transitions:
+            print("  (none)")
+        for t in transitions:
+            name = t.get("name") or (t.get("to") or {}).get("name", "?")
+            print(f"  • {name} (id={t.get('id', '?')})")
+        print()
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to fetch act context for {issue_key}: {_sanitize_error(str(e))}")
         sys.exit(1)
 
 

--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -658,7 +658,9 @@ def delete(ctx, issue_key: str, delete_subtasks: bool, dry_run: bool):
 # the first 50 comments in the embedded payload. The intent verbs fetch
 # comments separately via fetch_comments_paginated() to avoid silently
 # truncating long-running tickets.
-INTENT_FIELDS = "summary,status,assignee,reporter,priority,issuetype,description,attachment,issuelinks,labels,created,updated"
+INTENT_FIELDS = (
+    "summary,status,assignee,reporter,priority,issuetype,description,attachment,issuelinks,labels,created,updated"
+)
 
 
 def _author_matches(author: dict, key: str, name: str) -> bool:
@@ -1051,7 +1053,9 @@ def act(ctx, issue_key: str):
                 "summary": issue.get("fields", {}).get("summary"),
                 "status": (issue.get("fields", {}).get("status") or {}).get("name"),
                 "assignee": (issue.get("fields", {}).get("assignee") or {}).get("displayName"),
-                "transitions": [{"id": t.get("id"), "name": t.get("name") or t.get("to", {}).get("name")} for t in transitions],
+                "transitions": [
+                    {"id": t.get("id"), "name": t.get("name") or t.get("to", {}).get("name")} for t in transitions
+                ],
             }
             format_output(payload, as_json=True)
             return

--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -31,9 +31,9 @@ from lib.changelog import (
     format_timedelta,
     parse_jira_datetime,
 )
-from lib.client import LazyJiraClient, _sanitize_error, resolve_assignee, resolve_status
+from lib.client import LazyJiraClient, _sanitize_error, fetch_comments_paginated, resolve_assignee, resolve_status
 from lib.config import load_status_sets
-from lib.output import compact_json, error, extract_adf_text, format_output, success, warning
+from lib.output import comment_to_text, compact_json, error, extract_adf_text, format_output, success, warning
 
 
 def _expand_label_args(raw: tuple[str, ...]) -> list[str]:
@@ -654,7 +654,11 @@ def delete(ctx, issue_key: str, delete_subtasks: bool, dry_run: bool):
 # stitch together `get` + `comment list` + `transition list` themselves.
 # ═══════════════════════════════════════════════════════════════════════════════
 
-INTENT_FIELDS = "summary,status,assignee,reporter,priority,issuetype,description,comment,attachment,issuelinks,labels,created,updated"
+# Note: ``comment`` is intentionally NOT in INTENT_FIELDS — Jira returns only
+# the first 50 comments in the embedded payload. The intent verbs fetch
+# comments separately via fetch_comments_paginated() to avoid silently
+# truncating long-running tickets.
+INTENT_FIELDS = "summary,status,assignee,reporter,priority,issuetype,description,attachment,issuelinks,labels,created,updated"
 
 
 def _author_matches(author: dict, key: str, name: str) -> bool:
@@ -667,7 +671,11 @@ def _author_matches(author: dict, key: str, name: str) -> bool:
 
 
 def _comments_in_range(comments: list, start, end, author_filter: tuple[str, str] | None = None) -> list:
-    """Filter comments by created in [start, end], optionally by author key+name."""
+    """Filter comments by ``start <= created < end`` (half-open), optionally by author key+name.
+
+    The end bound is exclusive so a comment created exactly at the next status
+    transition is attributed to the next QA window, not the current one.
+    """
     out = []
     for c in comments:
         try:
@@ -676,7 +684,7 @@ def _comments_in_range(comments: list, start, end, author_filter: tuple[str, str
             continue
         if start is not None and created < start:
             continue
-        if end is not None and created > end:
+        if end is not None and created >= end:
             continue
         if author_filter is not None:
             if not _author_matches(c.get("author") or {}, *author_filter):
@@ -686,7 +694,7 @@ def _comments_in_range(comments: list, start, end, author_filter: tuple[str, str
 
 
 def _dedupe_comments(comments: list) -> list:
-    """Deduplicate by comment ID, preserving order."""
+    """Deduplicate by comment ID, returning chronological order."""
     seen: set[str] = set()
     out: list = []
     for c in comments:
@@ -698,26 +706,20 @@ def _dedupe_comments(comments: list) -> list:
     return sorted(out, key=lambda c: c.get("created", ""))
 
 
-def _collect_handover_bundle(issue: dict, status_sets: dict) -> dict:
+def _collect_handover_bundle(issue: dict, comments: list, status_sets: dict) -> dict:
     """Compose the qa (handover) bundle. See PLAN-context-fetch-optimization.md."""
-    comments = (issue.get("fields", {}).get("comment") or {}).get("comments") or []
     transitions = extract_status_transitions_with_authors(issue)
 
-    # Find the most recent INTO_QA transition
     into_qa_indices = [i for i, t in enumerate(transitions) if classify_transition(t, status_sets) == "into_qa"]
     if not into_qa_indices:
-        return {"fallback": True, "comments": list(reversed(comments[-5:])), "transition": None}
+        return {"fallback": True, "comments": comments[-5:], "transition": None}
 
     target_idx = into_qa_indices[-1]
     target = transitions[target_idx]
     t_transition = target["created"]
     t_prev, t_next = find_transition_window(transitions, target_idx)
     one_hour = timedelta(hours=1)
-    end_for_author = t_next or (t_transition + one_hour)
-    if t_next is None:
-        end_for_author = t_transition + one_hour
-    else:
-        end_for_author = min(t_next, t_transition + one_hour)
+    end_for_author = (t_transition + one_hour) if t_next is None else min(t_next, t_transition + one_hour)
 
     handover = _comments_in_range(
         comments, t_prev, end_for_author, author_filter=(target["author_key"], target["author_name"])
@@ -727,25 +729,23 @@ def _collect_handover_bundle(issue: dict, status_sets: dict) -> dict:
         "fallback": False,
         "comments": _dedupe_comments(handover + after),
         "transition": target,
-        "transitions": transitions,
     }
 
 
-def _collect_reject_bundle(issue: dict, status_sets: dict) -> dict:
+def _collect_reject_bundle(issue: dict, comments: list, status_sets: dict) -> dict:
     """Compose the qa-fail (reject) bundle. See PLAN-context-fetch-optimization.md."""
-    comments = (issue.get("fields", {}).get("comment") or {}).get("comments") or []
     transitions = extract_status_transitions_with_authors(issue)
 
     reject_indices = [i for i, t in enumerate(transitions) if classify_transition(t, status_sets) == "reject"]
     if not reject_indices:
-        return {"fallback": True, "comments": list(reversed(comments[-5:])), "transition": None}
+        return {"fallback": True, "comments": comments[-5:], "transition": None}
 
     target_idx = reject_indices[-1]
     target = transitions[target_idx]
     t_transition = target["created"]
     _, t_next = find_transition_window(transitions, target_idx)
 
-    # Find the most recent INTO_QA before the reject (= QA window start, implementer)
+    # Most recent INTO_QA before the reject = QA window start + implementer identity.
     implementer = None
     t_prev_into_qa = None
     for i in range(target_idx - 1, -1, -1):
@@ -762,30 +762,30 @@ def _collect_reject_bundle(issue: dict, status_sets: dict) -> dict:
     after = _comments_in_range(comments, t_transition, t_next)
     impl_comments = []
     if implementer is not None:
-        # Extend backwards by 1h to catch the implementer's handover comment when
-        # written just before the INTO_QA transition (same pre-transition pattern
-        # as the handover bundle — empirically 80% of comments precede the click).
+        # Extend back -1h to catch handover comments written just before the
+        # INTO_QA click (empirically 80% of handover comments precede the click).
         impl_start = (t_prev_into_qa - one_hour) if t_prev_into_qa else None
-        impl_comments = _comments_in_range(
-            comments, impl_start, t_transition, author_filter=implementer
-        )
+        impl_comments = _comments_in_range(comments, impl_start, t_transition, author_filter=implementer)
     return {
         "fallback": False,
         "comments": _dedupe_comments(reviewer_comments + after + impl_comments),
         "transition": target,
         "implementer": implementer,
-        "transitions": transitions,
     }
+
+
+def _truncate_text(text: str, n: int) -> str:
+    if not n or len(text) <= n:
+        return text
+    return text[:n].rsplit(" ", 1)[0] + " …[truncated]"
 
 
 def _print_comment(c: dict, *, truncate: int | None = None) -> None:
     author = (c.get("author") or {}).get("displayName", "Unknown")
     created = c.get("created", "")[:16].replace("T", " ")
-    body = c.get("body", "") or ""
-    if isinstance(body, dict):
-        body = extract_adf_text(body)
-    if truncate and len(body) > truncate:
-        body = body[: truncate].rsplit(" ", 1)[0] + " …[truncated]"
+    body = comment_to_text(c.get("body"))
+    if truncate:
+        body = _truncate_text(body, truncate)
     print(f"\n--- [{created}] {author} ---")
     for line in body.split("\n"):
         print(line)
@@ -801,14 +801,17 @@ def _print_intent_header(issue: dict) -> None:
     print(f"Status: {status} | Assignee: {assignee}")
 
 
-def _print_intent_description(issue: dict) -> None:
+def _print_intent_description(issue: dict, *, truncate: int | None = None) -> None:
     description = issue.get("fields", {}).get("description")
     if not description:
         return
     if isinstance(description, dict):
         description = extract_adf_text(description)
+    text = str(description)
+    if truncate:
+        text = _truncate_text(text, truncate)
     print("\nDescription:")
-    for line in str(description).split("\n"):
+    for line in text.split("\n"):
         print(f"  {line}")
 
 
@@ -828,13 +831,18 @@ def _intent_bundle_payload(issue: dict, comments: list, *, extras: dict | None =
     return payload
 
 
-def _resolve_status_sets_for_ctx(ctx, issue_key: str) -> dict:
-    """Load status sets, honoring --profile when set."""
+def _resolve_status_sets_for_ctx(ctx, issue_key: str | None = None) -> dict:
+    """Load status sets, mirroring load_config's auto-resolution.
+
+    Honors --profile if explicit; otherwise auto-resolves by issue-key project
+    prefix or default profile. Falls back to env / built-in defaults if no
+    profiles.json is configured.
+    """
     profile = None
     client_obj = ctx.obj.get("client")
     if client_obj is not None:
         profile = getattr(client_obj, "_profile", None)
-    return load_status_sets(profile=profile)
+    return load_status_sets(profile=profile, issue_key=issue_key)
 
 
 @cli.command()
@@ -854,6 +862,13 @@ def work(ctx, issue_key: str, truncate: int | None):
     client = ctx.obj["client"]
     try:
         issue = client.issue(issue_key, fields=INTENT_FIELDS)
+
+        # --quiet only validates the fetch — skip optional side calls (mirrors `get --quiet`)
+        if ctx.obj["quiet"]:
+            print(issue["key"])
+            return
+
+        comments, _ = fetch_comments_paginated(client, issue_key)
         web_links = []
         try:
             web_links = client.get_issue_remote_links(issue_key)
@@ -861,15 +876,15 @@ def work(ctx, issue_key: str, truncate: int | None):
             if ctx.obj["debug"]:
                 raise
             warning("Failed to fetch web links")
-        comments = (issue.get("fields", {}).get("comment") or {}).get("comments") or []
 
         if ctx.obj["json"]:
-            issue["webLinks"] = web_links
-            payload = _intent_bundle_payload(issue, comments, extras={"webLinks": web_links})
-            format_output(payload, as_json=True)
-            return
-        if ctx.obj["quiet"]:
-            print(issue["key"])
+            fields = issue.get("fields", {})
+            extras = {
+                "attachments": fields.get("attachment") or [],
+                "issueLinks": fields.get("issuelinks") or [],
+                "webLinks": web_links,
+            }
+            format_output(_intent_bundle_payload(issue, comments, extras=extras), as_json=True)
             return
 
         issue["webLinks"] = web_links
@@ -907,8 +922,13 @@ def qa(ctx, issue_key: str, truncate: int | None):
     client = ctx.obj["client"]
     try:
         issue = client.issue(issue_key, fields=INTENT_FIELDS, expand="changelog")
+        if ctx.obj["quiet"]:
+            print(issue["key"])
+            return
+
+        comments, _ = fetch_comments_paginated(client, issue_key)
         sets = _resolve_status_sets_for_ctx(ctx, issue_key)
-        bundle = _collect_handover_bundle(issue, sets)
+        bundle = _collect_handover_bundle(issue, comments, sets)
 
         if ctx.obj["json"]:
             extras = {"handover_fallback": bundle["fallback"]}
@@ -921,12 +941,9 @@ def qa(ctx, issue_key: str, truncate: int | None):
                 }
             format_output(_intent_bundle_payload(issue, bundle["comments"], extras=extras), as_json=True)
             return
-        if ctx.obj["quiet"]:
-            print(issue["key"])
-            return
 
         _print_intent_header(issue)
-        _print_intent_description(issue)
+        _print_intent_description(issue, truncate=truncate)
         if bundle["fallback"]:
             print("\n[no INTO-QA transition found — falling back to last 5 comments]")
         else:
@@ -964,8 +981,13 @@ def qa_fail(ctx, issue_key: str, truncate: int | None):
     client = ctx.obj["client"]
     try:
         issue = client.issue(issue_key, fields=INTENT_FIELDS, expand="changelog")
+        if ctx.obj["quiet"]:
+            print(issue["key"])
+            return
+
+        comments, _ = fetch_comments_paginated(client, issue_key)
         sets = _resolve_status_sets_for_ctx(ctx, issue_key)
-        bundle = _collect_reject_bundle(issue, sets)
+        bundle = _collect_reject_bundle(issue, comments, sets)
 
         if ctx.obj["json"]:
             extras = {"reject_fallback": bundle["fallback"]}
@@ -980,12 +1002,9 @@ def qa_fail(ctx, issue_key: str, truncate: int | None):
                 extras["implementer"] = bundle["implementer"][1]
             format_output(_intent_bundle_payload(issue, bundle["comments"], extras=extras), as_json=True)
             return
-        if ctx.obj["quiet"]:
-            print(issue["key"])
-            return
 
         _print_intent_header(issue)
-        _print_intent_description(issue)
+        _print_intent_description(issue, truncate=truncate)
         if bundle["fallback"]:
             print("\n[no REJECT transition found — falling back to last 5 comments]")
         else:
@@ -1015,19 +1034,16 @@ def act(ctx, issue_key: str):
     Example:
 
       jira-issue act NRS-4412
-      jira-issue act NRS-4412 --json | jq '.transitions[].name'
+      jira-issue --json act NRS-4412 | jq '.transitions[].name'
     """
     ctx.obj["client"].with_context(issue_key=issue_key)
     client = ctx.obj["client"]
     try:
         issue = client.issue(issue_key, fields="summary,status,assignee,priority,issuetype")
-        try:
-            transitions = client.get_issue_transitions(issue_key) or []
-        except Exception:
-            if ctx.obj["debug"]:
-                raise
-            warning("Failed to fetch available transitions")
-            transitions = []
+        # Fetching transitions IS the core purpose of `act` — surface failures
+        # rather than silently returning an empty list (which a caller might
+        # interpret as "no transitions are available").
+        transitions = client.get_issue_transitions(issue_key) or []
 
         if ctx.obj["json"]:
             payload = {

--- a/skills/jira-communication/scripts/lib/changelog.py
+++ b/skills/jira-communication/scripts/lib/changelog.py
@@ -1,6 +1,9 @@
 """Helpers for Jira issue changelog / status-history analysis."""
 
 from datetime import datetime, timedelta
+from typing import Literal
+
+TransitionKind = Literal["into_qa", "reject", "forward", "resolved", "out", "other"]
 
 
 def parse_jira_datetime(s: str) -> datetime:
@@ -97,6 +100,95 @@ def compute_time_in_status(
     _add(last["to"] or current_status, now - last["created"])
 
     return result
+
+
+def extract_status_transitions_with_authors(issue: dict) -> list[dict]:
+    """Like :func:`extract_status_transitions` but preserves transition author.
+
+    Each entry adds ``author_name`` (display name) and ``author_key`` (the
+    stable identifier — Server/DC ``name`` or Cloud ``accountId``).
+    """
+    transitions: list[dict] = []
+    histories = issue.get("changelog", {}).get("histories", [])
+    for h in histories:
+        created_raw = h.get("created")
+        if not created_raw:
+            continue
+        try:
+            created = parse_jira_datetime(created_raw)
+        except ValueError:
+            continue
+        author = h.get("author") or {}
+        author_name = author.get("displayName", "")
+        author_key = author.get("name") or author.get("accountId") or ""
+        for item in h.get("items", []):
+            if item.get("field") != "status":
+                continue
+            transitions.append(
+                {
+                    "created": created,
+                    "from": item.get("fromString") or "",
+                    "to": item.get("toString") or "",
+                    "author_name": author_name,
+                    "author_key": author_key,
+                }
+            )
+    transitions.sort(key=lambda t: t["created"])
+    return transitions
+
+
+def classify_transition(transition: dict, status_sets: dict) -> "TransitionKind":
+    """Classify a status transition against qa/working/resolved sets.
+
+    Returns one of:
+      * ``into_qa``  — moving from a non-QA state into a QA state (handover)
+      * ``reject``   — moving from a QA state back to a working state (fail)
+      * ``forward``  — moving between two distinct QA states (e.g. QA→QA2,
+                       Review→UAT) — a multi-stage QA progression, NOT a fail
+      * ``resolved`` — terminal success (any state → resolved set)
+      * ``out``      — leaving QA into something not classified above
+      * ``other``    — neither side touches QA
+    """
+    qa = status_sets["qa"]
+    working = status_sets["working"]
+    resolved = status_sets["resolved"]
+    src = transition["from"]
+    dst = transition["to"]
+    if dst in resolved:
+        return "resolved"
+    src_in_qa = src in qa
+    dst_in_qa = dst in qa
+    if not src_in_qa and dst_in_qa:
+        return "into_qa"
+    if src_in_qa and dst in working:
+        return "reject"
+    if src_in_qa and dst_in_qa and src != dst:
+        return "forward"
+    if src_in_qa and not dst_in_qa:
+        return "out"
+    return "other"
+
+
+def find_transition_window(transitions: list[dict], target_index: int) -> tuple[datetime | None, datetime | None]:
+    """Return (T_prev, T_next) bracketing ``transitions[target_index]``.
+
+    Both endpoints are *other* status changes, ignoring same-second duplicates.
+    Either may be ``None`` if no bracketing transition exists.
+    """
+    if not (0 <= target_index < len(transitions)):
+        return None, None
+    target_t = transitions[target_index]["created"]
+    t_prev = None
+    for t in reversed(transitions[:target_index]):
+        if t["created"] < target_t:
+            t_prev = t["created"]
+            break
+    t_next = None
+    for t in transitions[target_index + 1 :]:
+        if t["created"] > target_t:
+            t_next = t["created"]
+            break
+    return t_prev, t_next
 
 
 def format_timedelta(delta: timedelta) -> str:

--- a/skills/jira-communication/scripts/lib/client.py
+++ b/skills/jira-communication/scripts/lib/client.py
@@ -66,6 +66,42 @@ def resolve_assignee(client, identifier: str) -> dict:
     return {"name": identifier}
 
 
+def fetch_comments_paginated(client, issue_key: str, page_size: int = 100) -> tuple[list[dict], int | None]:
+    """Fetch all comments for an issue, paginating through Jira's REST endpoint.
+
+    The embedded ``fields.comment.comments`` block on an issue payload is
+    truncated by Jira (default 50 entries on Server/DC). For long-running
+    tickets that truncation silently drops comments. This helper hits
+    ``/rest/api/2/issue/{key}/comment`` with explicit ``startAt`` /
+    ``maxResults`` until the server signals it has returned everything.
+
+    Returns ``(comments, total)`` where ``total`` is the Jira-reported total
+    if available, or ``None`` if the server omits it.
+    """
+    comments: list[dict] = []
+    start_at = 0
+    total: int | None = None
+    while True:
+        payload = (
+            client.get(
+                f"rest/api/2/issue/{issue_key}/comment",
+                params={"startAt": start_at, "maxResults": page_size},
+            )
+            or {}
+        )
+        values = payload.get("comments", []) or []
+        if total is None:
+            raw_total = payload.get("total")
+            total = raw_total if isinstance(raw_total, int) else None
+        comments.extend(values)
+        if not values:
+            break
+        if total is not None and (start_at + len(values)) >= total:
+            break
+        start_at += len(values)
+    return comments, total
+
+
 def get_project_issue_types(client, project_key: str, subtask_only: bool | None = None) -> list[dict]:
     """Get available issue types for a project.
 

--- a/skills/jira-communication/scripts/lib/config.py
+++ b/skills/jira-communication/scripts/lib/config.py
@@ -360,4 +360,80 @@ def load_config(
     return load_env()
 
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# Workflow status sets (qa / working / resolved) used by intent verbs
+# ═══════════════════════════════════════════════════════════════════════════════
+
+DEFAULT_QA_STATUSES = (
+    "QA",
+    "Review",
+    "In Review",
+    "Code Review",
+    "Ready for QA",
+    "QA2",
+    "UAT",
+    "Acceptance",
+    "Testing",
+)
+# "QA failed" semantically reads like a QA stage, but functionally it's a
+# reject-target ("review verdict: send back to dev"). Putting it in the working
+# set means `QA → QA failed` correctly classifies as REJECT rather than FORWARD.
+DEFAULT_WORKING_STATUSES = (
+    "In Progress",
+    "Open",
+    "Reopened",
+    "To Do",
+    "In Development",
+    "Backlog",
+    "QA failed",
+)
+DEFAULT_RESOLVED_STATUSES = (
+    "Closed",
+    "Resolved",
+    "Done",
+    "Won't Fix",
+    "Cancelled",
+)
+
+
+def _split_csv(value: str | None) -> list[str] | None:
+    if not value:
+        return None
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def load_status_sets(profile: str | None = None) -> dict[str, frozenset[str]]:
+    """Resolve qa / working / resolved status name sets.
+
+    Priority per set: profile field → env var → built-in default.
+
+    Profile fields: ``qa_status_names``, ``working_status_names``,
+    ``resolved_status_names`` (each a JSON list).
+
+    Env vars: ``JIRA_QA_STATUS_NAMES``, ``JIRA_WORKING_STATUS_NAMES``,
+    ``JIRA_RESOLVED_STATUS_NAMES`` (comma-separated).
+    """
+    prof: dict = {}
+    if PROFILES_FILE.exists():
+        try:
+            prof = resolve_profile(profile=profile) if profile else {}
+        except (ValueError, FileNotFoundError):
+            prof = {}
+
+    def _resolve(profile_key: str, env_key: str, defaults: tuple[str, ...]) -> frozenset[str]:
+        from_profile = prof.get(profile_key)
+        if isinstance(from_profile, list) and from_profile:
+            return frozenset(str(s) for s in from_profile)
+        from_env = _split_csv(os.environ.get(env_key))
+        if from_env:
+            return frozenset(from_env)
+        return frozenset(defaults)
+
+    return {
+        "qa": _resolve("qa_status_names", "JIRA_QA_STATUS_NAMES", DEFAULT_QA_STATUSES),
+        "working": _resolve("working_status_names", "JIRA_WORKING_STATUS_NAMES", DEFAULT_WORKING_STATUSES),
+        "resolved": _resolve("resolved_status_names", "JIRA_RESOLVED_STATUS_NAMES", DEFAULT_RESOLVED_STATUSES),
+    }
+
+
 # === INLINE_END: config ===

--- a/skills/jira-communication/scripts/lib/config.py
+++ b/skills/jira-communication/scripts/lib/config.py
@@ -402,8 +402,18 @@ def _split_csv(value: str | None) -> list[str] | None:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
-def load_status_sets(profile: str | None = None) -> dict[str, frozenset[str]]:
+def load_status_sets(
+    profile: str | None = None,
+    issue_key: str | None = None,
+    url: str | None = None,
+) -> dict[str, frozenset[str]]:
     """Resolve qa / working / resolved status name sets.
+
+    Profile resolution mirrors :func:`load_config` — explicit profile name
+    wins, otherwise falls back to issue-key project prefix, URL host, the
+    project-directory ``.jira-profile`` marker, or the default profile from
+    ``profiles.json``. This keeps CLI behaviour consistent: the same profile
+    that authenticates also supplies the workflow status sets.
 
     Priority per set: profile field → env var → built-in default.
 
@@ -416,7 +426,16 @@ def load_status_sets(profile: str | None = None) -> dict[str, frozenset[str]]:
     prof: dict = {}
     if PROFILES_FILE.exists():
         try:
-            prof = resolve_profile(profile=profile) if profile else {}
+            cwd = os.getcwd()
+        except OSError:
+            cwd = None
+        try:
+            prof = resolve_profile(
+                profile=profile,
+                issue_key=issue_key,
+                url=url,
+                project_dir=cwd,
+            )
         except (ValueError, FileNotFoundError):
             prof = {}
 

--- a/skills/jira-communication/scripts/workflow/jira-comment.py
+++ b/skills/jira-communication/scripts/workflow/jira-comment.py
@@ -20,7 +20,7 @@ if _lib_path.exists():
     sys.path.insert(0, str(_lib_path.parent))
 
 import click
-from lib.client import LazyJiraClient, _sanitize_error
+from lib.client import LazyJiraClient, _sanitize_error, fetch_comments_paginated
 from lib.output import error, extract_adf_text, format_output, success, warning
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -28,30 +28,8 @@ from lib.output import error, extract_adf_text, format_output, success, warning
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-def _fetch_comments_paginated(client, issue_key: str) -> tuple[list[dict], int | None]:
-    comments: list[dict] = []
-    start_at = 0
-    page_size = 100
-    total: int | None = None
-    while True:
-        payload = (
-            client.get(
-                f"rest/api/2/issue/{issue_key}/comment",
-                params={"startAt": start_at, "maxResults": page_size},
-            )
-            or {}
-        )
-        values = payload.get("comments", []) or []
-        if total is None:
-            raw_total = payload.get("total")
-            total = raw_total if isinstance(raw_total, int) else None
-        comments.extend(values)
-        if not values:
-            break
-        if total is not None and (start_at + len(values)) >= total:
-            break
-        start_at += len(values)
-    return comments, total
+# Backwards-compat alias for any external imports — implementation moved to lib.client.
+_fetch_comments_paginated = fetch_comments_paginated
 
 
 @click.group()

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -10,10 +10,19 @@ _scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
 sys.path.insert(0, str(_scripts_path))
 
 from lib.changelog import (
+    classify_transition,
     compute_time_in_status,
     extract_status_transitions,
+    extract_status_transitions_with_authors,
+    find_transition_window,
     format_timedelta,
 )
+
+# Status sets used by classify_transition tests
+_QA = frozenset({"QA", "Review", "QA2", "UAT"})
+_WORKING = frozenset({"In Progress", "Open", "QA failed"})
+_RESOLVED = frozenset({"Closed", "Resolved", "Done"})
+_SETS = {"qa": _QA, "working": _WORKING, "resolved": _RESOLVED}
 
 UTC = timezone.utc
 
@@ -185,3 +194,139 @@ class TestFormatTimedelta:
     def test_negative_treated_as_zero(self):
         """Clock skew / reordering should never produce negative durations."""
         assert format_timedelta(timedelta(seconds=-1)) == "0m"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: extract_status_transitions_with_authors()
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestExtractStatusTransitionsWithAuthors:
+    """Augmented variant must preserve transition author identity."""
+
+    def _issue(self, history):
+        return {"changelog": {"histories": history}}
+
+    def test_extracts_author_name_and_key(self):
+        issue = self._issue(
+            [
+                {
+                    "created": "2026-05-10T08:29:05.000+0000",
+                    "author": {"name": "smendel", "displayName": "Sebastian Mendel"},
+                    "items": [{"field": "status", "fromString": "In Progress", "toString": "QA"}],
+                }
+            ]
+        )
+        ts = extract_status_transitions_with_authors(issue)
+        assert len(ts) == 1
+        assert ts[0]["from"] == "In Progress"
+        assert ts[0]["to"] == "QA"
+        assert ts[0]["author_name"] == "Sebastian Mendel"
+        assert ts[0]["author_key"] == "smendel"
+
+    def test_falls_back_to_account_id_when_no_name(self):
+        issue = self._issue(
+            [
+                {
+                    "created": "2026-05-10T08:29:05.000+0000",
+                    "author": {"accountId": "acc-1", "displayName": "Cloud User"},
+                    "items": [{"field": "status", "fromString": "Open", "toString": "QA"}],
+                }
+            ]
+        )
+        ts = extract_status_transitions_with_authors(issue)
+        assert ts[0]["author_key"] == "acc-1"
+
+    def test_handles_missing_author(self):
+        issue = self._issue(
+            [
+                {
+                    "created": "2026-05-10T08:29:05.000+0000",
+                    "items": [{"field": "status", "fromString": "Open", "toString": "QA"}],
+                }
+            ]
+        )
+        ts = extract_status_transitions_with_authors(issue)
+        assert ts[0]["author_key"] == ""
+        assert ts[0]["author_name"] == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: classify_transition()
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestClassifyTransition:
+    """Transitions classify by set membership, not by name."""
+
+    def test_into_qa(self):
+        t = {"from": "In Progress", "to": "QA"}
+        assert classify_transition(t, _SETS) == "into_qa"
+
+    def test_reject_to_working(self):
+        t = {"from": "QA", "to": "In Progress"}
+        assert classify_transition(t, _SETS) == "reject"
+
+    def test_reject_to_qa_failed(self):
+        """`QA → QA failed` must be reject (QA failed is in working set, not qa)."""
+        t = {"from": "QA", "to": "QA failed"}
+        assert classify_transition(t, _SETS) == "reject"
+
+    def test_forward_qa_to_qa2(self):
+        """Multi-stage QA progression is forward, NOT reject."""
+        t = {"from": "QA", "to": "QA2"}
+        assert classify_transition(t, _SETS) == "forward"
+
+    def test_forward_review_to_uat(self):
+        """Different two-stage naming (Review → UAT) classifies same as QA → QA2."""
+        t = {"from": "Review", "to": "UAT"}
+        assert classify_transition(t, _SETS) == "forward"
+
+    def test_resolved_takes_precedence_over_qa(self):
+        """`QA → Closed` is resolved, even though source is QA."""
+        t = {"from": "QA", "to": "Closed"}
+        assert classify_transition(t, _SETS) == "resolved"
+
+    def test_out_when_qa_to_unknown(self):
+        """`QA → SomethingUnknown` (not in any set) is `out`."""
+        t = {"from": "QA", "to": "SomethingNew"}
+        assert classify_transition(t, _SETS) == "out"
+
+    def test_other_when_neither_side_qa(self):
+        t = {"from": "Open", "to": "In Progress"}
+        assert classify_transition(t, _SETS) == "other"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: find_transition_window()
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFindTransitionWindow:
+    """find_transition_window returns previous and next adjacent timestamps."""
+
+    def _ts(self, *dts):
+        return [{"created": d, "from": "x", "to": "y", "author_name": "", "author_key": ""} for d in dts]
+
+    def test_returns_neighbors(self):
+        ts = self._ts(_dt(2026, 5, 1), _dt(2026, 5, 5), _dt(2026, 5, 10))
+        prev, nxt = find_transition_window(ts, 1)
+        assert prev == _dt(2026, 5, 1)
+        assert nxt == _dt(2026, 5, 10)
+
+    def test_first_transition_has_no_prev(self):
+        ts = self._ts(_dt(2026, 5, 1), _dt(2026, 5, 5))
+        prev, nxt = find_transition_window(ts, 0)
+        assert prev is None
+        assert nxt == _dt(2026, 5, 5)
+
+    def test_last_transition_has_no_next(self):
+        ts = self._ts(_dt(2026, 5, 1), _dt(2026, 5, 5))
+        prev, nxt = find_transition_window(ts, 1)
+        assert prev == _dt(2026, 5, 1)
+        assert nxt is None
+
+    def test_out_of_bounds_returns_none(self):
+        ts = self._ts(_dt(2026, 5, 1))
+        assert find_transition_window(ts, 5) == (None, None)
+        assert find_transition_window(ts, -1) == (None, None)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -953,3 +953,124 @@ class TestMockedCommands:
         # Pre-fix this raised TypeError ("unhashable type: 'slice'"-style on dict slicing).
         assert result.exit_code == 0, result.output
         assert "..." in result.output
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: jira-issue intent verbs (work / qa / qa-fail / act)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestIntentVerbs:
+    """Smoke tests for the four single-call intent verbs added in this PR."""
+
+    def _mock_client_for_intents(self, comments=None, transitions=None, status_name="QA", changelog=None):
+        client = mock.Mock()
+        client.issue.return_value = {
+            "key": "TEST-1",
+            "fields": {
+                "summary": "Test ticket",
+                "status": {"name": status_name},
+                "assignee": {"displayName": "Test User"},
+                "description": "Body",
+                "attachment": [],
+                "issuelinks": [],
+            },
+            "changelog": {"histories": changelog or []},
+        }
+        client.get.return_value = {"comments": comments or [], "total": len(comments or [])}
+        client.get_issue_remote_links.return_value = []
+        client.get_issue_transitions.return_value = transitions or []
+        return client
+
+    def test_work_help_lists_truncate(self):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_issue_mod.cli, ["work", "--help"])
+        assert result.exit_code == 0
+        assert "--truncate" in result.output
+
+    def test_qa_help_lists_truncate(self):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_issue_mod.cli, ["qa", "--help"])
+        assert result.exit_code == 0
+        assert "--truncate" in result.output
+
+    def test_act_help_has_no_truncate(self):
+        """`act` has no body content — `--truncate` should NOT be exposed."""
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_issue_mod.cli, ["act", "--help"])
+        assert result.exit_code == 0
+        assert "--truncate" not in result.output
+
+    def test_work_json_includes_attachments_and_links(self):
+        """`work --json` must include attachments, issueLinks, webLinks in payload."""
+        client = self._mock_client_for_intents(comments=[])
+        client.issue.return_value["fields"]["attachment"] = [{"filename": "x.log"}]
+        client.issue.return_value["fields"]["issuelinks"] = [{"type": {"name": "Blocks"}}]
+        client.get_issue_remote_links.return_value = [{"object": {"url": "https://x"}}]
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=client):
+            result = runner.invoke(_issue_mod.cli, ["--json", "work", "TEST-1"])
+        assert result.exit_code == 0, result.output
+        import json as _json
+
+        data = _json.loads(result.output)
+        assert data["attachments"] == [{"filename": "x.log"}]
+        assert data["issueLinks"] == [{"type": {"name": "Blocks"}}]
+        assert data["webLinks"] == [{"object": {"url": "https://x"}}]
+
+    def test_work_quiet_skips_remote_link_fetch(self):
+        """`work --quiet` must not hit the remote-link endpoint."""
+        client = self._mock_client_for_intents()
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=client):
+            result = runner.invoke(_issue_mod.cli, ["--quiet", "work", "TEST-1"])
+        assert result.exit_code == 0, result.output
+        assert "TEST-1" in result.output
+        client.get_issue_remote_links.assert_not_called()
+
+    def test_work_paginates_comments(self):
+        """`work` must call the paginated comment endpoint (not the embedded payload)."""
+        comments = [
+            {"id": str(i), "created": f"2026-05-10T08:00:0{i}.000+0000", "author": {"displayName": "U"}, "body": "x"}
+            for i in range(3)
+        ]
+        client = self._mock_client_for_intents(comments=comments)
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=client):
+            result = runner.invoke(_issue_mod.cli, ["--json", "work", "TEST-1"])
+        assert result.exit_code == 0, result.output
+        client.get.assert_any_call("rest/api/2/issue/TEST-1/comment", params={"startAt": 0, "maxResults": 100})
+
+    def test_qa_fallback_when_no_into_qa_transition(self):
+        """`qa` falls back to last 5 comments when no INTO_QA transition is in the changelog."""
+        comments = [
+            {"id": str(i), "created": f"2026-05-10T08:00:0{i}.000+0000", "author": {"displayName": "U"}, "body": "x"}
+            for i in range(3)
+        ]
+        client = self._mock_client_for_intents(comments=comments, changelog=[])
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=client):
+            result = runner.invoke(_issue_mod.cli, ["qa", "TEST-1"])
+        assert result.exit_code == 0, result.output
+        assert "falling back to last 5 comments" in result.output
+
+    def test_act_surfaces_transition_fetch_failure(self):
+        """`act` must exit non-zero (outside debug) if the transitions endpoint fails."""
+        client = self._mock_client_for_intents()
+        client.get_issue_transitions.side_effect = RuntimeError("boom")
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=client):
+            result = runner.invoke(_issue_mod.cli, ["act", "TEST-1"])
+        assert result.exit_code != 0
+        assert "boom" in result.output or "act context" in result.output
+
+    def test_act_lists_transitions_in_text_mode(self):
+        client = self._mock_client_for_intents(
+            transitions=[{"id": "11", "name": "Start work"}, {"id": "31", "name": "Resolve"}]
+        )
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=client):
+            result = runner.invoke(_issue_mod.cli, ["act", "TEST-1"])
+        assert result.exit_code == 0, result.output
+        assert "Start work" in result.output
+        assert "Resolve" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -418,3 +418,116 @@ class TestLoadEnvExportPrefix:
         config = load_env(str(env_file))
         assert config["JIRA_URL"] == "https://jira.example.com"
         assert config["JIRA_PERSONAL_TOKEN"] == "my-token"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: load_status_sets() — qa / working / resolved status name resolution
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestLoadStatusSets:
+    """Three status sets resolve in order: profile field → env var → built-in default."""
+
+    def _import(self):
+        from lib.config import (
+            DEFAULT_QA_STATUSES,
+            DEFAULT_RESOLVED_STATUSES,
+            DEFAULT_WORKING_STATUSES,
+            load_status_sets,
+        )
+
+        return load_status_sets, DEFAULT_QA_STATUSES, DEFAULT_WORKING_STATUSES, DEFAULT_RESOLVED_STATUSES
+
+    def test_defaults_when_no_profile_no_env(self, monkeypatch):
+        """No profiles.json + no env vars → returns built-in defaults."""
+        load_status_sets, qa_def, work_def, res_def = self._import()
+        monkeypatch.setattr("lib.config.PROFILES_FILE", Path("/nonexistent"))
+        for var in ("JIRA_QA_STATUS_NAMES", "JIRA_WORKING_STATUS_NAMES", "JIRA_RESOLVED_STATUS_NAMES"):
+            monkeypatch.delenv(var, raising=False)
+        sets = load_status_sets()
+        assert sets["qa"] == frozenset(qa_def)
+        assert sets["working"] == frozenset(work_def)
+        assert sets["resolved"] == frozenset(res_def)
+
+    def test_qa_failed_in_working_set_default(self, monkeypatch):
+        """`QA failed` defaults to working set so `QA → QA failed` classifies as REJECT."""
+        load_status_sets, _, _, _ = self._import()
+        monkeypatch.setattr("lib.config.PROFILES_FILE", Path("/nonexistent"))
+        for var in ("JIRA_QA_STATUS_NAMES", "JIRA_WORKING_STATUS_NAMES", "JIRA_RESOLVED_STATUS_NAMES"):
+            monkeypatch.delenv(var, raising=False)
+        sets = load_status_sets()
+        assert "QA failed" in sets["working"]
+        assert "QA failed" not in sets["qa"]
+
+    def test_env_var_overrides_default(self, monkeypatch):
+        """JIRA_QA_STATUS_NAMES env var replaces the qa set entirely."""
+        load_status_sets, _, _, _ = self._import()
+        monkeypatch.setattr("lib.config.PROFILES_FILE", Path("/nonexistent"))
+        monkeypatch.setenv("JIRA_QA_STATUS_NAMES", "Review,UAT,Acceptance")
+        for var in ("JIRA_WORKING_STATUS_NAMES", "JIRA_RESOLVED_STATUS_NAMES"):
+            monkeypatch.delenv(var, raising=False)
+        sets = load_status_sets()
+        assert sets["qa"] == frozenset({"Review", "UAT", "Acceptance"})
+        assert "QA" not in sets["qa"]
+
+    def test_profile_field_overrides_env(self, tmp_path, monkeypatch):
+        """Profile field wins over env var."""
+        load_status_sets, _, _, _ = self._import()
+        profiles_file = tmp_path / "profiles.json"
+        profiles_file.write_text(
+            json.dumps(
+                {
+                    "default": "p1",
+                    "profiles": {
+                        "p1": {
+                            "url": "https://jira.example.com",
+                            "auth": "pat",
+                            "token": "t",
+                            "qa_status_names": ["ProfileQA"],
+                        }
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr("lib.config.PROFILES_FILE", profiles_file)
+        monkeypatch.setenv("JIRA_QA_STATUS_NAMES", "EnvQA")
+        sets = load_status_sets(profile="p1")
+        assert sets["qa"] == frozenset({"ProfileQA"})
+
+    def test_auto_resolves_via_issue_key(self, tmp_path, monkeypatch):
+        """Issue-key project prefix matches a profile's projects list (no explicit --profile)."""
+        load_status_sets, _, _, _ = self._import()
+        profiles_file = tmp_path / "profiles.json"
+        profiles_file.write_text(
+            json.dumps(
+                {
+                    "default": "other",
+                    "profiles": {
+                        "other": {"url": "https://x", "auth": "pat", "token": "t"},
+                        "match": {
+                            "url": "https://jira.example.com",
+                            "auth": "pat",
+                            "token": "t",
+                            "projects": ["NRS"],
+                            "qa_status_names": ["MatchedQA"],
+                        },
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr("lib.config.PROFILES_FILE", profiles_file)
+        for var in ("JIRA_QA_STATUS_NAMES", "JIRA_WORKING_STATUS_NAMES", "JIRA_RESOLVED_STATUS_NAMES"):
+            monkeypatch.delenv(var, raising=False)
+        sets = load_status_sets(issue_key="NRS-4412")
+        assert sets["qa"] == frozenset({"MatchedQA"})
+
+    def test_invalid_profile_falls_back_to_defaults(self, tmp_path, monkeypatch):
+        """Profile resolution failure must not crash — fall back to env / defaults."""
+        load_status_sets, qa_def, _, _ = self._import()
+        profiles_file = tmp_path / "profiles.json"
+        profiles_file.write_text(json.dumps({"profiles": {"p1": {"url": "https://x", "auth": "pat", "token": "t"}}}))
+        monkeypatch.setattr("lib.config.PROFILES_FILE", profiles_file)
+        for var in ("JIRA_QA_STATUS_NAMES", "JIRA_WORKING_STATUS_NAMES", "JIRA_RESOLVED_STATUS_NAMES"):
+            monkeypatch.delenv(var, raising=False)
+        sets = load_status_sets(profile="nonexistent")
+        assert sets["qa"] == frozenset(qa_def)


### PR DESCRIPTION
## Summary

Four single-call intent verbs on `jira-issue.py` that compose existing API endpoints into the right bundle for one specific intent — replacing the common `jira-issue get` + `jira-comment list` 2-call pattern (or worse, shell-side filtering for "last comment from user X" queries that ran 5–6 calls per ticket).

| Verb | Bundle | Intent |
|---|---|---|
| `work KEY` | description + all comments + attachments + links | "ich arbeite am Ticket" |
| `qa KEY` | description + handover bundle (comments around INTO_QA) | "QA-Review starten" |
| `qa-fail KEY` | description + reviewer reject + implementer scope | "warum failed das" |
| `act KEY` | meta + available transitions | "Status ändern" |

`jira-issue get` stays minimal — backwards compatible. `jira-qa-gather` stays for comprehensive audit bundles.

## Heuristic — empirically validated

Sample of 10 tickets / 41 QA-relevant transitions in NRS, IOS, SRV*:

- **80%** of handover and reject comments are written **before** the transition click — a fixed `created >= transition_time` filter would silently lose them
- Naive `±15min` window catches 90% but misses the "thought-through reject" (-24min) and "evening-write, morning-transition" (-19.5h) patterns

Therefore comment windows are bracketed by **adjacent status changes** (no arbitrary time window):

- `qa` includes comments by the transition author in `[T_prev, min(T_next, T+1h)]` plus all comments by anyone in `[T, T_next)`
- `qa-fail` adds the **implementer's** comments from the same QA window (their scope/clarification context that the reject is reacting to). Window extended -1h backward to catch handover comments written just before the INTO_QA click.

Status-set classification (configurable per profile):

| Set | Default | Role |
|---|---|---|
| `qa_status_names` | QA, Review, In Review, Code Review, Ready for QA, QA2, UAT, Acceptance, Testing | review/QA stages |
| `working_status_names` | In Progress, Open, Reopened, To Do, In Development, Backlog, **QA failed** | dev stages = reject targets |
| `resolved_status_names` | Closed, Resolved, Done, Won't Fix, Cancelled | terminal |

`QA failed` is in the working set, not qa: it's a reject-target, not a review stage, so `QA → QA failed` correctly classifies as REJECT not FORWARD. Multi-stage QA (`QA → QA2`, `Review → UAT`, `QA → Acceptance`) classifies as FORWARD without code changes — only profile config (`qa_status_names`, `working_status_names`, `resolved_status_names` in `~/.jira/profiles.json` or env vars).

## SKILL.md `## Auto-Trigger`

Rewritten from "always run `jira-issue get`" to an intent-routing table that points agents at the matching verb. Anti-pattern (`get` + `comment list` for the same key) explicitly called out.

## Test plan

- [x] `--help` shows all 4 new verbs registered as sub-commands
- [x] `jira-issue qa-fail NRS-4412` returns description + Sebastians scope-setting handover (598338, written 1s before INTO_QA) + Björns full AC review reject + Sebastians clarification + resolution. Replaces the original 6-call scenario with 1 call.
- [x] `jira-issue qa NRS-4412` returns 5 handover comments around the 2026-05-10 INTO_QA transition
- [x] `jira-issue work NRS-4138` returns full bundle: description + comments + attachments + issue links
- [x] `jira-issue act NRS-4412` returns meta + 3 available transitions (Start work / Waiting / Resolve)
- [x] `--json` output: structured payload with `comments` (always a list), verb-specific keys (`reject_transition`, `handover_transition`, `implementer`)
- [x] `--quiet` returns just the issue key
- [x] Cross-validated `qa-fail` against 6 sample tickets (NRS-4138, NRS-4395, NRS-4398, NRS-4399, NRS-4411, NRS-4375) — all produce sensible bundles incl. cross-author scope context
- [x] Cross-validated `qa` against 4 sample tickets incl. overnight-pattern ticket NRS-4350 (-19.5h delta)
- [x] Existing `jira-issue get --fields ...` and `time-in-status` unaffected (regression-checked)

## Notes

- 720 net additions across 6 files. Above the ~300 LOC AGENTS.md target, but cohesive — splitting the 4 verbs into separate PRs would fragment shared helpers and the heuristic.
- No commits, no breaking changes to existing commands.
- New reference doc: `references/intent-verbs.md` documents heuristic, status sets, configuration.
- CHANGELOG entry under `[Unreleased] ### Added`.
- Plan and design discussion: `PLAN-context-fetch-optimization.md` in the working tree (not committed; can include if useful).