### PR TITLE
test: centralize CLI test harness into conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,58 @@
+"""Shared test harness for the Jira CLI script tests.
+
+Each CLI script is a standalone file (PEP 723, loaded by path rather than
+installed as a package), so tests import them via :func:`load_script`.
+:func:`make_mock_client` and :func:`run_cli` centralize the Click +
+mocked-``LazyJiraClient`` invocation every command test performs.
+
+Living in ``conftest.py`` means pytest makes these importable from any test
+module (``from conftest import load_script, make_mock_client, run_cli``) and
+the scripts path is added to ``sys.path`` once, before any test module loads.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+import click.testing
+
+_SCRIPTS_PATH = Path(__file__).parent.parent / "skills" / "jira-communication" / "scripts"
+if str(_SCRIPTS_PATH) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_PATH))
+
+
+def load_script(name: str, subdir: str):
+    """Import a standalone CLI script by file path and return the module.
+
+    ``name`` is the hyphenated script name (e.g. ``jira-issue``); ``subdir`` is
+    its directory under ``scripts/`` (``core`` / ``workflow`` / ``utility``).
+    """
+    path = _SCRIPTS_PATH / subdir / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def make_mock_client(url: str = "https://jira.example.com", **attrs):
+    """Build a mock Jira client exposing the attributes scripts read off
+    ``LazyJiraClient`` (``url``, ``with_context``, plus any extras via
+    ``attrs`` — e.g. ``cloud=True``)."""
+    mc = mock.Mock()
+    mc.with_context = mock.Mock()
+    mc.url = url
+    for key, value in attrs.items():
+        setattr(mc, key, value)
+    return mc
+
+
+def run_cli(mod, args, mock_client=None):
+    """Invoke a script module's Click ``cli`` with ``LazyJiraClient`` patched
+    to a mock. Returns ``(result, mock_client)``."""
+    if mock_client is None:
+        mock_client = make_mock_client()
+    runner = click.testing.CliRunner()
+    with mock.patch.object(mod, "LazyJiraClient", return_value=mock_client):
+        result = runner.invoke(mod.cli, args)
+    return result, mock_client

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -4,49 +4,32 @@ These tests use click.testing.CliRunner with mocked Jira clients to verify
 that CLI scripts load correctly, parse options, and handle errors gracefully.
 """
 
-import importlib.util
-import sys
-from pathlib import Path
 from unittest import mock
 
 import click.testing
-
-# Add scripts to path for lib imports
-_test_dir = Path(__file__).parent
-_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
-sys.path.insert(0, str(_scripts_path))
-
-
-def _load_script(name: str, subdir: str = "core"):
-    """Load a hyphenated CLI script via importlib."""
-    path = _scripts_path / subdir / f"{name}.py"
-    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
+from conftest import load_script
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Load all CLI modules once
 # ═══════════════════════════════════════════════════════════════════════════════
 
-_issue_mod = _load_script("jira-issue", "core")
-_search_mod = _load_script("jira-search", "core")
-_worklog_mod = _load_script("jira-worklog", "core")
-_create_mod = _load_script("jira-create", "workflow")
-_transition_mod = _load_script("jira-transition", "workflow")
-_comment_mod = _load_script("jira-comment", "workflow")
-_sprint_mod = _load_script("jira-sprint", "workflow")
-_board_mod = _load_script("jira-board", "workflow")
-_fields_mod = _load_script("jira-fields", "utility")
-_user_mod = _load_script("jira-user", "utility")
-_link_mod = _load_script("jira-link", "utility")
-_worklog_query_mod = _load_script("jira-worklog-query", "utility")
-_weblink_mod = _load_script("jira-weblink", "utility")
-_watchers_mod = _load_script("jira-watchers", "utility")
-_version_mod = _load_script("jira-version", "workflow")
-_qa_gather_mod = _load_script("jira-qa-gather", "utility")
-_move_mod = _load_script("jira-move", "workflow")
+_issue_mod = load_script("jira-issue", "core")
+_search_mod = load_script("jira-search", "core")
+_worklog_mod = load_script("jira-worklog", "core")
+_create_mod = load_script("jira-create", "workflow")
+_transition_mod = load_script("jira-transition", "workflow")
+_comment_mod = load_script("jira-comment", "workflow")
+_sprint_mod = load_script("jira-sprint", "workflow")
+_board_mod = load_script("jira-board", "workflow")
+_fields_mod = load_script("jira-fields", "utility")
+_user_mod = load_script("jira-user", "utility")
+_link_mod = load_script("jira-link", "utility")
+_worklog_query_mod = load_script("jira-worklog-query", "utility")
+_weblink_mod = load_script("jira-weblink", "utility")
+_watchers_mod = load_script("jira-watchers", "utility")
+_version_mod = load_script("jira-version", "workflow")
+_qa_gather_mod = load_script("jira-qa-gather", "utility")
+_move_mod = load_script("jira-move", "workflow")
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,46 +1,20 @@
 """Tests for jira-link.py list + delete subcommands."""
 
-import importlib.util
 import json
-import sys
-from pathlib import Path
-from unittest import mock
 
 import click.testing
 import pytest
+from conftest import load_script, make_mock_client, run_cli
 
-# Add scripts to path for lib imports
-_test_dir = Path(__file__).parent
-_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
-sys.path.insert(0, str(_scripts_path))
-
-
-def _load_script(name: str, subdir: str = "utility"):
-    """Load a hyphenated CLI script via importlib."""
-    path = _scripts_path / subdir / f"{name}.py"
-    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-_link_mod = _load_script("jira-link", "utility")
+_link_mod = load_script("jira-link", "utility")
 
 
 def _make_mock_client():
-    mc = mock.Mock()
-    mc.with_context = mock.Mock()
-    return mc
+    return make_mock_client()
 
 
 def _run_link(args, mock_client=None):
-    """Run jira-link CLI with a mocked LazyJiraClient."""
-    if mock_client is None:
-        mock_client = _make_mock_client()
-    runner = click.testing.CliRunner()
-    with mock.patch.object(_link_mod, "LazyJiraClient", return_value=mock_client):
-        result = runner.invoke(_link_mod.cli, args)
-    return result, mock_client
+    return run_cli(_link_mod, args, mock_client)
 
 
 def _issue_link(link_id="10042", type_name="Blocks", direction="outward", other_key="TEST-2", other_summary="Other"):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,45 +1,22 @@
 """Tests for jira-version.py — project versions CRUD."""
 
-import importlib.util
 import json
-import sys
-from pathlib import Path
 from unittest import mock
 
 import click
 import click.testing
 import pytest
+from conftest import load_script, make_mock_client, run_cli
 
-_test_dir = Path(__file__).parent
-_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
-sys.path.insert(0, str(_scripts_path))
-
-
-def _load_script(name: str = "jira-version", subdir: str = "workflow"):
-    path = _scripts_path / subdir / f"{name}.py"
-    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-_mod = _load_script()
+_mod = load_script("jira-version", "workflow")
 
 
 def _make_mock_client(url: str = "https://jira.example.com"):
-    mc = mock.Mock()
-    mc.with_context = mock.Mock()
-    mc.url = url  # atlassian.Jira exposes .url on the client instance
-    return mc
+    return make_mock_client(url)
 
 
 def _run(args, mock_client=None):
-    if mock_client is None:
-        mock_client = _make_mock_client()
-    runner = click.testing.CliRunner()
-    with mock.patch.object(_mod, "LazyJiraClient", return_value=mock_client):
-        result = runner.invoke(_mod.cli, args)
-    return result, mock_client
+    return run_cli(_mod, args, mock_client)
 
 
 def _make_version(

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -1,48 +1,21 @@
 """Tests for jira-watchers.py — list/add/remove issue watchers."""
 
-import importlib.util
 import json
-import sys
-from pathlib import Path
-from unittest import mock
 
 import click.testing
 import requests
+from conftest import load_script, make_mock_client, run_cli
 
-# Add scripts to path for lib imports
-_test_dir = Path(__file__).parent
-_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
-sys.path.insert(0, str(_scripts_path))
-
-
-def _load_script(name: str, subdir: str = "utility"):
-    """Load a hyphenated CLI script via importlib."""
-    path = _scripts_path / subdir / f"{name}.py"
-    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-_watchers_mod = _load_script("jira-watchers", "utility")
+_watchers_mod = load_script("jira-watchers", "utility")
 
 
 def _make_mock_client(cloud: bool = False):
-    mc = mock.Mock()
-    mc.with_context = mock.Mock()
-    # Explicit attribute — LazyJiraClient exposes .cloud via atlassian.Jira
-    object.__setattr__(mc, "cloud", cloud)
-    return mc
+    # LazyJiraClient exposes .cloud via atlassian.Jira
+    return make_mock_client(cloud=cloud)
 
 
 def _run(args, mock_client=None):
-    """Run jira-watchers CLI with a mocked LazyJiraClient."""
-    if mock_client is None:
-        mock_client = _make_mock_client()
-    runner = click.testing.CliRunner()
-    with mock.patch.object(_watchers_mod, "LazyJiraClient", return_value=mock_client):
-        result = runner.invoke(_watchers_mod.cli, args)
-    return result, mock_client
+    return run_cli(_watchers_mod, args, mock_client)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_weblink.py
+++ b/tests/test_weblink.py
@@ -1,57 +1,25 @@
 """Tests for jira-weblink.py CRUD subcommands and jira-issue.py link output."""
 
-import importlib.util
 import json
-import sys
-from pathlib import Path
-from unittest import mock
 
 import click.testing
 import pytest
+from conftest import load_script, make_mock_client, run_cli
 
-# Add scripts to path for lib imports
-_test_dir = Path(__file__).parent
-_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
-sys.path.insert(0, str(_scripts_path))
-
-
-def _load_script(name: str, subdir: str = "core"):
-    """Load a hyphenated CLI script via importlib."""
-    path = _scripts_path / subdir / f"{name}.py"
-    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-_weblink_mod = _load_script("jira-weblink", "utility")
-_issue_mod = _load_script("jira-issue", "core")
+_weblink_mod = load_script("jira-weblink", "utility")
+_issue_mod = load_script("jira-issue", "core")
 
 
 def _make_mock_client():
-    mc = mock.Mock()
-    mc.with_context = mock.Mock()
-    return mc
+    return make_mock_client()
 
 
 def _run_weblink(args, mock_client=None):
-    """Run jira-weblink CLI with a mocked LazyJiraClient."""
-    if mock_client is None:
-        mock_client = _make_mock_client()
-    runner = click.testing.CliRunner()
-    with mock.patch.object(_weblink_mod, "LazyJiraClient", return_value=mock_client):
-        result = runner.invoke(_weblink_mod.cli, args)
-    return result, mock_client
+    return run_cli(_weblink_mod, args, mock_client)
 
 
 def _run_issue(args, mock_client=None):
-    """Run jira-issue CLI with a mocked LazyJiraClient."""
-    if mock_client is None:
-        mock_client = _make_mock_client()
-    runner = click.testing.CliRunner()
-    with mock.patch.object(_issue_mod, "LazyJiraClient", return_value=mock_client):
-        result = runner.invoke(_issue_mod.cli, args)
-    return result, mock_client
+    return run_cli(_issue_mod, args, mock_client)
 
 
 def _link(link_id=42, url="https://example.com", title="Example"):

--- a/tests/test_worklog_query.py
+++ b/tests/test_worklog_query.py
@@ -1,29 +1,12 @@
 """Tests for jira-worklog-query.py — cross-cutting worklog query tool."""
 
-import importlib.util
 import json
-import sys
-from pathlib import Path
 from unittest import mock
 
 import click.testing
+from conftest import load_script
 
-# Add scripts to path for lib imports
-_test_dir = Path(__file__).parent
-_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
-sys.path.insert(0, str(_scripts_path))
-
-
-def _load_script():
-    """Load jira-worklog-query via importlib."""
-    path = _scripts_path / "utility" / "jira-worklog-query.py"
-    spec = importlib.util.spec_from_file_location("jira_worklog_query", path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-_mod = _load_script()
+_mod = load_script("jira-worklog-query", "utility")
 
 
 class TestBuildJql:


### PR DESCRIPTION
## Summary

The script-loading boilerplate — `load_script` (`spec_from_file_location` → `module_from_spec` → `exec_module`) plus near-identical `_make_mock_client` / `_run` helpers — was copy-pasted into ~6 test modules. SonarCloud flags that repeated block as **duplicated code on new code** for any new test file that follows the established pattern (as seen on #120 and #121).

This extracts the harness into one place so new test modules can reuse it instead of re-introducing the block.

## Changes

- New `tests/conftest.py` exposing `load_script`, `make_mock_client`, `run_cli`. Living in `conftest.py` means pytest makes it importable from every test module and the scripts path is added to `sys.path` once, before any test module loads.
- `make_mock_client(url=..., **attrs)` grows a `**attrs` kwarg so the `jira-watchers` `cloud=` variant no longer needs its own body.
- The 6 duplicating modules (`test_version`, `test_link`, `test_watchers`, `test_weblink`, `test_worklog_query`, `test_cli_smoke`) now import the shared helpers and keep only thin, module-specific wrappers binding their own loaded module.

## Impact

Pure refactor — **no test behavior changes**. Net **−84 LOC** (97 insertions, 181 deletions). 647 tests pass; ruff clean.

## Why now

Unblocks #120 and #121 (issue fixes for #115 / #116), whose new test files will rebase onto this and use the shared helpers instead of repeating the boilerplate — clearing their SonarCloud duplication gate.