### PR TITLE
chore(release): v3.14.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.13.1"
+  version: "3.14.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.13.1"
+  version: "3.14.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
## Release v3.14.0

Minor release. Bumps `.claude-plugin/plugin.json` and `skills/jira-communication/SKILL.md` + `skills/jira-syntax/SKILL.md` frontmatter `metadata.version` from `v3.13.1` to `v3.14.0`.

### Highlights since v3.13.1

- `jira-link` gains `bulk-create`, `bulk-delete`, and `invert` subcommands plus natural-language success/dry-run output (#102, #105).
- `jira-search` gains a `--order-by` flag for JQL sorting, with quick-reference docs alongside embedded `ORDER BY` (#102).
- `jira-issue` gains intent verbs `work`, `qa`, `qa-fail`, and `act` for common transition flows (#106).
- `jira-syntax` validator now catches literal `{}` inside `{{...}}` and documents cross-project references (#105).
- Hardening across the CLI: per-attachment `Content-Type`, mixed label-mode rejection, centralized JQL escaping, sanitized error output, upload timeouts, and `jira-communication` SKILL.md trimmed to the 500-word validator cap.

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
