### PR TITLE
chore(release): v3.16.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.16.0] - 2026-06-09
+
 ### Added
 
 - `jira-transition path KEY TARGET_STATUS`: walk a multi-stage workflow to a target status in one call, instead of repeating `list` + `do` per stage. Runs the `list → pick → do` loop internally. Because the Jira API only exposes transitions from the issue's *current* status, the walk is greedy rather than a full graph search: at each step it takes the target if directly reachable, else the single non-backward transition (names matching `reopen/cancel/reject/decline/abort/back`, or targets already visited, count as backward); an ambiguous step stops and lists the options for an explicit `do`. `--resolution`/`--comment` apply to the final transition only, `--max-steps` (default 10) caps the walk, and `--dry-run` previews the first step. Motivated by closing a ticket sitting deep in a `QA → UAT → Ready for deployment → Resolved → Closed` workflow, which previously cost 8 round-trips. Documented in `references/intent-verbs.md`.

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.15.0"
+  version: "3.16.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.15.0"
+  version: "3.16.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Release v3.16.0 (version bump only). 3 file(s) bumped: plugin.json + SKILL.md.