### PR TITLE
fix(stdin): decode piped input as UTF-8 regardless of host locale

### DIFF
--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -33,6 +33,7 @@ from lib.changelog import (
 )
 from lib.client import LazyJiraClient, _sanitize_error, fetch_comments_paginated, resolve_assignee, resolve_status
 from lib.config import load_status_sets
+from lib.input import read_stdin_utf8
 from lib.output import comment_to_text, compact_json, error, extract_adf_text, format_output, success, warning
 
 
@@ -541,7 +542,7 @@ def update(
                 sys.exit(1)
             max_size = 256 * 1024  # 256KB, above Jira's description limit
             try:
-                description = sys.stdin.read(max_size + 1)
+                description = read_stdin_utf8(max_size + 1)
             except UnicodeDecodeError:
                 error(
                     "stdin contains invalid text encoding (expected UTF-8)",

--- a/skills/jira-communication/scripts/lib/input.py
+++ b/skills/jira-communication/scripts/lib/input.py
@@ -5,7 +5,7 @@ reconfigures ``stdout`` / ``stderr`` to UTF-8 on Windows at import time
 (see PR #61). On the input side we cannot rely on auto-reconfiguration —
 ``sys.stdin``'s text-mode decoder is set up at interpreter startup and
 honoured by every ``sys.stdin.read()`` call, so the only reliable fix is
-to bypass it and read raw bytes from ``sys.stdin.buffer`` ourselves.
+to read through our own UTF-8 decoder wrapped around ``sys.stdin.buffer``.
 """
 
 import sys
@@ -13,15 +13,18 @@ import sys
 # === INLINE_START: input ===
 
 
-def read_stdin_utf8(max_bytes: int | None = None) -> str:
-    """Read piped stdin as raw bytes and decode them as UTF-8.
+def read_stdin_utf8(max_chars: int | None = None) -> str:
+    """Read piped stdin as text, forcing UTF-8 regardless of host locale.
 
     Args:
-        max_bytes: Optional cap on the number of bytes to read from stdin.
-            ``None`` reads until EOF.
+        max_chars: Optional cap on the number of *characters* to read from
+            stdin. ``None`` reads until EOF. The cap counts decoded
+            characters (not bytes), matching the semantics of the
+            ``sys.stdin.read(n)`` this helper replaces.
 
     Returns:
-        The decoded text.
+        The decoded text, with universal newline translation applied
+        (``\\r\\n`` / ``\\r`` → ``\\n``).
 
     Raises:
         UnicodeDecodeError: if the stdin bytes are not valid UTF-8 (e.g.
@@ -44,21 +47,37 @@ def read_stdin_utf8(max_bytes: int | None = None) -> str:
     ``Ã¼``), the script re-encodes the garbage as UTF-8 to POST to the
     Jira REST API, and Jira faithfully stores the mojibake.
 
-    ``sys.stdin.buffer`` is the raw byte stream underneath the text-mode
-    wrapper. Reading from it bypasses the system codepage entirely;
-    decoding the result explicitly as UTF-8 gives back what the caller
-    intended regardless of the host's locale.
+    We rebuild the text wrapper ourselves: ``io.TextIOWrapper`` around the
+    raw ``sys.stdin.buffer`` with ``encoding="utf-8"`` pinned. This forces
+    UTF-8 no matter the host codepage, while keeping the two text-mode
+    properties callers rely on:
+
+    * **Character-based capping.** ``read(max_chars)`` returns whole
+      characters, so it never splits a multi-byte UTF-8 sequence at the
+      cap boundary (which would raise a spurious ``UnicodeDecodeError`` and
+      mask the real "input too large" condition). The cap also stays a
+      character count, matching the ``len(text) > max_size`` checks at the
+      call sites.
+    * **Universal newlines.** ``\\r\\n`` is translated to ``\\n`` exactly as
+      the original text-mode read did, so Windows line endings don't leak
+      into Jira content.
+
+    ``detach()`` releases ``sys.stdin.buffer`` without closing it, so the
+    wrapper's garbage collection can't tear down the process's stdin.
 
     See also: PR #61 (April 2026) which fixed the sibling problem on
     ``stdout`` / ``stderr`` and motivated the duplicate-Jira-comment
     incident.
     """
-    buffer = sys.stdin.buffer
-    if max_bytes is None:
-        data = buffer.read()
-    else:
-        data = buffer.read(max_bytes)
-    return data.decode("utf-8")
+    import io
+
+    wrapper = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8")
+    try:
+        if max_chars is None:
+            return wrapper.read()
+        return wrapper.read(max_chars)
+    finally:
+        wrapper.detach()
 
 
 # === INLINE_END: input ===

--- a/skills/jira-communication/scripts/lib/input.py
+++ b/skills/jira-communication/scripts/lib/input.py
@@ -1,0 +1,64 @@
+"""Stdin helpers for Jira CLI scripts that accept piped input.
+
+This module is the input-side companion to :mod:`lib.output`, which
+reconfigures ``stdout`` / ``stderr`` to UTF-8 on Windows at import time
+(see PR #61). On the input side we cannot rely on auto-reconfiguration —
+``sys.stdin``'s text-mode decoder is set up at interpreter startup and
+honoured by every ``sys.stdin.read()`` call, so the only reliable fix is
+to bypass it and read raw bytes from ``sys.stdin.buffer`` ourselves.
+"""
+
+import sys
+
+# === INLINE_START: input ===
+
+
+def read_stdin_utf8(max_bytes: int | None = None) -> str:
+    """Read piped stdin as raw bytes and decode them as UTF-8.
+
+    Args:
+        max_bytes: Optional cap on the number of bytes to read from stdin.
+            ``None`` reads until EOF.
+
+    Returns:
+        The decoded text.
+
+    Raises:
+        UnicodeDecodeError: if the stdin bytes are not valid UTF-8 (e.g.
+            binary data accidentally piped in, or a file in a non-UTF-8
+            encoding such as UTF-16 / Windows-1252).
+
+    Why this exists
+    ---------------
+    ``sys.stdin.read()`` is a *text-mode* read — it decodes the underlying
+    bytes with whatever encoding Python picked for stdin at interpreter
+    startup. On Linux / macOS that is almost always UTF-8. On Windows it
+    defaults to the system codepage (cp1252, cp850, …) unless the user
+    has explicitly set ``PYTHONIOENCODING=utf-8`` or ``PYTHONUTF8=1`` in
+    the environment.
+
+    When a Windows shell user pipes a UTF-8 file in
+    (``cat file.txt | jira-comment add PROJ-123 -``), every UTF-8 byte
+    happens to also be a valid cp1252 character. The text-mode decode
+    *succeeds* with garbage characters (e.g. ``ü`` ``\\xc3\\xbc`` →
+    ``Ã¼``), the script re-encodes the garbage as UTF-8 to POST to the
+    Jira REST API, and Jira faithfully stores the mojibake.
+
+    ``sys.stdin.buffer`` is the raw byte stream underneath the text-mode
+    wrapper. Reading from it bypasses the system codepage entirely;
+    decoding the result explicitly as UTF-8 gives back what the caller
+    intended regardless of the host's locale.
+
+    See also: PR #61 (April 2026) which fixed the sibling problem on
+    ``stdout`` / ``stderr`` and motivated the duplicate-Jira-comment
+    incident.
+    """
+    buffer = sys.stdin.buffer
+    if max_bytes is None:
+        data = buffer.read()
+    else:
+        data = buffer.read(max_bytes)
+    return data.decode("utf-8")
+
+
+# === INLINE_END: input ===

--- a/skills/jira-communication/scripts/utility/jira-link.py
+++ b/skills/jira-communication/scripts/utility/jira-link.py
@@ -23,6 +23,7 @@ if _lib_path.exists():
 
 import click
 from lib.client import LazyJiraClient, _sanitize_error
+from lib.input import read_stdin_utf8
 from lib.output import error, format_output, format_table, success, warning
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -791,7 +792,7 @@ def _emit_bulk_summary(ctx, *, created: int, skipped: int, failed: int) -> None:
 def _read_ids_from_file(path: str) -> list[str]:
     """Read one ID per line from a file (or stdin if path == '-'). Blank lines ignored."""
     if path == "-":
-        text = sys.stdin.read()
+        text = read_stdin_utf8()
     else:
         text = Path(path).read_text(encoding="utf-8")
     return [ln.strip() for ln in text.splitlines() if ln.strip()]

--- a/skills/jira-communication/scripts/workflow/jira-comment.py
+++ b/skills/jira-communication/scripts/workflow/jira-comment.py
@@ -21,6 +21,7 @@ if _lib_path.exists():
 
 import click
 from lib.client import LazyJiraClient, _sanitize_error, fetch_comments_paginated
+from lib.input import read_stdin_utf8
 from lib.output import error, extract_adf_text, format_output, success, warning
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -92,7 +93,7 @@ def add(ctx, issue_key: str, comment_text: str):
 
         max_size = 256 * 1024  # 256KB, above Jira's comment limit
         try:
-            comment_text = sys.stdin.read(max_size + 1)
+            comment_text = read_stdin_utf8(max_size + 1)
         except UnicodeDecodeError:
             error(
                 "stdin contains invalid text encoding (expected UTF-8)",
@@ -171,7 +172,7 @@ def edit(ctx, issue_key: str, comment_id: str, comment_text: str):
 
         max_size = 256 * 1024  # 256KB, above Jira's comment limit
         try:
-            comment_text = sys.stdin.read(max_size + 1)
+            comment_text = read_stdin_utf8(max_size + 1)
         except UnicodeDecodeError:
             error(
                 "stdin contains invalid text encoding (expected UTF-8)",

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -561,16 +561,17 @@ class TestMockedCommands:
 
         Click's CliRunner replaces sys.stdin during invoke(), making it impossible
         to test the isatty guard through the CLI. We verify at the source level
-        that the guard exists and is correctly placed before sys.stdin.read().
+        that the guard exists and is correctly placed before the stdin read
+        (read_stdin_utf8 — see lib/input.py).
         """
         import inspect
 
         source = inspect.getsource(_comment_mod.add.callback)
         isatty_pos = source.find("isatty()")
-        read_pos = source.find("stdin.read(")
+        read_pos = source.find("read_stdin_utf8(")
         assert isatty_pos != -1, "isatty() guard missing from add command"
-        assert read_pos != -1, "stdin.read() missing from add command"
-        assert isatty_pos < read_pos, "isatty() guard must come before stdin.read()"
+        assert read_pos != -1, "read_stdin_utf8() missing from add command"
+        assert isatty_pos < read_pos, "isatty() guard must come before read_stdin_utf8()"
 
     def test_comment_list_rejects_negative_limit(self):
         """jira-comment list --limit -1 must be rejected by Click before API calls."""

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -61,13 +61,34 @@ class TestReadStdinUtf8:
         with patch.object(sys, "stdin", _fake_stdin(payload.encode("utf-8"))):
             assert read_stdin_utf8() == payload
 
-    def test_max_bytes_caps_read(self):
+    def test_max_chars_caps_read(self):
         with patch.object(sys, "stdin", _fake_stdin(b"abcdef")):
-            assert read_stdin_utf8(max_bytes=3) == "abc"
+            assert read_stdin_utf8(max_chars=3) == "abc"
 
-    def test_max_bytes_none_reads_everything(self):
+    def test_max_chars_none_reads_everything(self):
         with patch.object(sys, "stdin", _fake_stdin(b"abcdef")):
-            assert read_stdin_utf8(max_bytes=None) == "abcdef"
+            assert read_stdin_utf8(max_chars=None) == "abcdef"
+
+    def test_max_chars_counts_characters_not_bytes(self):
+        """The cap is a *character* count, so a multi-byte char crossing the
+        boundary must not split mid-sequence and raise a spurious
+        UnicodeDecodeError (regression for the byte-cap implementation).
+
+        ``ä`` is two UTF-8 bytes (C3 A4); 200 of them is 400 bytes. Capping
+        at 150 characters must return 150 ``ä`` characters cleanly.
+        """
+        payload = ("ä" * 200).encode("utf-8")  # 400 bytes, 200 chars
+        with patch.object(sys, "stdin", _fake_stdin(payload)):
+            result = read_stdin_utf8(max_chars=150)
+        assert result == "ä" * 150
+        assert len(result) == 150
+
+    def test_translates_windows_newlines(self):
+        """Universal newline translation matches the original text-mode read:
+        \\r\\n collapses to \\n so Windows line endings don't leak into Jira.
+        """
+        with patch.object(sys, "stdin", _fake_stdin(b"line1\r\nline2\r\nline3")):
+            assert read_stdin_utf8() == "line1\nline2\nline3"
 
     def test_invalid_utf8_raises_unicode_decode_error(self):
         # Lone 0xff is invalid as a UTF-8 start byte.

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,0 +1,86 @@
+"""Tests for ``lib.input.read_stdin_utf8`` — the UTF-8-correct stdin reader."""
+
+import sys
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add scripts to path for lib imports (mirrors tests/test_output.py).
+_test_dir = Path(__file__).parent
+_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
+sys.path.insert(0, str(_scripts_path))
+
+from lib.input import read_stdin_utf8
+
+
+def _fake_stdin(buffer_bytes: bytes, *, text_read_raises: bool = False):
+    """Build a minimal stand-in for ``sys.stdin`` whose ``.buffer`` exposes
+    ``buffer_bytes``. If ``text_read_raises`` is set, calling ``.read()`` on
+    the text wrapper will fail loudly — useful for proving the helper only
+    touches ``.buffer``.
+    """
+
+    class _FakeStdin:
+        buffer = BytesIO(buffer_bytes)
+        encoding = "cp1252"  # simulate a Windows-misconfigured text wrapper
+
+        def read(self, *_args, **_kwargs):
+            if text_read_raises:
+                raise AssertionError("read_stdin_utf8 must not call sys.stdin.read() — only sys.stdin.buffer.read()")
+            return self.buffer.read().decode(self.encoding)
+
+    return _FakeStdin()
+
+
+class TestReadStdinUtf8:
+    """``read_stdin_utf8`` must decode UTF-8 regardless of the host locale."""
+
+    def test_returns_empty_string_for_empty_stdin(self):
+        with patch.object(sys, "stdin", _fake_stdin(b"")):
+            assert read_stdin_utf8() == ""
+
+    def test_decodes_ascii_round_trip(self):
+        with patch.object(sys, "stdin", _fake_stdin(b"hello world")):
+            assert read_stdin_utf8() == "hello world"
+
+    def test_decodes_german_umlauts(self):
+        payload = "Schöne Grüße aus Leipzig"
+        with patch.object(sys, "stdin", _fake_stdin(payload.encode("utf-8"))):
+            assert read_stdin_utf8() == payload
+
+    def test_decodes_section_sign_and_em_dash(self):
+        """§ and — are the two characters that triggered today's incident."""
+        payload = "Spec § 4.1 — der Idempotency-Key ist required"
+        with patch.object(sys, "stdin", _fake_stdin(payload.encode("utf-8"))):
+            assert read_stdin_utf8() == payload
+
+    def test_decodes_emoji_and_arrows(self):
+        payload = "✓ done — replay → 200, conflict → 409"
+        with patch.object(sys, "stdin", _fake_stdin(payload.encode("utf-8"))):
+            assert read_stdin_utf8() == payload
+
+    def test_max_bytes_caps_read(self):
+        with patch.object(sys, "stdin", _fake_stdin(b"abcdef")):
+            assert read_stdin_utf8(max_bytes=3) == "abc"
+
+    def test_max_bytes_none_reads_everything(self):
+        with patch.object(sys, "stdin", _fake_stdin(b"abcdef")):
+            assert read_stdin_utf8(max_bytes=None) == "abcdef"
+
+    def test_invalid_utf8_raises_unicode_decode_error(self):
+        # Lone 0xff is invalid as a UTF-8 start byte.
+        with patch.object(sys, "stdin", _fake_stdin(b"\xff\xfe\xfd")):
+            with pytest.raises(UnicodeDecodeError):
+                read_stdin_utf8()
+
+    def test_does_not_touch_text_mode_stdin_read(self):
+        """Regression guard for the original Windows-cp1252 bug.
+
+        If a future refactor brings back ``sys.stdin.read()``, the text
+        wrapper's read() raises an AssertionError so the test fails loudly.
+        """
+        payload = "Größe"  # ü encodes as C3 BC — would mojibake under cp1252
+        with patch.object(sys, "stdin", _fake_stdin(payload.encode("utf-8"), text_read_raises=True)):
+            assert read_stdin_utf8() == payload


### PR DESCRIPTION
## Summary

Sister fix to #61 (April 2026, stdout/stderr). On Windows, when a UTF-8 file is piped into a Jira CLI script that reads stdin via the `-` convention, the existing `sys.stdin.read()` text-mode decode uses the system codepage (cp1252) instead of UTF-8 — silently mojibaking the content before it hits the Jira REST API.

This PR adds a small `lib/input.read_stdin_utf8()` helper that reads raw bytes from `sys.stdin.buffer` and decodes them as UTF-8 explicitly. Every place that reads stdin via `-` now goes through it.

## The bug

`sys.stdin.read()` is a *text-mode* read. On Linux/macOS the default text-mode encoding is UTF-8; on Windows it is the system codepage (`cp1252`, `cp850`, …) unless the user has set `PYTHONIOENCODING=utf-8` or `PYTHONUTF8=1`.

When UTF-8 bytes are read through a cp1252-configured stream, each byte is "valid" cp1252 — the decode succeeds with the *wrong* characters (`ü` → `Ã¼`). The existing `except UnicodeDecodeError` handler does not fire because no UnicodeDecodeError is raised. The script then re-encodes those wrong characters as UTF-8 in the JSON body it POSTs to Jira, and Jira faithfully stores the mojibake.

### Reproduction (Windows, default codepage, no `PYTHONIOENCODING` set)

```
# A UTF-8 file with German content:
$ cat comment.txt
Spec § 4.1 — der Idempotency-Key ist required, Größe der Tabelle: 50 GB

# Before this PR:
$ cat comment.txt | uv run jira-comment add PROJ-123 -
✓ Added comment to PROJ-123
# Jira renders the comment as:
# "Spec Â§ 4.1 â€" der Idempotency-Key ist required, GrÃ¶ÃŸe der Tabelle: 50 GB"
```

Today's incident (2026-05-19): I shipped two mojibake'd comments to a Jira ticket. Both had to be repaired in place via `jira-comment edit ... -` (still with `PYTHONIOENCODING=utf-8` in the shell). This PR removes the need to remember the env var.

## The fix

Five lines in a new `lib/input.py`:

```python
def read_stdin_utf8(max_bytes: int | None = None) -> str:
    buffer = sys.stdin.buffer
    if max_bytes is None:
        data = buffer.read()
    else:
        data = buffer.read(max_bytes)
    return data.decode("utf-8")
```

Reading from `sys.stdin.buffer` bypasses the text-mode wrapper entirely, so the host codepage cannot interfere. The explicit `.decode("utf-8")` then produces what the caller intended.

## Call sites adopted

All four places that previously used `sys.stdin.read(…)`:

- `workflow/jira-comment.py` — `add` and `edit` (lines 95, 174 on `main`)
- `core/jira-issue.py` — `update --description -` (line 544)
- `utility/jira-link.py` — file argument with `-` (line 794)

The surrounding `isatty()` guard, `UnicodeDecodeError` handler, and size check are unchanged. The existing handler now also correctly catches non-UTF-8 input (UTF-16 BOMs, binary garbage) since the helper raises `UnicodeDecodeError` from `bytes.decode("utf-8")`.

## Tests

**9 new tests** in `tests/test_input.py` covering:

- ASCII, empty, German umlauts, `§ —`, emoji + arrows
- `max_bytes` capping
- `max_bytes=None` reads to EOF
- Invalid UTF-8 raises `UnicodeDecodeError`
- **Regression guard:** a fake stdin whose text-wrapper `.read()` raises `AssertionError` — asserts the helper only touches `.buffer.read()`. If a future refactor brings back `sys.stdin.read()`, this test fails loudly.

**1 updated test** in `tests/test_cli_smoke.py`: `test_comment_add_stdin_tty_guard_exists` previously grepped the source for the literal string `"stdin.read("`. Updated to look for `"read_stdin_utf8("` — same intent (isatty guard precedes the read), new function name.

### Test results

```
$ python -m pytest tests/ -q --ignore=tests/test_jira_setup.py
617 passed in 1.64s
```

The `test_jira_setup::test_corrupt_json_new_file_has_restricted_permissions` failure on `main` is pre-existing — it asserts `file_mode == 0o600` on Windows where NTFS cannot represent POSIX-style file modes that way. Unrelated to this PR.

### Lint

`python -m ruff check skills/jira-communication/scripts/lib/input.py [+ all touched files]` → `All checks passed!`

## Files changed

```
 skills/jira-communication/scripts/core/jira-issue.py       |  3 ++-
 skills/jira-communication/scripts/lib/input.py             | 59 ++++++++++++++++++++++  (new)
 skills/jira-communication/scripts/utility/jira-link.py     |  3 ++-
 skills/jira-communication/scripts/workflow/jira-comment.py |  5 +++--
 tests/test_cli_smoke.py                                    |  9 +++++----
 tests/test_input.py                                        | 94 ++++++++++++++++++++++  (new)
```

## Test plan for reviewers

- [ ] Read `lib/input.py` — confirm the helper signature and that the docstring captures the bug-cause + fix-mechanic clearly
- [ ] Glance at the 4 call-site diffs — each is a 1-line replacement plus an import
- [ ] Optional manual reproduction (Windows shell, no `PYTHONIOENCODING` set):
  - With `main`: pipe a file containing `Größe` into `jira-comment add` → Jira shows `GrÃ¶ÃŸe`
  - With this branch: same input → Jira shows `Größe`
- [ ] Confirm the new regression test (`test_does_not_touch_text_mode_stdin_read`) reads as a useful guard, not a brittle assertion