### PR TITLE
chore(release): v3.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.15.0] - 2026-05-28
+
 ### Fixed
 
 - `jira-search query`, `jira-qa-gather`, `jira-worklog-query`: JQL search now works on Atlassian Cloud. Atlassian's CHANGE-2046 removed `/rest/api/2/search` and `/rest/api/3/search` from Cloud; `atlassian-python-api` hardcodes `api_version=2` so its `jql()` method failed with "The requested API has been removed" on every `*.atlassian.net` instance. `LazyJiraClient.jql()` now overrides the library and calls the new cursor-paginated `/rest/api/3/search/jql` endpoint directly on Cloud while Server/DC still goes through the library unchanged. The override translates cursor pagination (`nextPageToken`/`isLast`) back to the `startAt`/`total` shape the callers expect, so paginating loops keep terminating correctly on Cloud — no caller changes needed. Cloud detection uses `is_cloud_url(client.url)` (strict `.atlassian.net` match) rather than the library's `cloud` flag for cross-version robustness. Surgical override rather than bumping `atlassian-python-api` to 4.x — the 4.x line still has open Cloud-pathway bugs and the project cannot verify against a Cloud tenant. Inefficiency caveat: each call drains pages from index 0 up to `start + limit` because the new endpoint is cursor-based and we cannot resume from an offset, so deep pagination is O(N²) until upstream Cloud-aware `jql()` lands. Original fix by [@rschmied](https://github.com/rschmied) in [#107](https://github.com/netresearch/jira-skill/pull/107); pagination + Cloud-detection hardening in [#112](https://github.com/netresearch/jira-skill/pull/112).

--- a/evals/comprehensive-workspace/baseline-skill/SKILL.md
+++ b/evals/comprehensive-workspace/baseline-skill/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv, curl. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.11.0"
+  version: "3.15.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Bash(curl:*) Read Write
 ---

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.14.0"
+  version: "3.15.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.14.0"
+  version: "3.15.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Release **v3.15.0** (minor bump, conventional commits since v3.14.0).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 3.15.0.

Changes since v3.14.0:
- feat(jira-issue): add --description / -d flag to update
- 
- For plain description edits, callers previously had to fall back to
- --fields-json '{"description": "..."}' which is fragile under shell
- quoting (every newline, quote, and backslash in the body needs JSON
- escaping). The typed flag accepts the body directly, and '--description -'
- reads from stdin so heredocs / multi-line wiki markup pipe straight in:
- 
-     jira-issue update PROJ-123 --description "$(cat body.txt)"
-     cat body.txt | jira-issue update PROJ-123 --description -
- 
- --fields-json keeps working untouched for custom-field payloads.
- SKILL.md and references/issue-editing.md updated; CHANGELOG.md noted.
- 
- Signed-off-by: Sebastian Mendel <sebastian.mendel@netresearch.de>
- fix(jira-issue): isatty guard + size limit + tests for --description -
- 
- Address review feedback on PR #109:
- 
- - isatty() guard before sys.stdin.read() prevents the script from

After merge: a signed tag `v3.15.0` on `main` triggers the release workflow.