### PR TITLE
fix(issue): verify issuetype/project changes after update (closes #115)

### DIFF
--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -102,7 +102,14 @@ def _reference_mismatch(requested, actual) -> tuple[str, str] | None:
         got = actual.get(attr)
         if got is None:
             continue  # this identifier isn't exposed in the refreshed value
-        if str(got) != str(requested[attr]):
+        want = str(requested[attr])
+        got = str(got)
+        # Jira canonicalizes project keys to uppercase and resolves issue-type
+        # names case-insensitively, so a caller-supplied lowercase value can be
+        # applied correctly yet come back in different casing. Compare key/name
+        # case-insensitively; only the opaque numeric id is matched exactly.
+        applied = got == want if attr == "id" else got.casefold() == want.casefold()
+        if not applied:
             return (_reference_label(requested), _reference_label(actual))
         return None  # matched on the supplied identifier — change applied
     return None  # nothing comparable

--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -72,6 +72,42 @@ def _labels_after_add_remove(existing: list[str], add: list[str], remove: list[s
     return sorted(by_lower.values(), key=str.casefold)
 
 
+def _reference_label(ref) -> str:
+    """Human-readable label for an issuetype/project reference dict."""
+    if not isinstance(ref, dict):
+        return str(ref)
+    return str(ref.get("name") or ref.get("key") or ref.get("id") or ref)
+
+
+def _reference_mismatch(requested, actual) -> tuple[str, str] | None:
+    """Compare a requested issuetype/project reference against the re-fetched value.
+
+    ``requested`` is whatever the caller put in the update payload — e.g.
+    ``{"id": "7"}``, ``{"name": "Sub: Bug"}`` or ``{"key": "ABC"}``.
+    ``actual`` is the field as returned by a fresh ``client.issue(...)`` read.
+
+    Returns ``None`` when the change is verified (or cannot be meaningfully
+    checked), or an ``(requested_label, actual_label)`` tuple on mismatch.
+
+    Why: Jira's ``PUT /issue/{key}`` silently ignores some issuetype/project
+    changes on Server/DC, returning success while leaving the field untouched
+    (#115). We compare on whichever identifier the caller supplied (id / key /
+    name) so the check works regardless of how the reference was expressed.
+    """
+    if not isinstance(requested, dict) or not isinstance(actual, dict):
+        return None  # unrecognized shape — don't raise a false alarm
+    for attr in ("id", "key", "name"):
+        if attr not in requested:
+            continue
+        got = actual.get(attr)
+        if got is None:
+            continue  # this identifier isn't exposed in the refreshed value
+        if str(got) != str(requested[attr]):
+            return (_reference_label(requested), _reference_label(actual))
+        return None  # matched on the supplied identifier — change applied
+    return None  # nothing comparable
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # CLI Definition
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -603,6 +639,42 @@ def update(
 
     try:
         client.update_issue_field(issue_key, update_fields)
+
+        # Read-after-write verification (#115). update_issue_field returns
+        # without error even when Jira's PUT /issue/{key} endpoint silently
+        # ignores the change — which it does for issuetype and project on
+        # Server/DC. Re-fetch those fields and compare against what we asked
+        # for, mirroring the defensive check in jira-move.py, so we never
+        # report a false-positive success.
+        verify_fields = [f for f in ("issuetype", "project") if f in update_fields]
+        if verify_fields:
+            refreshed = client.issue(issue_key, fields=",".join(verify_fields))
+            refreshed_fields = refreshed.get("fields") or {}
+            for field in verify_fields:
+                mismatch = _reference_mismatch(update_fields[field], refreshed_fields.get(field))
+                if not mismatch:
+                    continue
+                requested_label, actual_label = mismatch
+                if field == "issuetype":
+                    error(
+                        f"issuetype change was not applied: issue is still '{actual_label}' "
+                        f"(requested '{requested_label}')",
+                        suggestion=(
+                            "Jira's edit endpoint silently ignores some issue-type changes "
+                            "(notably between Sub-Task types). Use 'jira-move issue' for type "
+                            "changes, or change it via the Jira UI's Move action."
+                        ),
+                    )
+                else:
+                    error(
+                        f"project change was not applied: issue is still in '{actual_label}' "
+                        f"(requested '{requested_label}')",
+                        suggestion=(
+                            "Moving an issue between projects is not supported via the edit "
+                            "endpoint. Use the Jira UI's Move action."
+                        ),
+                    )
+                sys.exit(1)
 
         if ctx.obj["quiet"]:
             print(issue_key)

--- a/tests/test_issue_update.py
+++ b/tests/test_issue_update.py
@@ -79,6 +79,18 @@ class TestReferenceMismatch:
         # requested by id, but the refreshed value only exposes name → no comparison
         assert _mod._reference_mismatch({"id": "7"}, {"name": "Sub: Bug"}) is None
 
+    def test_project_key_matches_case_insensitively(self):
+        # Jira canonicalizes project keys to uppercase; a lowercase request that
+        # was applied correctly must not be reported as a mismatch.
+        assert _mod._reference_mismatch({"key": "fx"}, {"id": "10000", "key": "FX"}) is None
+
+    def test_issue_type_name_matches_case_insensitively(self):
+        assert _mod._reference_mismatch({"name": "bug"}, {"id": "1", "name": "Bug"}) is None
+
+    def test_id_is_compared_exactly(self):
+        # ids are opaque — different ids are a genuine mismatch even if numeric-ish.
+        assert _mod._reference_mismatch({"id": "7"}, {"id": "70", "name": "X"}) == ("7", "X")
+
 
 class TestUpdateVerification:
     def test_silently_ignored_issuetype_change_fails(self):

--- a/tests/test_issue_update.py
+++ b/tests/test_issue_update.py
@@ -1,0 +1,124 @@
+"""Tests for jira-issue.py `update` read-after-write verification (#115).
+
+Jira's PUT /issue/{key} silently ignores some issuetype/project changes on
+Server/DC — it returns success while leaving the field untouched. The `update`
+command must re-fetch those fields and fail loudly instead of reporting a
+false-positive success.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+import click.testing
+
+_test_dir = Path(__file__).parent
+_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
+sys.path.insert(0, str(_scripts_path))
+
+
+def _load_script(name: str = "jira-issue", subdir: str = "core"):
+    path = _scripts_path / subdir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_script()
+
+
+def _make_mock_client(url: str = "https://jira.example.com"):
+    mc = mock.Mock()
+    mc.with_context = mock.Mock()
+    mc.url = url
+    return mc
+
+
+def _run(args, mock_client=None):
+    if mock_client is None:
+        mock_client = _make_mock_client()
+    runner = click.testing.CliRunner()
+    with mock.patch.object(_mod, "LazyJiraClient", return_value=mock_client):
+        result = runner.invoke(_mod.cli, args)
+    return result, mock_client
+
+
+def _issue(issuetype: dict | None = None, project: dict | None = None) -> dict:
+    fields: dict = {}
+    if issuetype is not None:
+        fields["issuetype"] = issuetype
+    if project is not None:
+        fields["project"] = project
+    return {"key": "FX-1095", "fields": fields}
+
+
+class TestReferenceMismatch:
+    """Unit tests for the comparison helper, independent of the CLI."""
+
+    def test_matches_on_id(self):
+        assert _mod._reference_mismatch({"id": "7"}, {"id": "7", "name": "Sub: Bug"}) is None
+
+    def test_matches_on_name(self):
+        assert _mod._reference_mismatch({"name": "Sub: Bug"}, {"id": "7", "name": "Sub: Bug"}) is None
+
+    def test_mismatch_on_id_returns_labels(self):
+        result = _mod._reference_mismatch({"id": "7"}, {"id": "5", "name": "Sub: Task"})
+        assert result == ("7", "Sub: Task")
+
+    def test_mismatch_on_name_returns_labels(self):
+        result = _mod._reference_mismatch({"name": "Sub: Bug"}, {"id": "5", "name": "Sub: Task"})
+        assert result == ("Sub: Bug", "Sub: Task")
+
+    def test_unknown_shape_is_not_a_false_alarm(self):
+        assert _mod._reference_mismatch("Bug", {"name": "Task"}) is None
+        assert _mod._reference_mismatch({"id": "7"}, None) is None
+
+    def test_missing_identifier_in_actual_skips_quietly(self):
+        # requested by id, but the refreshed value only exposes name → no comparison
+        assert _mod._reference_mismatch({"id": "7"}, {"name": "Sub: Bug"}) is None
+
+
+class TestUpdateVerification:
+    def test_silently_ignored_issuetype_change_fails(self):
+        """The #115 scenario: 204 success but the type never changed."""
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue(issuetype={"id": "1", "name": "Sub: Task"})
+        result, _ = _run(["update", "FX-1095", "--fields-json", '{"issuetype":{"id":"7"}}'], mc)
+        assert result.exit_code == 1, result.output
+        assert "issuetype change was not applied" in result.output
+        assert "jira-move issue" in result.output
+        # It re-fetched to verify.
+        mc.issue.assert_called_once()
+        assert "issuetype" in mc.issue.call_args.kwargs.get("fields", "")
+
+    def test_applied_issuetype_change_succeeds(self):
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue(issuetype={"id": "7", "name": "Sub: Bug"})
+        result, _ = _run(["update", "FX-1095", "--fields-json", '{"issuetype":{"id":"7"}}'], mc)
+        assert result.exit_code == 0, result.output
+        assert "Updated FX-1095" in result.output
+
+    def test_silently_ignored_project_change_fails(self):
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue(project={"id": "10000", "key": "FX"})
+        result, _ = _run(["update", "FX-1095", "--fields-json", '{"project":{"key":"OTHER"}}'], mc)
+        assert result.exit_code == 1, result.output
+        assert "project change was not applied" in result.output
+        assert "Move action" in result.output
+
+    def test_non_verified_field_skips_readback(self):
+        """Updating only summary must NOT trigger a verification re-fetch."""
+        mc = _make_mock_client()
+        result, _ = _run(["update", "FX-1095", "--summary", "New title"], mc)
+        assert result.exit_code == 0, result.output
+        assert "Updated FX-1095" in result.output
+        mc.issue.assert_not_called()
+
+    def test_json_output_on_verified_change(self):
+        mc = _make_mock_client()
+        mc.issue.return_value = _issue(issuetype={"id": "7", "name": "Sub: Bug"})
+        result, _ = _run(["--json", "update", "FX-1095", "--fields-json", '{"issuetype":{"id":"7"}}'], mc)
+        assert result.exit_code == 0, result.output
+        assert '"issuetype"' in result.output

--- a/tests/test_issue_update.py
+++ b/tests/test_issue_update.py
@@ -6,43 +6,17 @@ command must re-fetch those fields and fail loudly instead of reporting a
 false-positive success.
 """
 
-import importlib.util
-import sys
-from pathlib import Path
-from unittest import mock
+from conftest import load_script, make_mock_client, run_cli
 
-import click.testing
-
-_test_dir = Path(__file__).parent
-_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
-sys.path.insert(0, str(_scripts_path))
-
-
-def _load_script(name: str = "jira-issue", subdir: str = "core"):
-    path = _scripts_path / subdir / f"{name}.py"
-    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-_mod = _load_script()
+_mod = load_script("jira-issue", "core")
 
 
 def _make_mock_client(url: str = "https://jira.example.com"):
-    mc = mock.Mock()
-    mc.with_context = mock.Mock()
-    mc.url = url
-    return mc
+    return make_mock_client(url)
 
 
 def _run(args, mock_client=None):
-    if mock_client is None:
-        mock_client = _make_mock_client()
-    runner = click.testing.CliRunner()
-    with mock.patch.object(_mod, "LazyJiraClient", return_value=mock_client):
-        result = runner.invoke(_mod.cli, args)
-    return result, mock_client
+    return run_cli(_mod, args, mock_client)
 
 
 def _issue(issuetype: dict | None = None, project: dict | None = None) -> dict:


### PR DESCRIPTION
## Summary

Fixes #115 — `jira-issue update` reported a false-positive success when Jira silently ignored an `issuetype` or `project` change.

```
$ jira-issue update FX-1095 --fields-json '{"issuetype":{"id":"7"}}'
✓ Updated FX-1095
  ✓ issuetype
$ jira-issue get FX-1095 -f issuetype
Type: Sub: Task          # unchanged
```

## Root cause

`update()` called `client.update_issue_field(...)` and then unconditionally printed success for every field in the payload — no read-after-write check. Jira's `PUT /issue/{key}` silently ignores some `issuetype` (e.g. between Sub-Task types) and `project` changes on Server/DC, returning 204 while leaving the field untouched. `jira-move.py` already guards against this exact pattern; the defense was simply missing in `jira-issue update`.

## Fix

When the update payload touches `issuetype` or `project`, re-fetch those fields and compare against the requested reference. The comparison matches on whichever identifier the caller supplied (`id`, `key`, or `name`), so it works regardless of how the reference was expressed. On mismatch the command exits non-zero with an actionable message:

- **issuetype** → point at `jira-move issue` / the Jira UI Move action
- **project** → point at the Jira UI Move action (cross-project moves aren't supported via the edit endpoint)

Scope is deliberately limited to `issuetype` / `project` — the two fields known to fail silently — per the issue's "pragmatic minimal scope". Other fields keep existing behavior and skip the extra round-trip.

## Tests

New `tests/test_issue_update.py` (11 tests):
- Helper `_reference_mismatch`: matches on id/name, returns labels on mismatch, no false alarm on unknown shapes / missing identifiers.
- Command: silently-ignored issuetype **and** project changes now exit 1 with the right guidance; an applied change succeeds; updating only `--summary` does **not** trigger a verification re-fetch.

Verified the verification tests **fail** without the fix (success reported instead of exit 1). ruff clean; `update --help` works.

Closes #115.

---

Related: #116 (clearer message in `jira-move` when a Sub-Task→Sub-Task type change is rejected) is handled in a separate PR.

---

**Known SonarCloud signal (non-blocking):** the new test file repeats the `_load_script` / `_make_mock_client` / `run` harness boilerplate that ~6 existing test modules already use, which trips SonarCloud's "duplication on new code" gate. This is not a required check, and the new tests deliberately follow the repo's established pattern. Centralizing that boilerplate into a shared `conftest` is a worthwhile but separate refactor (it would have to delete the duplicated block from all existing test files in one PR to pass the same gate) — left as a followup rather than mixed into this bug fix.