### PR TITLE
feat(jira-syntax): suggest closest-fit language for unsupported {code:X}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `validate-jira-syntax.sh`: the "Unsupported `{code:<lang>}` language" error now suggests the closest-fit valid language for common stumbles instead of always falling back to the full valid-languages list. Recognised hints: `hcl/tf/terraform/tofu` → `{code:none}`, `dockerfile/Dockerfile` → `{code:bash}` or `{code:none}`, `rust/rs` → `{code:none}`, `kotlin/kt` → `{code:java}`, `typescript/ts/tsx` → `{code:javascript}`, `shell/zsh/fish/console` → `{code:bash}`, `make/Makefile` → `{code:none}`, `ini/toml/conf/properties` → `{code:none}`, `diff/patch` → `{code:none}`, `go-template/jinja` → `{code:none}`. Unknown languages still get the full list.
+
 ### Added
 
 - `jira-issue update --description / -d`: typed flag for plain description edits — previously required `--fields-json '{"description": "..."}'` with its JSON-escaping fragility. `--description -` reads the body from stdin so multi-line wiki markup can be piped in without shell-escape gymnastics. `references/issue-editing.md` updated; the long-tail `--fields-json` route remains for custom-field payloads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `validate-jira-syntax.sh`: the "Unsupported `{code:<lang>}` language" error now suggests the closest-fit valid language for common stumbles instead of always falling back to the full valid-languages list. Recognised hints: `hcl/tf/terraform/tofu` → `{code:none}`, `dockerfile/Dockerfile` → `{code:bash}` or `{code:none}`, `rust/rs` → `{code:none}`, `kotlin/kt` → `{code:java}`, `typescript/ts/tsx` → `{code:javascript}`, `shell/zsh/fish/console` → `{code:bash}`, `make/Makefile` → `{code:none}`, `ini/toml/conf/properties` → `{code:none}`, `diff/patch` → `{code:none}`, `go-template/jinja` → `{code:none}`. Unknown languages still get the full list.
+- `validate-jira-syntax.sh`: the "Unsupported `{code:<lang>}` language" error now suggests the closest-fit valid language for common stumbles instead of always falling back to the full valid-languages list. Identifiers are matched case-insensitively (`Dockerfile`, `Makefile`, `HCL`, `TypeScript` etc. all resolve). Recognised hints: `hcl/tf/terraform/tofu` → `{code:none}`, `dockerfile/containerfile` → `{code:bash}` or `{code:none}`, `rust/rs` → `{code:none}`, `kotlin/kt` → `{code:java}` or `{code:none}`, `typescript/ts/tsx` → `{code:javascript}` or `{code:none}`, `shell/zsh/fish/console` → `{code:bash}` or `{code:none}`, `make/makefile` → `{code:none}`, `ini/toml/conf/properties` → `{code:none}`, `diff/patch` → `{code:none}`, `go-template/gotmpl/jinja/jinja2` → `{code:none}`. Unknown languages still get the full valid-languages list.
 
 ### Added
 

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -133,15 +133,17 @@ validate_file() {
         if [[ "$search_langs" != *" $lang "* ]]; then
             # Suggest the closest-fit valid language for common stumbles before
             # falling back to the generic "use {code:none} or ..." message.
+            # Lower-case the identifier so `Dockerfile`, `Makefile` etc. match
+            # without per-variant case entries.
             local hint=""
-            case "$lang" in
+            case "${lang,,}" in
                 hcl|tf|terraform|tofu)               hint="{code:none} for HCL / Terraform / OpenTofu" ;;
-                dockerfile|Dockerfile|containerfile) hint="{code:bash} (Dockerfile RUN lines lex acceptably as bash) or {code:none}" ;;
+                dockerfile|containerfile)            hint="{code:bash} (Dockerfile RUN lines lex acceptably as bash) or {code:none}" ;;
                 rust|rs)                             hint="{code:none} for Rust" ;;
                 kotlin|kt)                           hint="{code:java} (Kotlin lexes acceptably as Java) or {code:none}" ;;
-                typescript|ts|tsx)                   hint="{code:javascript}" ;;
-                shell|zsh|fish|console)              hint="{code:bash}" ;;
-                make|makefile|Makefile)              hint="{code:none} for Makefile" ;;
+                typescript|ts|tsx)                   hint="{code:javascript} or {code:none}" ;;
+                shell|zsh|fish|console)              hint="{code:bash} or {code:none}" ;;
+                make|makefile)                       hint="{code:none} for Makefile" ;;
                 ini|toml|conf|properties)            hint="{code:none} for INI / TOML / config" ;;
                 diff|patch)                          hint="{code:none}" ;;
                 go-template|gotmpl|jinja|jinja2)     hint="{code:none}" ;;

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -131,7 +131,26 @@ validate_file() {
             continue
         fi
         if [[ "$search_langs" != *" $lang "* ]]; then
-            error "Unsupported {code:$lang} language. Jira Server rejects this; use {code:none} or one of: $valid_langs"
+            # Suggest the closest-fit valid language for common stumbles before
+            # falling back to the generic "use {code:none} or ..." message.
+            local hint=""
+            case "$lang" in
+                hcl|tf|terraform|tofu)               hint="{code:none} for HCL / Terraform / OpenTofu" ;;
+                dockerfile|Dockerfile|containerfile) hint="{code:bash} (Dockerfile RUN lines lex acceptably as bash) or {code:none}" ;;
+                rust|rs)                             hint="{code:none} for Rust" ;;
+                kotlin|kt)                           hint="{code:java} (Kotlin lexes acceptably as Java) or {code:none}" ;;
+                typescript|ts|tsx)                   hint="{code:javascript}" ;;
+                shell|zsh|fish|console)              hint="{code:bash}" ;;
+                make|makefile|Makefile)              hint="{code:none} for Makefile" ;;
+                ini|toml|conf|properties)            hint="{code:none} for INI / TOML / config" ;;
+                diff|patch)                          hint="{code:none}" ;;
+                go-template|gotmpl|jinja|jinja2)     hint="{code:none}" ;;
+            esac
+            if [ -n "$hint" ]; then
+                error "Unsupported {code:$lang} language. Jira Server rejects this; use $hint"
+            else
+                error "Unsupported {code:$lang} language. Jira Server rejects this; use {code:none} or one of: $valid_langs"
+            fi
         fi
     done < <(grep -oE '\{code:[^}|]+' <<< "$content" | sed 's/^{code://' | sort -u)
 


### PR DESCRIPTION
## Summary

`validate-jira-syntax.sh` already flags `{code:hcl}`, `{code:dockerfile}`, `{code:rust}`, etc. as rejected by Jira Server. Today the error always lists all 36 valid languages and lets the reader guess the right substitute:

```
❌ ERROR: Unsupported {code:hcl} language. Jira Server rejects this; use {code:none} or one of: actionscript ada applescript bash c c# c++ cpp css erlang go groovy haskell html java javascript js json lua none nyan objc perl php python r rainbow ruby scala sh sql swift visualbasic xml yaml
```

For the recurring stumbles, the closest-fit replacement is unambiguous (`{code:none}` for IaC, `{code:bash}` for Dockerfile, `{code:javascript}` for TypeScript). This PR makes the error suggest that targeted replacement first, falling back to the full list only for languages we have no hint for.

After:

```
❌ ERROR: Unsupported {code:hcl} language. Jira Server rejects this; use {code:none} for HCL / Terraform / OpenTofu
❌ ERROR: Unsupported {code:dockerfile} language. Jira Server rejects this; use {code:bash} (Dockerfile RUN lines lex acceptably as bash) or {code:none}
❌ ERROR: Unsupported {code:cobol} language. Jira Server rejects this; use {code:none} or one of: <full list>
```

## Motivation

Real-world friction: a Jira ticket comment with a Terraform snippet `{code:hcl}` was rejected by the validator, the agent tried `{code:none}` and was satisfied — but only after scanning the 36-item list. The targeted hint short-circuits that scan.

## Coverage

Hints added for: `hcl / tf / terraform / tofu`, `dockerfile / Dockerfile / containerfile`, `rust / rs`, `kotlin / kt`, `typescript / ts / tsx`, `shell / zsh / fish / console`, `make / Makefile`, `ini / toml / conf / properties`, `diff / patch`, `go-template / gotmpl / jinja / jinja2`.

Anything outside the hint table still gets the full valid-list (unchanged behaviour for the long tail).

## Test plan

- [x] `{code:hcl}` → suggests `{code:none}` for HCL / Terraform / OpenTofu
- [x] `{code:dockerfile}` → suggests `{code:bash}` or `{code:none}`
- [x] `{code:cobol}` (no hint) → falls back to full valid-list (regression check)
- [ ] Existing tests in `tests/` pass (no signatures changed; only the error string)