### PR TITLE
docs(jira-syntax): call out the literal-{code}-in-prose macro gotcha

### DIFF
--- a/skills/jira-syntax/references/jira-syntax-quick-reference.md
+++ b/skills/jira-syntax/references/jira-syntax-quick-reference.md
@@ -259,6 +259,22 @@ Horizontal rule (4 dashes)
 
 To escape special characters, use backslash: `\*`, `\{`, `\[`
 
+### Common gotcha: macro names in prose
+
+Writing a macro name literally in prose (e.g. *"commands wrapped in \{code\} blocks"*) without escaping breaks rendering — Jira parses the literal as the *start* of a code-block macro and either consumes the rest of the comment or pairs with the next unrelated occurrence it finds. The same trap applies to any macro that opens and closes with the same token: `{noformat}…{noformat}`, `{quote}…{quote}`, `{color}…{color}`, `{panel}…{panel}`, `{anchor}…{anchor}`, and so on.
+
+Three ways to write the literal token safely, in order of preference:
+
+| Approach | Example | When to use |
+|----------|---------|-------------|
+| Rephrase to avoid the token | `commands shown as code blocks` | First choice — readers don't need the macro name to understand the prose |
+| Backslash-escape | `\{code\}` | When you genuinely need to show the macro name |
+| Wrap in a code span | `` `{{code}}` `` | Last resort — some style guides ban inline `{{monospace}}` in favour of bold `*term*` for technical terms |
+
+The backslash escape is the official Jira mechanism; the rephrase is editorial; the `{{monospace}}` wrap renders fine but is disliked by teams that reserve monospace for actual code spans rather than inline references.
+
+A quick sanity check before posting: run `skills/jira-syntax/scripts/validate-jira-syntax.sh <file>` on your draft (from the repo root). The script verifies that the six paired macros (`code`, `panel`, `color`, `noformat`, `quote`, `anchor`) are balanced — every opener matches a closer, even with a language tag like `{code:bash}` — and catches Markdown leakage (` ``` ` fences, `[text](url)` links, `` `code` `` spans), language declarations Jira Server does not recognise, and malformed table headers.
+
 ## Emoticons
 
 | Code | Emoji | Meaning |

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -185,6 +185,16 @@ validate_file() {
         warning "Potential unclosed {color} tag (odd number of occurrences)"
     fi
 
+    # Check for unclosed {noformat}, {quote}, {anchor} blocks
+    # Same single-token open/close rule as {code}, {panel}, {color}: an odd
+    # occurrence count signals an unescaped literal in prose or a missing close.
+    for macro in noformat quote anchor; do
+        local mcount=$(grep -oE "\{${macro}[}:]" <<< "$content" | wc -l)
+        if [ $((mcount % 2)) -ne 0 ]; then
+            warning "Potential unclosed {${macro}} tag (odd number of occurrences)"
+        fi
+    done
+
     # Check for Markdown-style lists (- item instead of * item)
     if echo "$content" | grep -qE "^- [^-]"; then
         warning "Found Markdown-style bullets (- item). Jira prefers: * item"


### PR DESCRIPTION
## Why

The existing escape guidance under *Special Characters* is correct (`\{escaped brace\}`, "use backslash for `\*`, `\{`, `\[`") but generic enough that it doesn't surface the specific recurring trip-up: writing `{code}`, `{noformat}`, `{quote}`, etc. literally in prose.

Concrete failure mode I just hit while QA-ing several Netresearch maintenance tickets:

> `* (/) Commands in {code} blocks throughout`

Jira parses the unescaped `{code}` as the *start* of a code-macro and pairs it with the next `{code}` it finds (either consuming the rest of the comment, or pairing across unrelated code blocks). Renders as visual garbage.

## What

A new "Common gotcha: macro names in prose" callout under *Special Characters* in `skills/jira-syntax/references/jira-syntax-quick-reference.md`:

- Names the failure mode explicitly so it's grep-able when someone hits it.
- Lists three safe alternatives in editorial order: rephrase / backslash-escape / inline-monospace wrap.
- Notes the inline-monospace wrap (`{{...}}`) is fine in stock Jira but disliked by some downstream style guides (e.g. the netresearch maintenance skill's `conventions.md`).
- Adds a pre-post sanity check: odd count of `{code}` tokens in a draft = unbalanced literal somewhere.

Scope kept to the reference doc per the repo's "small PR" rule. A validator extension (grep for odd `{code}` count in `scripts/validate-jira-syntax.sh`) is a sensible follow-up but kept out of this PR.

## Test plan

- [ ] Render the new callout in a real Jira preview to confirm the example renderings match the description.
- [ ] No template or script changes, so the existing `scripts/validate-jira-syntax.sh templates/*.md` check stays green.