### PR TITLE
ci(codeql): replace default setup with advanced-setup workflow (fork-PR coverage)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,21 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '27 3 * * 1'
+
+permissions: {}
+
+jobs:
+  codeql:
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    with:
+      languages: actions,python


### PR DESCRIPTION
## Summary

GitHub CodeQL **default setup does not run on pull requests from forks**, so the required `Analyze (actions)` / `Analyze (python)` status checks never appear on fork PRs — leaving them permanently `BLOCKED` (hit on #98, currently blocking #113).

This replaces default setup with the org **advanced-setup** reusable workflow (`netresearch/.github/.github/workflows/codeql.yml`), which runs on `pull_request` and therefore **also covers fork PRs**.

## Changes

- Add `.github/workflows/codeql.yml` calling the org reusable CodeQL workflow with `languages: actions,python`.
- Default setup has already been **disabled** via the code-scanning API (default and advanced setup are mutually exclusive).

## Follow-up (done at merge time, not in this diff)

Branch-protection required contexts swap from the unprefixed default-setup names to the caller-prefixed advanced-setup names:
- `Analyze (actions)` → `codeql / Analyze (actions)`
- `Analyze (python)` → `codeql / Analyze (python)`

## Type of Change

- [x] CI / build / dependencies

## Checklist

- [x] Commits are signed (`-S`) and signed-off (`--signoff`)
- [x] Commits follow Conventional Commits format