### PR TITLE
fix(jira-communication): tighten `transition path` backward-match and --max-steps

### DIFF
--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -8,6 +8,7 @@
 # ///
 """Jira issue transitions - list available transitions and change issue status."""
 
+import re
 import sys
 from pathlib import Path
 
@@ -214,14 +215,19 @@ def do_transition(ctx, issue_key: str, status_name: str, comment: str | None, re
 # Transition names/targets that move an issue *backwards* (or out of the
 # forward flow). Skipped when the walker auto-picks the next step so a linear
 # workflow doesn't bounce back toward where it came from.
-_BACKWARD_PATTERN = ("reopen", "cancel", "reject", "decline", "abort", "back")
+# Matched as substrings so inflected forms are caught ("reopen" -> "Reopened",
+# "cancel" -> "Cancelled", "reject" -> "Rejected").
+_BACKWARD_SUBSTRINGS = ("reopen", "cancel", "reject", "decline", "abort")
+# "back" is matched as a whole word only: "Move back" counts, but "Backlog",
+# "Rollback" and "Feedback" must not be mistaken for backward transitions.
+_BACKWARD_WORD_RE = re.compile(r"\bback\b")
 
 
 def _is_backward(transition: dict, visited: set[str]) -> bool:
     """True if a transition leads backward: its name matches a backward verb,
     or its target status was already visited (would loop)."""
     name = (transition.get("name") or "").lower()
-    if any(word in name for word in _BACKWARD_PATTERN):
+    if any(word in name for word in _BACKWARD_SUBSTRINGS) or _BACKWARD_WORD_RE.search(name):
         return True
     return _get_to_status(transition).lower() in visited
 
@@ -231,7 +237,9 @@ def _is_backward(transition: dict, visited: set[str]) -> bool:
 @click.argument("target_status")
 @click.option("--resolution", "-r", help="Resolution applied on the final transition")
 @click.option("--comment", "-c", help="Comment added on the final transition")
-@click.option("--max-steps", type=int, default=10, show_default=True, help="Safety cap on transitions walked")
+@click.option(
+    "--max-steps", type=click.IntRange(min=1), default=10, show_default=True, help="Safety cap on transitions walked"
+)
 @click.option("--dry-run", is_flag=True, help="Show the first planned step without transitioning")
 @click.pass_context
 def path_transition(

--- a/tests/test_transition_path.py
+++ b/tests/test_transition_path.py
@@ -81,3 +81,41 @@ class TestGreedyWalk:
         assert mc.set_issue_status.call_count == 0
         assert "DRY RUN" in result.output
         assert "QA passed -> UAT Stage" in result.output
+
+
+class TestBackwardDetection:
+    """`back` must match as a whole word only, not as a substring (#125 review)."""
+
+    def test_inflected_backward_verbs_match_as_substrings(self):
+        for name in ("Reopen", "Reopened", "Cancelled", "Rejected", "Decline", "Abort"):
+            assert _mod._is_backward(_t(name, "Whatever"), set()) is True, name
+
+    def test_back_matches_only_as_whole_word(self):
+        assert _mod._is_backward(_t("Move back", "Start"), set()) is True
+        # Names that merely *contain* "back" are forward, not backward.
+        for name in ("Backlog", "Rollback", "Feedback received", "Send to Backlog"):
+            assert _mod._is_backward(_t(name, name), set()) is False, name
+
+    def test_walker_does_not_treat_backlog_as_backward(self):
+        # Single forward transition to Backlog must be taken, not filtered out.
+        mc = _client_at("Open")
+        mc.get_issue_transitions.side_effect = [
+            [_t("Send to Backlog", "Backlog"), _t("Reopen", "Reopened")],
+            [_t("Pick up", "In Progress"), _t("Reopen", "Reopened")],
+        ]
+        result, _ = _run(["path", "ABC-1", "In Progress"], mc)
+        assert result.exit_code == 0, result.output
+        assert [c.args[1] for c in mc.set_issue_status.call_args_list] == ["Backlog", "In Progress"]
+
+
+class TestMaxStepsValidation:
+    """--max-steps must reject 0/negative via Click (#125 review)."""
+
+    def test_zero_is_rejected(self):
+        result, _ = _run(["path", "ABC-1", "Closed", "--max-steps", "0"], _client_at("Open"))
+        assert result.exit_code == 2, result.output  # Click usage error
+        assert "max-steps" in result.output.lower()
+
+    def test_negative_is_rejected(self):
+        result, _ = _run(["path", "ABC-1", "Closed", "--max-steps", "-3"], _client_at("Open"))
+        assert result.exit_code == 2, result.output


### PR DESCRIPTION
## Summary

Follow-up to the post-merge review on #125 — fixes two issues Copilot flagged on the `transition path` walker.

## Fixes

1. **`back` matched as a substring** (`jira-transition.py:226`): `_is_backward` treated any name containing `back` as backward, so `Backlog`, `Rollback`, `Feedback`, `Send to Backlog` were wrongly filtered — the walker could bail or take the wrong path. `back` now matches as a whole word (`\bback\b`); the inflected verbs (`reopen`/`cancel`/`reject`/`decline`/`abort`) keep substring matching so `Reopened`/`Cancelled`/`Rejected` are still caught.
2. **`--max-steps` accepted 0/negative**: now `click.IntRange(min=1)`, so bad input is rejected by Click with a clear message instead of failing later with a confusing "Reached --max-steps".

## Tests

5 new cases in `tests/test_transition_path.py`: inflected backward verbs still match; `back` only as a whole word; a walk that must take a `Send to Backlog` forward transition rather than filter it; `--max-steps 0` and `-3` rejected (exit 2). Full suite: 672 passed, ruff clean.
