### PR TITLE
fix(jira-communication): surface comment count and never render requested fields silently (#127)

### DIFF
--- a/skills/jira-communication/scripts/core/jira-issue.py
+++ b/skills/jira-communication/scripts/core/jira-issue.py
@@ -393,6 +393,69 @@ def _print_issue(
             link_url = obj.get("url", "")
             print(f"  [{link_id}] {title} \u2014 {link_url}")
 
+    # Comments \u2014 always surface the count when the comment field is present, so a
+    # populated discussion is never invisible (the original silent `-f comment` trap).
+    # Full bodies stay in the `work` command / `jira-comment.py list`.
+    if field_available("comment"):
+        comment_field = fields.get("comment") or {}
+        # Jira may send total/comments as explicit null, so guard against None
+        # rather than relying on dict.get defaults (a present-but-null key skips them).
+        comment_total = comment_field.get("total")
+        if comment_total is None:
+            comment_total = len(comment_field.get("comments") or [])
+        if comment_total:
+            print(
+                f"\nComments: {comment_total} "
+                f"(run `jira-issue.py work {issue['key']}` or `jira-comment.py list {issue['key']}` to read them)"
+            )
+        else:
+            print("\nComments: 0")
+
+    # Parent \u2014 cheap, high-value metadata; same silent-omission gap as comments.
+    if field_available("parent"):
+        parent = fields.get("parent") or {}
+        parent_key = parent.get("key")
+        if parent_key:
+            parent_summary = (parent.get("fields") or {}).get("summary", "")
+            print(f"\nParent: {parent_key}" + (f": {parent_summary}" if parent_summary else ""))
+
+    # Subtasks \u2014 list compactly (keys are short); closes the silent `-f subtasks` gap.
+    if field_available("subtasks"):
+        subtasks = fields.get("subtasks") or []
+        if subtasks:
+            print(f"\nSubtasks ({len(subtasks)}):")
+            for subtask in subtasks:
+                subtask_fields = subtask.get("fields") or {}
+                subtask_status = (subtask_fields.get("status") or {}).get("name", "")
+                suffix = f" [{subtask_status}]" if subtask_status else ""
+                print(f"  \u2022 {subtask.get('key', '?')}: {subtask_fields.get('summary') or ''}{suffix}")
+
+    # Safety net: never let an explicitly requested field render nothing silently.
+    # Any -f field that reached the payload but has no renderer above gets a
+    # one-line pointer instead of vanishing (the core correctness fix).
+    if requested is not None:
+        rendered_fields = {
+            "summary",
+            "issuetype",
+            "status",
+            "priority",
+            "assignee",
+            "reporter",
+            "labels",
+            "description",
+            "created",
+            "updated",
+            "attachment",
+            "issuelinks",
+            "weblinks",
+            "comment",
+            "parent",
+            "subtasks",
+        }
+        for field_name in sorted(requested):
+            if field_name not in rendered_fields and field_available(field_name):
+                print(f"\n{field_name}: present in the response but not rendered here, use `--json` to view it")
+
     print()
 
 

--- a/tests/test_issue_comment_field.py
+++ b/tests/test_issue_comment_field.py
@@ -1,0 +1,128 @@
+"""Tests for jira-issue.py `_print_issue` comment/parent/subtasks rendering (#127).
+
+The default human-readable formatter used to ignore `-f comment` (and
+`parent`/`subtasks`) silently: no output, no error, no "0 comments" notice. An
+empty result then reads as "this issue has no comments" when it has many. These
+tests pin the fix: an always-on comment count, parent/subtask metadata, and a
+safety net so an explicitly requested field never renders nothing.
+"""
+
+from conftest import load_script
+
+_mod = load_script("jira-issue", "core")
+
+
+def _issue(fields: dict) -> dict:
+    return {"key": "FX-1", "fields": fields}
+
+
+def test_comment_count_and_pointer_when_requested(capsys):
+    """`-f ...,comment` surfaces the count plus a pointer instead of nothing."""
+    _mod._print_issue(
+        _issue({"summary": "S", "comment": {"total": 9, "comments": []}}),
+        requested_fields={"summary", "comment"},
+    )
+    out = capsys.readouterr().out
+    assert "Comments: 9" in out
+    assert "jira-issue.py work FX-1" in out
+    assert "jira-comment.py list FX-1" in out
+
+
+def test_comment_count_shown_on_default_view(capsys):
+    """A default `get` (no field filter) always surfaces the comment count."""
+    _mod._print_issue(_issue({"summary": "S", "comment": {"total": 3, "comments": []}}))
+    out = capsys.readouterr().out
+    assert "Comments: 3" in out
+
+
+def test_zero_comments_renders_explicit_zero(capsys):
+    """Zero comments is stated explicitly, never left blank."""
+    _mod._print_issue(
+        _issue({"summary": "S", "comment": {"total": 0, "comments": []}}),
+        requested_fields={"summary", "comment"},
+    )
+    out = capsys.readouterr().out
+    assert "Comments: 0" in out
+
+
+def test_comment_total_falls_back_to_array_length(capsys):
+    """When `total` is absent, the rendered count falls back to the array length."""
+    _mod._print_issue(
+        _issue({"summary": "S", "comment": {"comments": [{"id": "1"}, {"id": "2"}]}}),
+        requested_fields={"comment"},
+    )
+    out = capsys.readouterr().out
+    assert "Comments: 2" in out
+
+
+def test_comment_total_explicit_null_falls_back_to_array_length(capsys):
+    """An explicit `total: null` must not leak through; fall back to the array length."""
+    _mod._print_issue(
+        _issue({"summary": "S", "comment": {"total": None, "comments": [{"id": "1"}]}}),
+        requested_fields={"comment"},
+    )
+    out = capsys.readouterr().out
+    assert "Comments: 1" in out
+
+
+def test_comment_array_explicit_null_renders_zero(capsys):
+    """An explicit `comments: null` with no total must not raise; render zero."""
+    _mod._print_issue(
+        _issue({"summary": "S", "comment": {"comments": None}}),
+        requested_fields={"comment"},
+    )
+    out = capsys.readouterr().out
+    assert "Comments: 0" in out
+
+
+def test_subtask_null_summary_does_not_print_none(capsys):
+    """A subtask with an explicit `summary: null` must not print the literal 'None'."""
+    _mod._print_issue(_issue({"summary": "S", "subtasks": [{"key": "SUB-1", "fields": {"summary": None}}]}))
+    out = capsys.readouterr().out
+    assert "Subtasks (1):" in out
+    assert "SUB-1:" in out
+    assert "None" not in out
+
+
+def test_no_comment_line_when_field_absent(capsys):
+    """A restricted `-f` that omits comment fetches no comment field, so no line."""
+    _mod._print_issue(
+        _issue({"summary": "S", "status": {"name": "Open"}}),
+        requested_fields={"summary", "status"},
+    )
+    out = capsys.readouterr().out
+    assert "Comments:" not in out
+
+
+def test_parent_and_subtasks_rendered(capsys):
+    """Parent and subtasks surface as cheap metadata in the default view."""
+    _mod._print_issue(
+        _issue(
+            {
+                "summary": "S",
+                "parent": {"key": "EP-1", "fields": {"summary": "Epic"}},
+                "subtasks": [{"key": "SUB-1", "fields": {"summary": "Do thing", "status": {"name": "Open"}}}],
+            }
+        )
+    )
+    out = capsys.readouterr().out
+    assert "Parent: EP-1: Epic" in out
+    assert "Subtasks (1):" in out
+    assert "SUB-1: Do thing [Open]" in out
+
+
+def test_requested_field_without_renderer_gets_notice(capsys):
+    """An explicitly requested field with no renderer emits a pointer, not silence."""
+    _mod._print_issue(
+        _issue({"summary": "S", "customfield_10071": "some value"}),
+        requested_fields={"summary", "customfield_10071"},
+    )
+    out = capsys.readouterr().out
+    assert "customfield_10071: present in the response but not rendered here" in out
+
+
+def test_no_safety_net_notice_on_default_view(capsys):
+    """The safety net only fires for explicit `-f` requests, not the default view."""
+    _mod._print_issue(_issue({"summary": "S", "customfield_10071": "some value"}))
+    out = capsys.readouterr().out
+    assert "customfield_10071" not in out


### PR DESCRIPTION
Closes #127.

## Problem
`jira-issue.py get` (default human-readable formatter) silently ignored `-f comment` (and `parent`/`subtasks`): no output, no error, no "0 comments" notice. An issue with many comments read as having none — a correctness trap indistinguishable from a true empty. This bit me in real use (6 comments read as zero, and they held the decisive context).

## Approach
Per the discussion on #127, `get` stays low-level: full comment **bodies** remain the job of `work` / `jira-comment.py list`. This PR closes the trap without making `get` comprehensive.

- **Always-on comment count.** When the comment field is present, print `Comments: N` with a pointer to `work` / `jira-comment.py list`. So the *existence* of discussion is never invisible, on a default `get` and on `-f comment`.
- **Parent and subtasks** rendered as cheap metadata (`Parent: KEY: summary`, `Subtasks (N)` with keys).
- **Safety net.** Any explicitly requested `-f` field that reached the payload but has no renderer now emits a one-line pointer (`<field>: present in the response but not rendered here, use --json to view it`) instead of vanishing.

`INTENT_FIELDS` excludes `comment`/`parent`/`subtasks`, so the `work` output (which renders full comments itself) is unaffected — verified.

## Tests
New `tests/test_issue_comment_field.py` covers the count, the zero case, the `total`→array-length fallback, the absent-field case, parent/subtasks, and both safety-net branches. Full suite green (680 passed), ruff and bandit clean.

## Verified manually
- `get -f summary,status,comment` → now `Comments: 9 (run ...)` instead of nothing.
- default `get` → `Comments: 9` + `Parent: ...`.
- `get -f summary,customfield_10071` → notice for the unrendered field.
- `work` → still renders the full `COMMENTS (N)` section, no duplicate pointer line.
