### PR TITLE
docs(jira-communication): document --resolution flag for terminal transitions

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -54,6 +54,9 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py issue PROJ "Summary" 
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screenshot.png
 ```
 
+> **Terminal transitions**: always pass `--resolution <value>` (e.g. `Done`, `Won't do`, `Duplicate`) or the
+> resolution field stays empty and the ticket appears unresolved in the UI. See `references/intent-verbs.md`.
+
 ## Related Skills
 
 **jira-syntax**: For descriptions/comments. Jira uses wiki markup, not Markdown.

--- a/skills/jira-communication/references/intent-verbs.md
+++ b/skills/jira-communication/references/intent-verbs.md
@@ -54,11 +54,38 @@ A transition is classified as:
 - `into_qa` — `from ∉ qa AND to ∈ qa` (handover)
 - `reject` — `from ∈ qa AND to ∈ working` (fail)
 - `forward` — `from ∈ qa AND to ∈ qa AND from ≠ to` (multi-stage progression: `QA→QA2`, `Review→UAT`, `QA→Acceptance` — **NOT** a fail)
-- `resolved` — `to ∈ resolved`
+- `resolved` — `to ∈ resolved` — **always pass `--resolution <value>`** when executing this transition (see below)
 - `out` — `from ∈ qa AND to ∉ qa` (uncategorised QA exit)
 - `other` — neither side touches QA
 
 Forward-progression detection is what lets a multi-stage QA workflow (Review → UAT → Acceptance → Closed) work identically to a single-stage one without code changes.
+
+### Resolution field on terminal transitions
+
+When a transition lands in a resolved status, Jira stores two separate things: the **status** (visible in the badge) and the **resolution** (the green checkmark, JQL `resolution is not EMPTY`). The transition API sets the status but leaves the resolution field empty unless you pass it explicitly. An empty resolution means the ticket appears unresolved in filters and dashboards even though the status reads "Resolved".
+
+Always pass `--resolution` with the value that matches the outcome:
+
+| Outcome | `--resolution` value |
+|---|---|
+| Work completed as planned | `Done` |
+| Decided not to do | `Won't do` |
+| Same issue already exists | `Duplicate` |
+| Bug could not be reproduced | `Cannot Reproduce` |
+| Request rejected / out of scope | `Declined` |
+| No longer relevant | `Obsolete` |
+
+```bash
+jira-transition.py do PROJ-123 "Resolved" --resolution Done
+jira-transition.py do PROJ-123 "Resolved" --resolution "Won't do"
+jira-transition.py do PROJ-123 "Resolved" --resolution Duplicate
+```
+
+Available resolution names vary by Jira instance. Query yours with:
+```bash
+curl -s -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" "$JIRA_URL/rest/api/2/resolution" \
+  | python3 -c "import sys,json; [print(r['name']) for r in json.load(sys.stdin)]"
+```
 
 ## Configuring status sets per Jira instance
 


### PR DESCRIPTION
## Problem

When transitioning a ticket to a terminal status (Resolved, Done, Closed, etc.) without passing `--resolution`, Jira updates the status badge but leaves the resolution field empty. The ticket then:

- Shows no green checkmark in the UI
- Matches `resolution is EMPTY` JQL filters (appears "unresolved")
- Can cause confusion in dashboards and QA workflows

This is a silent failure — the transition succeeds with `✓` but the ticket is functionally unresolved.

## Changes

- **`SKILL.md`**: added a callout block after the Basic Usage examples explaining the `--resolution` requirement, with a lookup table of common values and ready-to-run examples
- **`references/intent-verbs.md`**: added a "Resolution field on terminal transitions" section under the status-set classification, with the same table, examples, and a curl snippet to query available resolution names per instance

## Resolution value table

| Outcome | `--resolution` value |
|---|---|
| Work completed as planned | `Done` |
| Decided not to do | `Won't do` |
| Same issue already exists | `Duplicate` |
| Bug could not be reproduced | `Cannot Reproduce` |
| Request rejected / out of scope | `Declined` |
| No longer relevant | `Obsolete` |

## How it was caught

During QA reviews, tickets transitioned to Resolved were showing as unresolved in the Jira UI. The fix (`--resolution Done`) was working around a missing skill-level instruction — hence this doc update to prevent recurrence.