### PR TITLE
fix(version): strip user-date mirrors from safe-merge PUT (closes #103)

### DIFF
--- a/skills/jira-communication/scripts/workflow/jira-version.py
+++ b/skills/jira-communication/scripts/workflow/jira-version.py
@@ -304,8 +304,16 @@ def _safe_update_version(client, vid: str, **patch) -> dict:
         if value is _UNSET:
             continue
         merged[key] = value
-    # Strip server-managed fields we shouldn't echo back
-    for ro in ("self", "operations", "projectId"):
+    # Strip server-managed fields we shouldn't echo back.
+    #
+    # userReleaseDate / userStartDate are display-only, locale-formatted
+    # mirrors of releaseDate / startDate that Jira Server/DC includes in the
+    # GET response (e.g. "06/Mai/26"). Echoing them back alongside the ISO
+    # releaseDate / startDate trips the API's mutually-exclusive validation:
+    #   "Only one of 'releaseDate' and 'userReleaseDate' can be specified
+    #    when editing a version."
+    # Jira regenerates them from the ISO dates on read, so dropping them is safe.
+    for ro in ("self", "operations", "projectId", "userReleaseDate", "userStartDate"):
         merged.pop(ro, None)
     return client.put(f"rest/api/2/version/{vid}", data=merged)
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -510,6 +510,39 @@ class TestSafeUpdate:
         # description retained from GET, not cleared
         assert body["description"] == "orig"
 
+    def test_strips_user_date_mirrors_from_put_body(self):
+        """Regression for #103.
+
+        Jira Server/DC returns display-only ``userReleaseDate`` /
+        ``userStartDate`` mirrors alongside the ISO dates. Echoing them back
+        in the PUT trips the API's mutually-exclusive validation:
+        "Only one of 'releaseDate' and 'userReleaseDate' can be specified".
+        They must be stripped from the merged body.
+        """
+        mc = _make_mock_client()
+        current = _make_version(
+            "10042",
+            "1.4.0",
+            released=False,
+            start_date="2026-05-01",
+            release_date="2026-05-06",
+        )
+        # Server/DC GET response also carries the locale-formatted mirrors.
+        current["userReleaseDate"] = "06/Mai/26"
+        current["userStartDate"] = "01/Mai/26"
+        mc.get.return_value = current
+        mc.put.return_value = {}
+
+        _mod._safe_update_version(mc, "10042", released=True)
+
+        body = mc.put.call_args.kwargs.get("data") or mc.put.call_args.kwargs.get("json")
+        assert "userReleaseDate" not in body
+        assert "userStartDate" not in body
+        # The ISO dates the server derives them from are preserved.
+        assert body["releaseDate"] == "2026-05-06"
+        assert body["startDate"] == "2026-05-01"
+        assert body["released"] is True
+
 
 class TestUpdate:
     def test_update_description(self):


### PR DESCRIPTION
## Summary

Fixes #103 — `jira-version release <id>` and `update --released` fail on Jira Server/DC with:

> Only one of `releaseDate` and `userReleaseDate` can be specified when editing a version.

## Root cause

`_safe_update_version` GETs the current version, dict-merges the caller's patch onto it, and PUTs the whole thing back (to avoid clobbering unspecified fields). On Server/DC the GET response carries display-only, locale-formatted mirrors of the dates — `userReleaseDate` / `userStartDate` (e.g. `06/Mai/26`) — *next to* the ISO `releaseDate` / `startDate`. Sending both halves of a mutually-exclusive pair makes the API reject the edit.

The previous strip list only dropped `self`, `operations`, `projectId`.

## Fix

Add `userReleaseDate` and `userStartDate` to the strip list. They are derived display fields; Jira regenerates them from the ISO dates on read, so dropping them from the PUT body is safe and the ISO dates are preserved.

## Tests

New regression test `TestSafeUpdate::test_strips_user_date_mirrors_from_put_body`: GET returns both the ISO dates and the locale mirrors; asserts the PUT body omits the `user*` mirrors and keeps the ISO dates. Verified it **fails** without the one-line fix and passes with it. Full `test_version.py` suite green (95 passed); ruff clean.

Closes #103.