### PR TITLE
fix(move): clearer error when Jira REST rejects an issue-type change (closes #116)

### DIFF
--- a/skills/jira-communication/scripts/workflow/jira-move.py
+++ b/skills/jira-communication/scripts/workflow/jira-move.py
@@ -146,7 +146,16 @@ def move_issue(ctx, issue_key: str, target_project: str, issue_type: str | None,
                 )
                 sys.exit(1)
             if refreshed_type and refreshed_type != target_type:
-                error(f"Type verification failed: issue is type {refreshed_type} (expected {target_type})")
+                error(
+                    f"Type change {current_type} → {target_type} was rejected by Jira's REST "
+                    f"edit endpoint: {issue_key} is still type {refreshed_type}.",
+                    suggestion=(
+                        "Jira's edit endpoint silently refuses some issue-type conversions — "
+                        "notably between Sub-Task types (e.g. Sub: Task → Sub: Bug) and between "
+                        "Sub-Task and standard types. No payload variation makes it work via "
+                        "REST. Use the Jira UI's 'Move' action on the issue instead."
+                    ),
+                )
                 sys.exit(1)
             # Type change within same project — key stays the same
             if ctx.obj["quiet"]:

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -6,43 +6,19 @@ read-after-write check; this verifies the error message explains the REST
 limitation and points the user at the UI Move action.
 """
 
-import importlib.util
-import sys
-from pathlib import Path
 from unittest import mock
 
-import click.testing
+from conftest import load_script, make_mock_client, run_cli
 
-_test_dir = Path(__file__).parent
-_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
-sys.path.insert(0, str(_scripts_path))
-
-
-def _load_script(name: str = "jira-move", subdir: str = "workflow"):
-    path = _scripts_path / subdir / f"{name}.py"
-    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-_mod = _load_script()
+_mod = load_script("jira-move", "workflow")
 
 
 def _make_mock_client(url: str = "https://jira.example.com"):
-    mc = mock.Mock()
-    mc.with_context = mock.Mock()
-    mc.url = url
-    return mc
+    return make_mock_client(url)
 
 
 def _run(args, mock_client=None):
-    if mock_client is None:
-        mock_client = _make_mock_client()
-    runner = click.testing.CliRunner()
-    with mock.patch.object(_mod, "LazyJiraClient", return_value=mock_client):
-        result = runner.invoke(_mod.cli, args)
-    return result, mock_client
+    return run_cli(_mod, args, mock_client)
 
 
 def _issue(issue_type: str, *, project: str = "FX", status: str = "Open", summary: str = "S"):

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -1,0 +1,97 @@
+"""Tests for jira-move.py `issue` type-change verification messaging (#116).
+
+Jira's REST edit endpoint silently refuses some issue-type conversions
+(notably between Sub-Task types). The command already detects this via a
+read-after-write check; this verifies the error message explains the REST
+limitation and points the user at the UI Move action.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+import click.testing
+
+_test_dir = Path(__file__).parent
+_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
+sys.path.insert(0, str(_scripts_path))
+
+
+def _load_script(name: str = "jira-move", subdir: str = "workflow"):
+    path = _scripts_path / subdir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_script()
+
+
+def _make_mock_client(url: str = "https://jira.example.com"):
+    mc = mock.Mock()
+    mc.with_context = mock.Mock()
+    mc.url = url
+    return mc
+
+
+def _run(args, mock_client=None):
+    if mock_client is None:
+        mock_client = _make_mock_client()
+    runner = click.testing.CliRunner()
+    with mock.patch.object(_mod, "LazyJiraClient", return_value=mock_client):
+        result = runner.invoke(_mod.cli, args)
+    return result, mock_client
+
+
+def _issue(issue_type: str, *, project: str = "FX", status: str = "Open", summary: str = "S"):
+    return {
+        "fields": {
+            "summary": summary,
+            "issuetype": {"name": issue_type},
+            "status": {"name": status},
+            "project": {"key": project},
+        }
+    }
+
+
+def _put_response(status_code: int = 204):
+    resp = mock.Mock()
+    resp.status_code = status_code
+    return resp
+
+
+class TestSubtaskTypeRejection:
+    def test_rejected_type_change_explains_rest_limitation(self):
+        """#116: a silently-rejected Sub-Task→Sub-Task change must point at the UI."""
+        mc = _make_mock_client()
+        # 1) initial fetch (Sub: Task), 2) read-after-write fetch (still Sub: Task)
+        mc.issue.side_effect = [
+            _issue("Sub: Task"),
+            {"fields": {"issuetype": {"name": "Sub: Task"}, "project": {"key": "FX"}}},
+        ]
+        mc._session.put.return_value = _put_response(204)
+
+        result, _ = _run(["issue", "FX-1095", "FX", "--issue-type", "Sub: Bug"], mc)
+
+        assert result.exit_code == 1, result.output
+        out = result.output
+        assert "rejected by Jira's REST edit endpoint" in out
+        assert "still type Sub: Task" in out
+        assert "Move' action" in out
+        # The old, uninformative phrasing must be gone.
+        assert "Type verification failed" not in out
+
+    def test_successful_type_change_reports_success(self):
+        mc = _make_mock_client()
+        mc.issue.side_effect = [
+            _issue("Sub: Task"),
+            {"fields": {"issuetype": {"name": "Sub: Bug"}, "project": {"key": "FX"}}},
+        ]
+        mc._session.put.return_value = _put_response(204)
+
+        result, _ = _run(["issue", "FX-1095", "FX", "--issue-type", "Sub: Bug"], mc)
+
+        assert result.exit_code == 0, result.output
+        assert "Sub: Task → Sub: Bug" in result.output


### PR DESCRIPTION
## Summary

Fixes #116 — when `jira-move issue` tries a Sub-Task→Sub-Task type change that Jira's REST edit endpoint silently rejects, the error was technically correct but uninformative:

```
✗ Type verification failed: issue is type Sub: Task (expected Sub: Bug)
```

The read-after-write check (added previously) catches the silent rejection correctly — the problem was only that the message didn't tell the user *why* it's a hard wall, leaving them to retry payload variations that can never work.

## Background

Option (a) from the issue — routing through a REST equivalent of the UI's Move wizard — is not feasible: the wizard goes through `secure/MoveIssue.jspa` (a Struts web action) on Server/DC, and there is no public REST endpoint for it. So this implements option (b): a clear, honest error.

## Fix

Rewrite the type-verification-failed message to name the rejected conversion and point at the Jira UI's Move action:

```
✗ Type change Sub: Task → Sub: Bug was rejected by Jira's REST edit endpoint:
  FX-1095 is still type Sub: Task.

  Jira's edit endpoint silently refuses some issue-type conversions — notably
  between Sub-Task types (e.g. Sub: Task → Sub: Bug) and between Sub-Task and
  standard types. No payload variation makes it work via REST. Use the Jira
  UI's 'Move' action on the issue instead.
```

Behavior is unchanged (still exits non-zero); only the messaging improved.

## Tests

New `tests/test_move.py`:
- Rejection path emits the REST-limitation explanation + UI hint and drops the old "Type verification failed" phrasing.
- A genuinely applied type change still reports success.

Verified the rejection test **fails** against the old message. ruff clean.

Closes #116.

---

The issue also floated a "nudge users to pick the right type at creation" doc tweak as a *related preventive measure*. That's out of scope here (the `--type` flag and its examples already exist in `jira-create --help`) — left as a possible follow-up.

---

**Known SonarCloud signal (non-blocking):** the new test file repeats the `_load_script` / `_make_mock_client` / `run` harness boilerplate that ~6 existing test modules already use, which trips SonarCloud's "duplication on new code" gate. This is not a required check, and the new tests deliberately follow the repo's established pattern. Centralizing that boilerplate into a shared `conftest` is a worthwhile but separate refactor (it would have to delete the duplicated block from all existing test files in one PR to pass the same gate) — left as a followup rather than mixed into this bug fix.