### PR TITLE
feat(jira-communication): add `transition path` to walk a multi-stage workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `jira-transition path KEY TARGET_STATUS`: walk a multi-stage workflow to a target status in one call, instead of repeating `list` + `do` per stage. Runs the `list → pick → do` loop internally. Because the Jira API only exposes transitions from the issue's *current* status, the walk is greedy rather than a full graph search: at each step it takes the target if directly reachable, else the single non-backward transition (names matching `reopen/cancel/reject/decline/abort/back`, or targets already visited, count as backward); an ambiguous step stops and lists the options for an explicit `do`. `--resolution`/`--comment` apply to the final transition only, `--max-steps` (default 10) caps the walk, and `--dry-run` previews the first step. Motivated by closing a ticket sitting deep in a `QA → UAT → Ready for deployment → Resolved → Closed` workflow, which previously cost 8 round-trips. Documented in `references/intent-verbs.md`.
+
 ## [3.15.0] - 2026-05-28
 
 ### Fixed

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -24,7 +24,7 @@ On Jira URL or issue key (PROJ-123), pick by **intent** — each is one call:
 | start QA review | `jira-issue.py qa KEY` |
 | QA-fail follow-up | `jira-issue.py qa-fail KEY` |
 | field-only lookup | `jira-issue.py get KEY --fields ...` |
-| change status | `jira-issue.py act KEY` → `jira-transition.py do`/`path` |
+| change status | `jira-issue.py act KEY` → `jira-transition.py do` |
 | audit / sibling discovery | `jira-qa-gather.py KEY` |
 
 Auth issues → `jira-setup.py`. **Anti-pattern:** `get` + `comment list` for the same key — use the matching verb. See `references/intent-verbs.md`.

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -24,7 +24,7 @@ On Jira URL or issue key (PROJ-123), pick by **intent** — each is one call:
 | start QA review | `jira-issue.py qa KEY` |
 | QA-fail follow-up | `jira-issue.py qa-fail KEY` |
 | field-only lookup | `jira-issue.py get KEY --fields ...` |
-| change status | `jira-issue.py act KEY` → `jira-transition.py do` |
+| change status | `jira-issue.py act KEY` → `jira-transition.py do`/`path` |
 | audit / sibling discovery | `jira-qa-gather.py KEY` |
 
 Auth issues → `jira-setup.py`. **Anti-pattern:** `get` + `comment list` for the same key — use the matching verb. See `references/intent-verbs.md`.

--- a/skills/jira-communication/references/intent-verbs.md
+++ b/skills/jira-communication/references/intent-verbs.md
@@ -106,8 +106,9 @@ jira-transition.py path PROJ-123 Closed --dry-run           # preview the first 
 It is a **greedy** walk, not a graph search: the Jira API only exposes the
 transitions available from the issue's *current* status, so `path` cannot see the
 whole workflow ahead of time. At each step it takes the target if directly reachable,
-otherwise the single non-backward transition (transitions named `reopen/cancel/reject/
-decline/abort/back`, or leading to an already-visited status, are treated as backward).
+otherwise the single non-backward transition (transitions whose name matches
+`reopen/cancel/reject/decline/abort/back`, or which lead to an already-visited status,
+are treated as backward).
 If a step offers several forward options it **stops and lists them** rather than guess —
 pick one with `do` and re-run. `--resolution`/`--comment` apply only to the final step;
 `--max-steps` (default 10) caps the walk. Because it cannot look ahead, `--dry-run`

--- a/skills/jira-communication/references/intent-verbs.md
+++ b/skills/jira-communication/references/intent-verbs.md
@@ -87,6 +87,32 @@ curl -s -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" "$JIRA_URL/rest/api/2/re
   | python3 -c "import sys,json; [print(r['name']) for r in json.load(sys.stdin)]"
 ```
 
+### Walking a multi-stage workflow (`path`)
+
+`jira-transition.py do` performs **one** transition. Workflows with intermediate
+gates (e.g. `QA → UAT Stage → Ready for deployment → Resolved → Closed`) otherwise
+need one `list` + one `do` per stage — closing a ticket deep in such a workflow is
+4+ round-trips of discovering the next status by hand.
+
+`path` collapses that into one call: it runs the `list → pick → do` loop internally,
+walking from the current status to a target.
+
+```bash
+jira-transition.py path PROJ-123 Closed --resolution Done   # walk all the way to Closed
+jira-transition.py path PROJ-123 "Ready for deployment"     # walk to an intermediate gate
+jira-transition.py path PROJ-123 Closed --dry-run           # preview the first step
+```
+
+It is a **greedy** walk, not a graph search: the Jira API only exposes the
+transitions available from the issue's *current* status, so `path` cannot see the
+whole workflow ahead of time. At each step it takes the target if directly reachable,
+otherwise the single non-backward transition (transitions named `reopen/cancel/reject/
+decline/abort/back`, or leading to an already-visited status, are treated as backward).
+If a step offers several forward options it **stops and lists them** rather than guess —
+pick one with `do` and re-run. `--resolution`/`--comment` apply only to the final step;
+`--max-steps` (default 10) caps the walk. Because it cannot look ahead, `--dry-run`
+shows only the *first* planned step.
+
 ## Configuring status sets per Jira instance
 
 Per profile in `~/.jira/profiles.json`:

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -211,5 +211,137 @@ def do_transition(ctx, issue_key: str, status_name: str, comment: str | None, re
         sys.exit(1)
 
 
+# Transition names/targets that move an issue *backwards* (or out of the
+# forward flow). Skipped when the walker auto-picks the next step so a linear
+# workflow doesn't bounce back toward where it came from.
+_BACKWARD_PATTERN = ("reopen", "cancel", "reject", "decline", "abort", "back")
+
+
+def _is_backward(transition: dict, visited: set[str]) -> bool:
+    """True if a transition leads backward: its name matches a backward verb,
+    or its target status was already visited (would loop)."""
+    name = transition.get("name", "").lower()
+    if any(word in name for word in _BACKWARD_PATTERN):
+        return True
+    return _get_to_status(transition).lower() in visited
+
+
+@cli.command("path")
+@click.argument("issue_key")
+@click.argument("target_status")
+@click.option("--resolution", "-r", help="Resolution applied on the final transition")
+@click.option("--comment", "-c", help="Comment added on the final transition")
+@click.option("--max-steps", type=int, default=10, show_default=True, help="Safety cap on transitions walked")
+@click.option("--dry-run", is_flag=True, help="Show the first planned step without transitioning")
+@click.pass_context
+def path_transition(
+    ctx,
+    issue_key: str,
+    target_status: str,
+    resolution: str | None,
+    comment: str | None,
+    max_steps: int,
+    dry_run: bool,
+):
+    """Walk the workflow from the current status to TARGET_STATUS.
+
+    Runs the list -> pick -> do loop internally, collapsing a multi-stage
+    transition chain (e.g. QA -> UAT -> Resolved -> Closed) into one command.
+
+    The Jira API only exposes the transitions available from the issue's
+    *current* status, so the walk is greedy, not a full graph search: at each
+    step it takes TARGET_STATUS if directly reachable, otherwise the single
+    non-backward transition. If a step is ambiguous (several forward options)
+    it stops and lists them so you can pick with `do`. --resolution/--comment
+    apply only to the final transition.
+
+    Examples:
+
+      jira-transition path PROJ-123 Closed --resolution Done
+
+      jira-transition path PROJ-123 "Ready for deployment" --dry-run
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+    quiet, as_json = ctx.obj["quiet"], ctx.obj["json"]
+
+    try:
+        issue = client.issue(issue_key, fields="status")
+        current = issue["fields"]["status"]["name"]
+        target_l = target_status.lower()
+        visited = {current.lower()}
+        chain: list[str] = []
+
+        if current.lower() == target_l:
+            if as_json:
+                format_output({"key": issue_key, "status": current, "steps": []}, as_json=True)
+            elif quiet:
+                print(issue_key)
+            else:
+                success(f"{issue_key} is already in status '{current}' - nothing to do")
+            return
+
+        for _ in range(max_steps):
+            transitions = client.get_issue_transitions(issue_key)
+
+            # Prefer a transition landing directly on the target.
+            chosen = next((t for t in transitions if _get_to_status(t).lower() == target_l), None)
+            is_final = chosen is not None
+
+            if chosen is None:
+                forward = [t for t in transitions if not _is_backward(t, visited)]
+                if len(forward) != 1:
+                    options = ", ".join(f"{t.get('name', '')} -> {_get_to_status(t)}" for t in transitions) or "none"
+                    error(
+                        f"Cannot auto-advance {issue_key} from '{current}' toward '{target_status}': "
+                        + ("no forward transition available" if not forward else "ambiguous next step")
+                    )
+                    print(f"\nAvailable transitions: {options}")
+                    print("Pick one explicitly with: jira-transition do <KEY> <STATUS>")
+                    sys.exit(1)
+                chosen = forward[0]
+
+            to_status = _get_to_status(chosen)
+
+            if dry_run:
+                warning("DRY RUN - No transition will be performed")
+                print(f"\nNext step for {issue_key}: {chosen.get('name', '')} -> {to_status}")
+                print(f"Current: {current} | Target: {target_status}")
+                if not is_final:
+                    print("(walk continues greedily from there; re-run without --dry-run to execute)")
+                return
+
+            fields = {"resolution": {"name": resolution}} if (resolution and is_final) else {}
+            update = {"comment": [{"add": {"body": comment}}]} if (comment and is_final) else None
+            client.set_issue_status(issue_key, to_status, fields=fields or None, update=update)
+
+            chain.append(to_status)
+            visited.add(to_status.lower())
+            current = to_status
+            if is_final:
+                break
+        else:
+            error(f"Reached --max-steps ({max_steps}) before arriving at '{target_status}' (now at '{current}')")
+            sys.exit(1)
+
+        if as_json:
+            format_output({"key": issue_key, "status": current, "steps": chain}, as_json=True)
+        elif quiet:
+            print(issue_key)
+        else:
+            success(f"Transitioned {issue_key} to '{current}'")
+            print(f"  Path: {' -> '.join(chain)}")
+            if resolution:
+                print(f"  Resolution: {resolution}")
+
+    except SystemExit:
+        raise
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to walk {issue_key} to '{target_status}': {e}")
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     cli()

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -220,7 +220,7 @@ _BACKWARD_PATTERN = ("reopen", "cancel", "reject", "decline", "abort", "back")
 def _is_backward(transition: dict, visited: set[str]) -> bool:
     """True if a transition leads backward: its name matches a backward verb,
     or its target status was already visited (would loop)."""
-    name = transition.get("name", "").lower()
+    name = (transition.get("name") or "").lower()
     if any(word in name for word in _BACKWARD_PATTERN):
         return True
     return _get_to_status(transition).lower() in visited
@@ -291,13 +291,13 @@ def path_transition(
             if chosen is None:
                 forward = [t for t in transitions if not _is_backward(t, visited)]
                 if len(forward) != 1:
-                    options = ", ".join(f"{t.get('name', '')} -> {_get_to_status(t)}" for t in transitions) or "none"
+                    options = ", ".join(f"{t.get('name') or ''} -> {_get_to_status(t)}" for t in transitions) or "none"
+                    reason = "no forward transition available" if not forward else "ambiguous next step"
                     error(
-                        f"Cannot auto-advance {issue_key} from '{current}' toward '{target_status}': "
-                        + ("no forward transition available" if not forward else "ambiguous next step")
+                        f"Cannot auto-advance {issue_key} from '{current}' toward '{target_status}': {reason}",
+                        suggestion=f"Available transitions: {options}. "
+                        f"Pick one explicitly with: jira-transition do {issue_key} <STATUS>",
                     )
-                    print(f"\nAvailable transitions: {options}")
-                    print("Pick one explicitly with: jira-transition do <KEY> <STATUS>")
                     sys.exit(1)
                 chosen = forward[0]
 

--- a/tests/test_transition_path.py
+++ b/tests/test_transition_path.py
@@ -1,0 +1,83 @@
+"""Tests for jira-transition.py `path` — greedy workflow walker.
+
+`path` collapses a multi-stage transition chain into one command by running
+the list -> pick -> do loop internally. The Jira API only exposes transitions
+from the issue's *current* status, so the walk is greedy: take the target if
+directly reachable, else the single non-backward transition, else stop.
+"""
+
+from conftest import load_script, make_mock_client, run_cli
+
+_mod = load_script("jira-transition", "workflow")
+
+
+def _run(args, mock_client=None):
+    return run_cli(_mod, args, mock_client)
+
+
+def _t(name: str, to: str):
+    """A transition dict in Server/DC shape ({'to': 'Status'})."""
+    return {"id": name, "name": name, "to": to}
+
+
+def _client_at(status: str):
+    mc = make_mock_client()
+    mc.issue.return_value = {"fields": {"status": {"name": status}}}
+    return mc
+
+
+# QA -> UAT Stage -> Ready for deployment -> Resolved -> Closed, each step
+# offering one forward transition plus a backward Reopen.
+def _linear_chain():
+    return [
+        [_t("QA passed", "UAT Stage"), _t("Reopen", "Reopened")],
+        [_t("UAT passed", "Ready for deployment"), _t("Reopen", "Reopened")],
+        [_t("deployed", "Resolved"), _t("Reopen", "Reopened")],
+        [_t("Close", "Closed"), _t("Reopen", "Reopened")],
+    ]
+
+
+class TestGreedyWalk:
+    def test_walks_full_chain_to_target(self):
+        mc = _client_at("QA")
+        mc.get_issue_transitions.side_effect = _linear_chain()
+
+        result, _ = _run(["path", "NRSIQ-57", "Closed", "--resolution", "Done"], mc)
+
+        assert result.exit_code == 0, result.output
+        assert mc.set_issue_status.call_count == 4
+        # Final transition lands on Closed and carries the resolution.
+        final = mc.set_issue_status.call_args_list[-1]
+        assert final.args[1] == "Closed"
+        assert final.kwargs["fields"] == {"resolution": {"name": "Done"}}
+        # Intermediate steps must NOT set a resolution.
+        assert mc.set_issue_status.call_args_list[0].kwargs["fields"] is None
+        assert "UAT Stage -> Ready for deployment -> Resolved -> Closed" in result.output
+
+    def test_already_at_target_is_noop(self):
+        mc = _client_at("Closed")
+        result, _ = _run(["path", "NRSIQ-57", "Closed"], mc)
+        assert result.exit_code == 0, result.output
+        assert mc.set_issue_status.call_count == 0
+        assert "already in status" in result.output
+
+    def test_ambiguous_step_stops_and_lists_options(self):
+        mc = _client_at("Open")
+        # Two forward (non-backward) transitions -> walker must not guess.
+        mc.get_issue_transitions.side_effect = [
+            [_t("Start", "In Progress"), _t("Postpone", "On Hold")],
+        ]
+        result, _ = _run(["path", "NRSIQ-57", "Closed"], mc)
+        assert result.exit_code == 1, result.output
+        assert mc.set_issue_status.call_count == 0
+        assert "ambiguous next step" in result.output
+        assert "In Progress" in result.output and "On Hold" in result.output
+
+    def test_dry_run_shows_first_step_only(self):
+        mc = _client_at("QA")
+        mc.get_issue_transitions.side_effect = _linear_chain()
+        result, _ = _run(["path", "NRSIQ-57", "Closed", "--dry-run"], mc)
+        assert result.exit_code == 0, result.output
+        assert mc.set_issue_status.call_count == 0
+        assert "DRY RUN" in result.output
+        assert "QA passed -> UAT Stage" in result.output


### PR DESCRIPTION
## Summary

Adds `jira-transition path KEY TARGET_STATUS` — walk a multi-stage Jira workflow to a target status in **one** call, instead of repeating `transition list` + `transition do` per stage.

### Motivation

Closing a ticket sitting deep in a workflow — e.g. `QA → UAT Stage → Ready for deployment → Resolved → Closed` — previously cost **8 round-trips**: a `list` to discover the next status, then a `do`, repeated per stage, because the API only reveals the transitions available from the issue's *current* status. `path` runs that `list → pick → do` loop internally.

### Behaviour

- **Greedy, not a graph search** (by necessity — the API can't show the whole workflow ahead of time): at each step take the target if directly reachable, else the single non-backward transition. Transitions named `reopen/cancel/reject/decline/abort/back`, or leading to an already-visited status, count as backward.
- **Stops on ambiguity**: if a step offers several forward options it lists them and exits non-zero rather than guess — pick one with `do` and re-run.
- `--resolution` / `--comment` apply to the **final** transition only.
- `--max-steps` (default 10) caps the walk; `--dry-run` previews the first step.

```bash
jira-transition.py path PROJ-123 Closed --resolution Done
jira-transition.py path PROJ-123 "Ready for deployment"
jira-transition.py path PROJ-123 Closed --dry-run
```

## Tests

`tests/test_transition_path.py` (4 cases): full linear walk with final-only resolution, already-at-target no-op, ambiguous-step bail-out, dry-run first-step-only. Full suite: 667 passed, ruff clean, harness Level 3.

## Docs

- `references/intent-verbs.md`: new "Walking a multi-stage workflow" section.
- `SKILL.md` is at the 500-word hard cap, so the change-status row gains a net-zero `/path` mention only; full docs live in the reference.
- CHANGELOG `[Unreleased] → Added`.

## Notes

Origin: surfaced by a `/retro` session retrospective after closing the NRSIQ-56 ScormIQ ticket cluster by hand.
