### PR TITLE
feat(jira-issue): add --description flag to update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `jira-issue update --description / -d`: typed flag for plain description edits — previously required `--fields-json '{"description": "..."}'` with its JSON-escaping fragility. `--description -` reads the body from stdin so multi-line wiki markup can be piped in without shell-escape gymnastics. `references/issue-editing.md` updated; the long-tail `--fields-json` route remains for custom-field payloads.
 - `jira-issue work / qa / qa-fail / act`: four single-call intent verbs that compose existing API endpoints (issue + comments + changelog + remote_links + transitions) into the right bundle for one specific intent — replacing the common `jira-issue get` + `jira-comment list` 2-call (or worse, with shell-side filtering, 5–6-call) pattern.
   - `work KEY` — description + all comments + attachments + links (use when starting work on a ticket)
   - `qa KEY` — description + handover bundle (comments around the most recent INTO_QA transition, before-or-after agnostic — empirically 80% of handover comments precede the transition click)

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -63,7 +63,7 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screensh
 - `references/jql-quick-reference.md`, `references/jql-cookbook.md` — JQL beyond simple filters
 - `references/multi-profile.md` — multiple Jira instances, `--profile`
 - `references/troubleshooting.md` — auth, SSL, 401, 403, connection
-- `references/issue-editing.md` — `--fields-json`, reporter, deletes, moves
+- `references/issue-editing.md` — `--description`, `--fields-json`, reporter, deletes, moves
 - `references/creation.md` — `--parent`, components, custom fields
 - `references/comments.md` — edit, delete, list comments
 - `references/worklog.md` — `--started`, date ranges, `jira-worklog-query.py`

--- a/skills/jira-communication/references/issue-editing.md
+++ b/skills/jira-communication/references/issue-editing.md
@@ -4,15 +4,25 @@
 
 Load this reference whenever the user wants to set `--fields-json`, set a custom `--reporter`, delete an issue (especially with sub-tasks), attempt an unsupported cross-project move via CLI (see below), or change any field that is not assignee, priority, or labels.
 
-## `--fields-json` for description and custom fields
+## `--description` for plain description edits
 
-`jira-issue.py update` accepts a raw JSON object to set any field the Jira REST API exposes:
+For a plain description rewrite, use the typed flag — it avoids JSON-escaping the body:
 
 ```bash
-# Plain description edit
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py update PROJ-123 \
-    --fields-json '{"description": "Rewritten description"}'
+    --description "Rewritten description"
 
+# Pipe a longer body from a file
+cat body.txt | uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py update PROJ-123 --description -
+```
+
+The body is Jira wiki markup (see the `jira-syntax` skill).
+
+## `--fields-json` for custom fields and structured payloads
+
+`jira-issue.py update` accepts a raw JSON object to set any field the Jira REST API exposes — reach for it when the typed flags don't cover the field:
+
+```bash
 # Custom fields (Sprint ID as integer, Epic Link as issue key)
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py update PROJ-123 \
     --fields-json '{"customfield_SPRINT": 916, "customfield_EPIC": "PROJ-1940"}'

--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -532,7 +532,30 @@ def update(
         update_fields["summary"] = summary
 
     if description is not None:
-        update_fields["description"] = sys.stdin.read() if description == "-" else description
+        if description == "-":
+            if sys.stdin.isatty():
+                error(
+                    "'-' requires piped input but stdin is a terminal",
+                    suggestion="Usage: cat body.txt | jira-issue update PROJ-123 --description -",
+                )
+                sys.exit(1)
+            max_size = 256 * 1024  # 256KB, above Jira's description limit
+            try:
+                description = sys.stdin.read(max_size + 1)
+            except UnicodeDecodeError:
+                error(
+                    "stdin contains invalid text encoding (expected UTF-8)",
+                    suggestion="Ensure the piped file is valid UTF-8 text, not binary data.",
+                )
+                sys.exit(1)
+            if len(description) > max_size:
+                error(
+                    f"description from stdin exceeds {max_size} bytes",
+                    suggestion="Truncate the input or split the description across multiple updates.",
+                )
+                sys.exit(1)
+            description = description.rstrip("\n")
+        update_fields["description"] = description
 
     if priority:
         update_fields["priority"] = {"name": priority}

--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -474,6 +474,7 @@ def _status_order(current_status: str, transitions: list) -> list[str]:
 @cli.command()
 @click.argument("issue_key")
 @click.option("--summary", "-s", help="New summary")
+@click.option("--description", "-d", help="New description (Jira wiki markup; '-' reads from stdin)")
 @click.option("--priority", "-p", help="Priority name")
 @click.option("--labels", "-l", help="Comma-separated labels (replaces existing)")
 @click.option(
@@ -494,6 +495,7 @@ def update(
     ctx,
     issue_key: str,
     summary: str | None,
+    description: str | None,
     priority: str | None,
     labels: str | None,
     add_label: tuple[str, ...],
@@ -510,6 +512,10 @@ def update(
 
       jira-issue update PROJ-123 --summary "New title"
 
+      jira-issue update PROJ-123 --description "$(cat body.txt)"
+
+      jira-issue update PROJ-123 --description -            # read from stdin
+
       jira-issue update PROJ-123 --priority High --labels backend,urgent
 
       jira-issue update PROJ-123 --fields-json '{"customfield_10001": "value"}'
@@ -524,6 +530,9 @@ def update(
 
     if summary:
         update_fields["summary"] = summary
+
+    if description is not None:
+        update_fields["description"] = sys.stdin.read() if description == "-" else description
 
     if priority:
         update_fields["priority"] = {"name": priority}
@@ -556,7 +565,7 @@ def update(
     if not update_fields:
         error("No fields specified for update")
         click.echo(
-            "\nUse one or more of: --summary, --priority, --labels, "
+            "\nUse one or more of: --summary, --description, --priority, --labels, "
             "--add-label, --remove-label, --assignee, --fields-json"
         )
         sys.exit(1)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -745,6 +745,61 @@ class TestMockedCommands:
         mock_client.issue.assert_not_called()
         mock_client.update_issue_field.assert_not_called()
 
+    def test_issue_update_description_typed_flag(self):
+        """--description should set the description field on update."""
+        mock_client = self._make_mock_client()
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _issue_mod.cli,
+                ["update", "TEST-1", "--description", "New body"],
+            )
+        assert result.exit_code == 0, result.output
+        mock_client.update_issue_field.assert_called_once()
+        args, _kwargs = mock_client.update_issue_field.call_args
+        assert args[0] == "TEST-1"
+        assert args[1] == {"description": "New body"}
+
+    def test_issue_update_description_from_stdin_strips_trailing_newline(self):
+        """--description - should read from stdin and rstrip trailing newlines."""
+        mock_client = self._make_mock_client()
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _issue_mod.cli,
+                ["update", "TEST-1", "--description", "-"],
+                input="Body from heredoc\n",
+            )
+        assert result.exit_code == 0, result.output
+        args, _kwargs = mock_client.update_issue_field.call_args
+        assert args[1] == {"description": "Body from heredoc"}
+
+    def test_issue_update_description_empty_string_is_set(self):
+        """Empty --description still issues an update (clears the field)."""
+        mock_client = self._make_mock_client()
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _issue_mod.cli,
+                ["update", "TEST-1", "--description", ""],
+            )
+        assert result.exit_code == 0, result.output
+        args, _kwargs = mock_client.update_issue_field.call_args
+        assert args[1] == {"description": ""}
+
+    def test_issue_update_description_combines_with_other_flags(self):
+        """--description should compose with other typed flags."""
+        mock_client = self._make_mock_client()
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _issue_mod.cli,
+                ["update", "TEST-1", "--description", "x", "--priority", "High"],
+            )
+        assert result.exit_code == 0, result.output
+        args, _kwargs = mock_client.update_issue_field.call_args
+        assert args[1] == {"description": "x", "priority": {"name": "High"}}
+
     def test_move_issue_cross_project_refused_even_for_dry_run(self):
         mock_client = self._make_mock_client()
         mock_client.issue.return_value = {


### PR DESCRIPTION
## Summary

`jira-issue.py update` previously had typed flags for `--summary`, `--priority`, `--labels`, `--assignee`, plus `--fields-json` as the catch-all. Setting a plain description required the catch-all:

```bash
uv run jira-issue update PROJ-123 \
  --fields-json '{"description": "Multi-line body with \"quotes\" and\nbackslashes ..."}'
```

— which is fragile: every newline, quote, and backslash in the body needs JSON-escaping. This PR adds the typed flag, plus a stdin variant for long bodies:

```bash
jira-issue update PROJ-123 --description "$(cat body.txt)"
cat body.txt | jira-issue update PROJ-123 --description -
```

`--fields-json` keeps working untouched for custom-field payloads (`customfield_*`, `reporter`, structured arrays).

## Motivation

Real-world friction from a session that needed to edit a description with a 50-line wiki-markup body — quoting the JSON by hand failed twice before falling back to writing the body to a tmp file + `python3 json.dumps(open('...').read())` to escape. The typed flag eliminates that whole detour.

## Changes

- `scripts/core/jira-issue.py`: new `-d / --description` option on the `update` command; reads from stdin when the value is `-`. Docstring + error hint updated.
- `references/issue-editing.md`: new "`--description` for plain description edits" section above the `--fields-json` one; the latter is now framed as the long-tail option for custom fields and structured payloads.
- `SKILL.md`: one-line index reference update.
- `CHANGELOG.md`: entry under `[Unreleased] / Added`.

## Test plan

- [x] `uv run skills/jira-communication/scripts/core/jira-issue.py update --help` shows the new option.
- [ ] `jira-issue update <KEY> --description "test" --dry-run` lists `description: test`.
- [ ] `echo body | jira-issue update <KEY> --description -` updates the description from stdin.
- [ ] `jira-issue update <KEY>` (no fields) still errors and lists `--description` in the hint.