### PR TITLE
feat(markup): lint comments for inline block tags before posting

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -57,6 +57,13 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screensh
 > **Terminal transitions**: always pass `--resolution <value>` (e.g. `Done`, `Won't do`, `Duplicate`) or the
 > resolution field stays empty and the ticket appears unresolved in the UI. See `references/intent-verbs.md`.
 
+## Gotchas
+
+- **Transition names are exact strings** and may carry emoji prefixes (e.g. `✅ Resolve`). On mismatch the error lists the available names — copy verbatim.
+- **Link types are instance-specific** (e.g. `Relation`, not `Relates`). Discover with `jira-link.py list-types` before `jira-link.py create A B --type <name>`.
+- **`jira-attachment.py download URL FILE`** refuses output paths outside the current working directory — `cd` to the target dir first. Don't fetch attachment URLs with raw `curl`; you get the login page.
+- **Comments are wiki-markup-linted** before posting (inline block tags, unbalanced `\{code\}`/`\{noformat\}` pairs). Fix the markup or override with `--force`.
+
 ## Related Skills
 
 **jira-syntax**: For descriptions/comments. Jira uses wiki markup, not Markdown.

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 
 # Jira Communication
 
-CLI scripts via `uv run`. All support `--help`, `--json`, `--quiet`, `--debug`.
+CLI scripts via `uv run`, all supporting `--help`, `--json`, `--quiet`, `--debug`.
 
 ## Auto-Trigger
 
@@ -27,7 +27,7 @@ On Jira URL or issue key (PROJ-123), pick by **intent** — each is one call:
 | change status | `jira-issue.py act KEY` → `jira-transition.py do` |
 | audit / sibling discovery | `jira-qa-gather.py KEY` |
 
-Auth issues → `jira-setup.py`. **Anti-pattern:** `get` + `comment list` for the same key — use the matching verb. See `references/intent-verbs.md`.
+Auth issues → `jira-setup.py`. **Anti-pattern:** `get` + `comment list` on one key — use the matching verb. See `references/intent-verbs.md`.
 
 ## Scripts
 
@@ -55,14 +55,7 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screensh
 ```
 
 > **Terminal transitions**: always pass `--resolution <value>` (e.g. `Done`, `Won't do`, `Duplicate`) or the
-> resolution field stays empty and the ticket appears unresolved in the UI. See `references/intent-verbs.md`.
-
-## Gotchas
-
-- **Transition names are exact strings** and may carry emoji prefixes (e.g. `✅ Resolve`). On mismatch the error lists the available names — copy verbatim.
-- **Link types are instance-specific** (e.g. `Relation`, not `Relates`). Discover with `jira-link.py list-types` before `jira-link.py create A B --type <name>`.
-- **`jira-attachment.py download URL FILE`** refuses output paths outside the current working directory — `cd` to the target dir first. Don't fetch attachment URLs with raw `curl`; you get the login page.
-- **Comments are wiki-markup-linted** before posting (inline block tags, unbalanced `\{code\}`/`\{noformat\}` pairs). Fix the markup or override with `--force`.
+> resolution field stays empty and the ticket appears unresolved. See `references/intent-verbs.md`.
 
 ## Related Skills
 
@@ -75,16 +68,16 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screensh
 - `references/troubleshooting.md` — auth, SSL, 401, 403, connection
 - `references/issue-editing.md` — `--description`, `--fields-json`, reporter, deletes, moves
 - `references/creation.md` — `--parent`, components, custom fields
-- `references/comments.md` — edit, delete, list comments
+- `references/comments.md` — edit, delete, list, markup lint / `--force`
 - `references/worklog.md` — `--started`, date ranges, `jira-worklog-query.py`
-- `references/attachments.md` — upload, download, inspect attachments
-- `references/links.md` — issue and web links
+- `references/attachments.md` — upload, download (cwd-only), inspect
+- `references/links.md` — issue/web links, instance-specific link types
 - `references/agile.md` — sprints, boards, `board --name`
 - `references/fields-and-users.md` — custom field IDs, users, issue types
 - `references/watchers.md` — watch, subscribe, list watchers
 - `references/versions.md` — fix/affects versions, releases, version CRUD
 - `references/qa-gather.md` — comprehensive audit bundle (siblings, prose URLs)
-- `references/intent-verbs.md` — `work / qa / qa-fail / act`: heuristic + status-set config
+- `references/intent-verbs.md` — `work / qa / qa-fail / act`, exact transition names
 
 ## Authentication
 

--- a/skills/jira-communication/references/attachments.md
+++ b/skills/jira-communication/references/attachments.md
@@ -34,4 +34,8 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py download \
 
 ## Safety guarantees
 
-- **Path traversal**: output paths are constrained to the current working directory — the script rejects targets that resolve outside cwd.
+- **Path traversal**: output paths are constrained to the current working directory — the script rejects targets that resolve outside cwd. `cd` to the target directory before downloading.
+
+## Don't use raw curl
+
+Fetching `/secure/attachment/...` URLs with plain `curl` returns the Jira login page, not the file — attachment downloads need the authenticated session handling this script provides. Always use `jira-attachment.py download`.

--- a/skills/jira-communication/references/comments.md
+++ b/skills/jira-communication/references/comments.md
@@ -20,7 +20,8 @@ The JSON output has a top-level `comments` array; each entry has `id`, `author.d
 
 ```bash
 # Full replacement of the body — edits preserve created timestamp, update the "updated" timestamp
-uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py edit PROJ-123 --id 594276 "Corrected text"
+# (issue key, comment ID and text are positional arguments)
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py edit PROJ-123 594276 "Corrected text"
 ```
 
 Jira appends an "edited" marker in the UI automatically.
@@ -29,10 +30,10 @@ Jira appends an "edited" marker in the UI automatically.
 
 ```bash
 # Preview
-uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py delete PROJ-123 --id 594276 --dry-run
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py delete PROJ-123 594276 --dry-run
 
 # Real delete
-uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py delete PROJ-123 --id 594276
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py delete PROJ-123 594276
 ```
 
 Deleting someone else's comment requires the Delete All Comments permission.
@@ -53,3 +54,7 @@ cat comment.txt | uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py ad
 ```
 
 Comments use Jira wiki markup — see the **jira-syntax** skill for formatting.
+
+## Markup lint
+
+`add` and `edit` lint the body before posting: inline block tags (`{code}`, `{noformat}`, `{quote}`, `{panel}` are block-level — a tag with other text on the same line opens a block mid-prose) and unbalanced tag counts abort with an error. Escape literal mentions as `\{code\}`. Override with `--force` (findings are then printed as warnings).

--- a/skills/jira-communication/references/intent-verbs.md
+++ b/skills/jira-communication/references/intent-verbs.md
@@ -163,3 +163,7 @@ jira-issue.py qa-fail NRS-4412
 ```
 
 Returns: description + Sebastian's scope-setting handover comment + Björn's full AC review with rejection + Sebastian's response + subsequent resolution. Chronologically sorted, ready to read.
+
+## Transition names are exact strings
+
+`jira-transition.py do KEY "<name>"` matches the transition name verbatim — including emoji prefixes some instances configure (e.g. `✅ Resolve`, `❌ QA failed`). On mismatch the error lists the available names; copy the wanted one exactly as printed. `jira-issue.py act KEY` shows them up front.

--- a/skills/jira-communication/scripts/lib/markup.py
+++ b/skills/jira-communication/scripts/lib/markup.py
@@ -1,0 +1,75 @@
+"""Jira wiki-markup lint helpers.
+
+Catches the most damaging authoring mistakes before text is sent to Jira:
+
+- Block-markup tags ({code}, {noformat}, {quote}, {panel}) used inline.
+  These are block-level macros; an unescaped tag with other text on the
+  same line opens a real block mid-prose and swallows the rest of the
+  line. Literal mentions must be escaped as \\{code\\}.
+- Unbalanced block tags (odd occurrence count), which leave an unclosed
+  block that swallows everything after it.
+
+Escaped tags (\\{code\\}) and tags inside {code}/{noformat} blocks are
+ignored.
+"""
+
+import re
+
+BLOCK_TAGS = ("code", "noformat", "quote", "panel")
+
+# Unescaped block tag, optionally with parameters ({code:bash}, {panel:title=x}).
+_TAG_RE = re.compile(r"(?<!\\)\{(code|noformat|quote|panel)(?::[^}\n]*)?\}")
+
+
+def lint_wiki_markup(text: str) -> list[str]:
+    """Return a list of human-readable lint findings (empty = clean)."""
+    findings: list[str] = []
+    counts = dict.fromkeys(BLOCK_TAGS, 0)
+    in_block: str | None = None
+
+    for lineno, line in enumerate(text.split("\n"), 1):
+        matches = list(_TAG_RE.finditer(line))
+
+        if in_block is not None:
+            # Inside a block, only the matching closing tag is markup;
+            # everything else on the line is verbatim content.
+            closing = next((m for m in matches if m.group(1) == in_block), None)
+            if closing is not None:
+                counts[in_block] += 1
+                if line[closing.end() :].strip():
+                    findings.append(
+                        f"line {lineno}: text after closing {{{in_block}}} tag - "
+                        f"block tags must stand alone on their own line"
+                    )
+                in_block = None
+            continue
+
+        if not matches:
+            continue
+
+        for m in matches:
+            counts[m.group(1)] += 1
+
+        # A clean block-tag line contains nothing but the tag itself.
+        if _TAG_RE.sub("", line).strip():
+            findings.append(
+                f"line {lineno}: block tag used inline - {{code}}/{{noformat}}/"
+                f"{{quote}}/{{panel}} are block markup and never inline; escape "
+                f"literal mentions as \\{{code\\}}: {line.strip()[:80]!r}"
+            )
+        elif len(matches) == 1:
+            # Only a clean, solitary tag opens a block for lint purposes;
+            # an inline tag is already flagged and would corrupt the state.
+            in_block = matches[0].group(1)
+
+    if in_block is not None:
+        findings.append(f"unclosed {{{in_block}}} block - everything after the opening tag is swallowed")
+
+    for tag, n in counts.items():
+        if n % 2:
+            findings.append(
+                f"unbalanced {{{tag}}} tags: {n} unescaped occurrence(s), expected "
+                f"pairs - escape literal mentions as \\{{{tag}\\}}"
+            )
+
+    return findings

--- a/skills/jira-communication/scripts/lib/markup.py
+++ b/skills/jira-communication/scripts/lib/markup.py
@@ -9,8 +9,11 @@ Catches the most damaging authoring mistakes before text is sent to Jira:
 - Unbalanced block tags (odd occurrence count), which leave an unclosed
   block that swallows everything after it.
 
-Escaped tags (\\{code\\}) and tags inside {code}/{noformat} blocks are
-ignored.
+Escaped tags (\\{code\\}), inline-monospace lookalikes ({{code}}) and
+*other* tags inside an open block are ignored. An occurrence of the
+*same* tag inside an open block closes it — exactly what the Jira
+renderer does (verified against Jira Server 9.12: a mid-line {code}
+inside a code block terminates the block there).
 """
 
 import re
@@ -18,7 +21,8 @@ import re
 BLOCK_TAGS = ("code", "noformat", "quote", "panel")
 
 # Unescaped block tag, optionally with parameters ({code:bash}, {panel:title=x}).
-_TAG_RE = re.compile(r"(?<!\\)\{(code|noformat|quote|panel)(?::[^}\n]*)?\}")
+# (?<!\{) keeps {{code}} / {{panel}} (inline monospace content) out of scope.
+_TAG_RE = re.compile(r"(?<!\\)(?<!\{)\{(code|noformat|quote|panel)(?::[^}\n]*)?\}")
 
 
 def lint_wiki_markup(text: str) -> list[str]:
@@ -50,8 +54,10 @@ def lint_wiki_markup(text: str) -> list[str]:
         for m in matches:
             counts[m.group(1)] += 1
 
-        # A clean block-tag line contains nothing but the tag itself.
-        if _TAG_RE.sub("", line).strip():
+        # A clean block-tag line contains nothing but a single tag; several
+        # tags on one line ({code} {panel}) are inline usage even when the
+        # remainder is whitespace.
+        if _TAG_RE.sub("", line).strip() or len(matches) > 1:
             findings.append(
                 f"line {lineno}: block tag used inline - {{code}}/{{noformat}}/"
                 f"{{quote}}/{{panel}} are block markup and never inline; escape "

--- a/skills/jira-communication/scripts/workflow/jira-comment.py
+++ b/skills/jira-communication/scripts/workflow/jira-comment.py
@@ -22,7 +22,25 @@ if _lib_path.exists():
 import click
 from lib.client import LazyJiraClient, _sanitize_error, fetch_comments_paginated
 from lib.input import read_stdin_utf8
+from lib.markup import lint_wiki_markup
 from lib.output import error, extract_adf_text, format_output, success, warning
+
+
+def _check_markup(comment_text: str, force: bool) -> None:
+    """Lint wiki markup; abort on findings unless --force is given."""
+    findings = lint_wiki_markup(comment_text)
+    if not findings:
+        return
+    if force:
+        for finding in findings:
+            warning(f"markup: {finding}")
+        return
+    error(
+        "Wiki-markup lint found problems:\n  " + "\n  ".join(findings),
+        suggestion="Block tags are never inline; escape literal mentions as \\{code\\}. Re-run with --force to post anyway.",
+    )
+    sys.exit(1)
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CLI Definition
@@ -56,8 +74,9 @@ def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str 
 @cli.command()
 @click.argument("issue_key")
 @click.argument("comment_text")
+@click.option("--force", is_flag=True, help="Post despite wiki-markup lint findings")
 @click.pass_context
-def add(ctx, issue_key: str, comment_text: str):
+def add(ctx, issue_key: str, comment_text: str, force: bool):
     """Add a comment to an issue.
 
     ISSUE_KEY: The Jira issue key (e.g., PROJ-123)
@@ -68,14 +87,18 @@ def add(ctx, issue_key: str, comment_text: str):
     Note: Use Jira wiki syntax:
       - *bold* not **bold**
       - _italic_ not *italic*
-      - {code}...{code} for code blocks
-      - [link text|url] for links
+      - {code}...{code} blocks for multi-line code, {{monospace}} for inline
+      - [link text|url] for links, [^file.log] for attachments
+
+    Block tags ({code}, {noformat}, {quote}, {panel}) must stand alone on
+    their own line; literal mentions in prose must be escaped (\\{code\\}).
+    The comment is linted for this before posting (override with --force).
 
     Examples:
 
       jira-comment add PROJ-123 "Fixed in commit abc123"
 
-      jira-comment add PROJ-123 "See {code}config.py{code} for details"
+      jira-comment add PROJ-123 "See {{config.py}} for details"
 
       cat comment.txt | jira-comment add PROJ-123 -
     """
@@ -117,6 +140,8 @@ def add(ctx, issue_key: str, comment_text: str):
             )
             sys.exit(1)
 
+    _check_markup(comment_text, force)
+
     try:
         result = client.issue_add_comment(issue_key, comment_text)
 
@@ -139,8 +164,9 @@ def add(ctx, issue_key: str, comment_text: str):
 @click.argument("issue_key")
 @click.argument("comment_id")
 @click.argument("comment_text")
+@click.option("--force", is_flag=True, help="Post despite wiki-markup lint findings")
 @click.pass_context
-def edit(ctx, issue_key: str, comment_id: str, comment_text: str):
+def edit(ctx, issue_key: str, comment_id: str, comment_text: str, force: bool):
     """Edit an existing comment on an issue.
 
     ISSUE_KEY: The Jira issue key (e.g., PROJ-123)
@@ -148,7 +174,8 @@ def edit(ctx, issue_key: str, comment_id: str, comment_text: str):
     COMMENT_ID: The ID of the comment to edit (use 'list' to find IDs)
 
     COMMENT_TEXT: New comment text (use Jira wiki markup, not Markdown).
-    Use "-" to read from stdin (e.g., cat file.txt | jira-comment edit PROJ-123 12345 -)
+    Use "-" to read from stdin (e.g., cat file.txt | jira-comment edit PROJ-123 12345 -).
+    Linted for wiki-markup problems before posting (override with --force).
 
     Examples:
 
@@ -195,6 +222,8 @@ def edit(ctx, issue_key: str, comment_id: str, comment_text: str):
                 suggestion="Verify your piped command produces non-empty output.",
             )
             sys.exit(1)
+
+    _check_markup(comment_text, force)
 
     try:
         result = client.issue_edit_comment(issue_key, comment_id, comment_text)

--- a/skills/jira-syntax/evals/evals.json
+++ b/skills/jira-syntax/evals/evals.json
@@ -56,5 +56,19 @@
         "pattern": "```"
       }
     ]
+  },
+  {
+    "name": "escape_literal_block_tag_mention",
+    "prompt": "Write a short Jira QA comment in wiki markup with one finding line stating that all commands are documented in {code} blocks with command and output together, plus one real code block containing: ls -l",
+    "assertions": [
+      {
+        "type": "content",
+        "pattern": "\\\\\\{code\\\\\\}"
+      },
+      {
+        "type": "not_content",
+        "pattern": "\\{code\\}[^\\n]*[A-Za-z]"
+      }
+    ]
   }
 ]

--- a/skills/jira-syntax/references/cross-project-refs.md
+++ b/skills/jira-syntax/references/cross-project-refs.md
@@ -30,11 +30,15 @@ When an issue references multiple repos in the same group (e.g. `jira/jira` for 
 
 ## Inside `{{...}}` monospace
 
-`!`, `#`, and `@` all work inside `{{...}}`, but **literal `{` and `}` inside a `{{...}}` block break Jira's parser** and render the whole block as raw text. If a reference contains brace expansion or set notation, split it:
+`!`, `#`, and `@` all work inside `{{...}}`, but **unescaped `{`, `}` and `*` inside a `{{...}}` block break Jira's parser**: a raw `{` makes the whole block render as raw text, and a `*` pair turns bold mid-token. Escape them with a backslash (verified against the Jira Server 9.12 wiki renderer):
 
 ```
-✗ {{compose.example.{yml,override.pga.yml}}}
-✓ {{compose.example.yml}} and {{compose.example.override.pga.yml}}
+✗ {{compose.example.{yml,override.pga.yml}}}      → block falls apart
+✓ {{compose.example.\{yml,override.pga.yml\}}}    → compose.example.{yml,override.pga.yml}
+✗ {{jira-*backup-*}}                              → "backup-" renders bold
+✓ {{jira-\*backup-\*}}                            → jira-*backup-*
 ```
 
-The `validate-jira-syntax.sh` script catches this collision.
+Splitting into separate `{{...}}` references also works when escaping would hurt readability.
+
+The `validate-jira-syntax.sh` script catches the brace collision.

--- a/skills/jira-syntax/references/cross-project-refs.md
+++ b/skills/jira-syntax/references/cross-project-refs.md
@@ -30,13 +30,20 @@ When an issue references multiple repos in the same group (e.g. `jira/jira` for 
 
 ## Inside `{{...}}` monospace
 
-`!`, `#`, and `@` all work inside `{{...}}`, but **unescaped `{`, `}` and `*` inside a `{{...}}` block break Jira's parser**: a raw `{` makes the whole block render as raw text, and a `*` pair turns bold mid-token. Escape them with a backslash (verified against the Jira Server 9.12 wiki renderer):
+`!`, `#`, and `@` all work inside `{{...}}`, but **unescaped `{`, `}` and `*` inside a `{{...}}` block break Jira's parser**: a raw `{` makes the whole block render as raw text, and a `*` pair turns bold mid-token. Escape them with a backslash (verified against the Jira Server 9.12 wiki renderer).
+
+Broken — the block falls apart on the raw `{`, and `backup-` renders bold:
 
 ```
-✗ {{compose.example.{yml,override.pga.yml}}}      → block falls apart
-✓ {{compose.example.\{yml,override.pga.yml\}}}    → compose.example.{yml,override.pga.yml}
-✗ {{jira-*backup-*}}                              → "backup-" renders bold
-✓ {{jira-\*backup-\*}}                            → jira-*backup-*
+{{compose.example.{yml,override.pga.yml}}}
+{{jira-*backup-*}}
+```
+
+Correct — renders `compose.example.{yml,override.pga.yml}` and `jira-*backup-*` in monospace:
+
+```
+{{compose.example.\{yml,override.pga.yml\}}}
+{{jira-\*backup-\*}}
 ```
 
 Splitting into separate `{{...}}` references also works when escaping would hurt readability.

--- a/skills/jira-syntax/references/jira-syntax-quick-reference.md
+++ b/skills/jira-syntax/references/jira-syntax-quick-reference.md
@@ -146,14 +146,18 @@ Preserves whitespace and formatting
 
 ### Block Tags Are Never Inline
 
-`{code}`, `{noformat}`, `{quote}` and `{panel}` are **block-level** macros: the tag must stand alone on its own line. An unescaped tag inside a prose sentence opens a real block mid-line and swallows the rest of the line — the classic failure is writing *about* code blocks:
+`{code}`, `{noformat}`, `{quote}` and `{panel}` are **block-level** macros: the tag must stand alone on its own line. An unescaped tag inside a prose sentence opens a real block mid-line and swallows the rest of the line — the classic failure is writing *about* code blocks.
+
+Broken — renders everything after "in" as an opened code block:
 
 ```
-BROKEN:  All commands are documented in {code} blocks with output.
-         → renders everything after "in" as an opened code block
+All commands are documented in {code} blocks with output.
+```
 
-CORRECT: All commands are documented in \{code\} blocks with output.
-         → renders the literal text {code}
+Correct — renders the literal text `{code}`:
+
+```
+All commands are documented in \{code\} blocks with output.
 ```
 
 Escape literal mentions of any block tag with backslashes: `\{code\}`, `\{noformat\}`, `\{quote\}`, `\{panel\}`. For inline monospace use `{{...}}`, never an inline `{code}` pair — even `{code}one-liner{code}` renders as a block, not inline.

--- a/skills/jira-syntax/references/jira-syntax-quick-reference.md
+++ b/skills/jira-syntax/references/jira-syntax-quick-reference.md
@@ -144,6 +144,22 @@ Preserves whitespace and formatting
 {noformat}
 ```
 
+### Block Tags Are Never Inline
+
+`{code}`, `{noformat}`, `{quote}` and `{panel}` are **block-level** macros: the tag must stand alone on its own line. An unescaped tag inside a prose sentence opens a real block mid-line and swallows the rest of the line — the classic failure is writing *about* code blocks:
+
+```
+BROKEN:  All commands are documented in {code} blocks with output.
+         → renders everything after "in" as an opened code block
+
+CORRECT: All commands are documented in \{code\} blocks with output.
+         → renders the literal text {code}
+```
+
+Escape literal mentions of any block tag with backslashes: `\{code\}`, `\{noformat\}`, `\{quote\}`, `\{panel\}`. For inline monospace use `{{...}}`, never an inline `{code}` pair — even `{code}one-liner{code}` renders as a block, not inline.
+
+`scripts/validate-jira-syntax.sh` flags inline block tags and unbalanced tag counts; run it on composed text before submitting to Jira.
+
 ## Tables
 
 ### Basic Table

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -81,19 +81,30 @@ validate_file() {
         warning "Found Markdown inline code (\`code\`). Consider Jira format: {{code}}"
     fi
 
-    # Check for literal { or } inside {{...}} monospace blocks. The Jira parser
-    # is greedy and breaks on inner braces, rendering the block as raw text
+    # Check for unescaped { or } inside {{...}} monospace blocks. The Jira parser
+    # is greedy and breaks on raw inner braces, rendering the block as raw text
     # (e.g. {{compose.example.{yml,override.pga.yml}}} renders verbatim).
+    # Backslash-escaped braces (\{ \}) render literally and are fine.
     # Two failure modes:
-    #   1. {{ followed by another { before any } — e.g. {{path/{a,b}.txt}}
+    #   1. {{ followed by another raw { before any } — e.g. {{path/{a,b}.txt}}
     #      or {{a{b}c}}.
-    #   2. A {{ block with an extra } before the closing }} — e.g. {{a}b}}.
-    # ERE alternation: the first branch catches mode 1 robustly without needing
-    # to span the closing }}; the second branch catches mode 2.
-    if grep -qE '\{\{[^}]*\{|\{\{[^{]*\}[^{]*\}\}' <<< "$content"; then
-        error "Found literal { or } inside {{...}} monospace block — Jira parser will render it as raw text. Split the reference or escape the braces."
+    #   2. A {{ block with an extra raw } before the closing }} — e.g. {{a}b}}.
+    # `([^...\\]|\\.)*` skips escaped characters so \{ and \} don't false-positive.
+    local brace_re='\{\{([^{}\\]|\\.)*\{|\{\{([^{}\\]|\\.)*\}([^{}]|\\.)*\}\}'
+    if grep -qE "$brace_re" <<< "$content"; then
+        error "Found unescaped { or } inside {{...}} monospace block — Jira parser will render it as raw text. Escape as \\{ \\} or split the reference."
         echo "   Lines with issue:"
-        grep -nE '\{\{[^}]*\{|\{\{[^{]*\}[^{]*\}\}' <<< "$content" | head -3
+        grep -nE "$brace_re" <<< "$content" | head -3
+    fi
+
+    # Check for unescaped * inside {{...}} monospace blocks. Jira still parses
+    # inline markup inside {{...}}: a * pair turns bold mid-token
+    # (e.g. {{jira-*backup-*}} renders "backup-" bold). Escape as \*.
+    local star_re='\{\{([^{}*\\]|\\.)*\*'
+    if grep -qE "$star_re" <<< "$content"; then
+        warning "Found unescaped * inside {{...}} monospace block — renders as bold mid-token. Escape as \\* (e.g. {{jira-\\*backup-\\*}})."
+        echo "   Lines with issue:"
+        grep -nE "$star_re" <<< "$content" | head -3
     fi
 
     # Check for Markdown-style links ([text](url) instead of [text|url])

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -122,7 +122,8 @@ validate_file() {
     fi
 
     # Check for code blocks without language specification
-    if echo "$content" | grep -qE "{code}[^{]"; then
+    # (skip escaped \{code\} literals and inline-monospace {{code}})
+    if grep -qE '(^|[^\\{])\{code\}[^{]' <<< "$content"; then
         warning "Found {code} blocks without language. Consider: {code:java} for syntax highlighting"
     fi
 
@@ -165,7 +166,7 @@ validate_file() {
                 error "Unsupported {code:$lang} language. Jira Server rejects this; use {code:none} or one of: $valid_langs"
             fi
         fi
-    done < <(grep -oE '(^|[^\\])\{code:[^}|\\]+' <<< "$content" | sed 's/.*{code://' | sort -u)
+    done < <(grep -oE '(^|[^\\{])\{code:[^}|\\]+' <<< "$content" | sed 's/.*{code://' | sort -u)
 
     # Check for tables with incorrect header syntax (|Header| instead of ||Header||)
     if echo "$content" | grep -qE "^\|[^|]+\|$" && ! echo "$content" | grep -qE "^\|\|"; then
@@ -178,9 +179,10 @@ validate_file() {
     # Use `grep -o ... | wc -l` to count each occurrence (not just matching
     # lines), matching the {color} check below for consistency and to catch
     # multiple tags on the same line.
-    # `(^|[^\\])` skips escaped literals (\{code\}), which are prose, not markup.
+    # `(^|[^\\{])` skips escaped literals (\{code\}) and inline-monospace
+    # lookalikes ({{code}}) — both are prose, not block markup.
     local code_count
-    code_count=$(grep -oE '(^|[^\\])\{code[}:]' <<< "$content" | wc -l)
+    code_count=$(grep -oE '(^|[^\\{])\{code[}:]' <<< "$content" | wc -l)
     if [ $((code_count % 2)) -ne 0 ]; then
         error "Mismatched {code} tags: odd number ($code_count) of occurrences (expected pairs)"
     fi
@@ -188,7 +190,7 @@ validate_file() {
     # Check for unclosed {panel} blocks
     # Same rule applies: {panel} opens and closes the block.
     local panel_count
-    panel_count=$(grep -oE '(^|[^\\])\{panel[}:]' <<< "$content" | wc -l)
+    panel_count=$(grep -oE '(^|[^\\{])\{panel[}:]' <<< "$content" | wc -l)
     if [ $((panel_count % 2)) -ne 0 ]; then
         error "Mismatched {panel} tags: odd number ($panel_count) of occurrences (expected pairs)"
     fi
@@ -204,7 +206,7 @@ validate_file() {
     # occurrence count signals an unescaped literal in prose or a missing close.
     for macro in noformat quote anchor; do
         local mcount
-        mcount=$(grep -oE "(^|[^\\\\])\{${macro}[}:]" <<< "$content" | wc -l)
+        mcount=$(grep -oE "(^|[^\\\\{])\{${macro}[}:]" <<< "$content" | wc -l)
         if [ $((mcount % 2)) -ne 0 ]; then
             warning "Potential unclosed {${macro}} tag (odd number of occurrences)"
         fi

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -217,16 +217,23 @@ validate_file() {
     # An unescaped tag with other text on the same line opens the block
     # mid-prose and swallows the rest of the line (classic case: writing
     # *about* {code} in a sentence). Escape literal mentions as \{code\}.
-    # Excluded: escaped tags (\{code\}) and {{monospace}} content such as
-    # {{code}} (tag preceded by another brace or a backslash).
+    # Escaped tags (\{code\}) and {{monospace}} lookalikes ({{code}}) are
+    # stripped per line BEFORE testing — a line-level exclusion would hide a
+    # genuine unescaped tag sharing a line with an escaped/monospace mention.
     local inline_hits
-    inline_hits=$(grep -nE '\{(code|noformat|quote|panel)(:[^}]*)?\}' <<< "$content" \
-        | grep -vE '^[0-9]+:[[:space:]]*\{(code|noformat|quote|panel)(:[^}]*)?\}[[:space:]]*$' \
-        | grep -vE '(\\|\{)\{(code|noformat|quote|panel)' || true)
+    inline_hits=$(awk '
+        {
+            line = $0
+            gsub(/\\\{(code|noformat|quote|panel)[^}]*\\\}/, "", line)
+            gsub(/\{\{(code|noformat|quote|panel)(:[^}]*)?\}\}/, "", line)
+            if (line ~ /\{(code|noformat|quote|panel)(:[^}]*)?\}/ &&
+                line !~ /^[[:space:]]*\{(code|noformat|quote|panel)(:[^}]*)?\}[[:space:]]*$/)
+                printf "%d:%s\n", NR, $0
+        }' <<< "$content" | head -3)
     if [ -n "$inline_hits" ]; then
         error "Block tag used inline — {code}/{noformat}/{quote}/{panel} must stand alone on their own line; escape literal mentions as \\{code\\}"
         echo "   Lines with issue:"
-        head -3 <<< "$inline_hits"
+        echo "$inline_hits"
     fi
 
     # Check for Markdown-style lists (- item instead of * item)

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -90,7 +90,7 @@ validate_file() {
     #      or {{a{b}c}}.
     #   2. A {{ block with an extra raw } before the closing }} — e.g. {{a}b}}.
     # `([^...\\]|\\.)*` skips escaped characters so \{ and \} don't false-positive.
-    local brace_re='\{\{([^{}\\]|\\.)*\{|\{\{([^{}\\]|\\.)*\}([^{}]|\\.)*\}\}'
+    local brace_re='\{\{([^{}\\]|\\.)*\{|\{\{([^{}\\]|\\.)*\}([^{}\\]|\\.)*\}\}'
     if grep -qE "$brace_re" <<< "$content"; then
         error "Found unescaped { or } inside {{...}} monospace block — Jira parser will render it as raw text. Escape as \\{ \\} or split the reference."
         echo "   Lines with issue:"

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -154,7 +154,7 @@ validate_file() {
                 error "Unsupported {code:$lang} language. Jira Server rejects this; use {code:none} or one of: $valid_langs"
             fi
         fi
-    done < <(grep -oE '\{code:[^}|]+' <<< "$content" | sed 's/^{code://' | sort -u)
+    done < <(grep -oE '(^|[^\\])\{code:[^}|\\]+' <<< "$content" | sed 's/.*{code://' | sort -u)
 
     # Check for tables with incorrect header syntax (|Header| instead of ||Header||)
     if echo "$content" | grep -qE "^\|[^|]+\|$" && ! echo "$content" | grep -qE "^\|\|"; then
@@ -167,14 +167,17 @@ validate_file() {
     # Use `grep -o ... | wc -l` to count each occurrence (not just matching
     # lines), matching the {color} check below for consistency and to catch
     # multiple tags on the same line.
-    local code_count=$(grep -oE "\{code[}:]" <<< "$content" | wc -l)
+    # `(^|[^\\])` skips escaped literals (\{code\}), which are prose, not markup.
+    local code_count
+    code_count=$(grep -oE '(^|[^\\])\{code[}:]' <<< "$content" | wc -l)
     if [ $((code_count % 2)) -ne 0 ]; then
         error "Mismatched {code} tags: odd number ($code_count) of occurrences (expected pairs)"
     fi
 
     # Check for unclosed {panel} blocks
     # Same rule applies: {panel} opens and closes the block.
-    local panel_count=$(grep -oE "\{panel[}:]" <<< "$content" | wc -l)
+    local panel_count
+    panel_count=$(grep -oE '(^|[^\\])\{panel[}:]' <<< "$content" | wc -l)
     if [ $((panel_count % 2)) -ne 0 ]; then
         error "Mismatched {panel} tags: odd number ($panel_count) of occurrences (expected pairs)"
     fi
@@ -189,11 +192,29 @@ validate_file() {
     # Same single-token open/close rule as {code}, {panel}, {color}: an odd
     # occurrence count signals an unescaped literal in prose or a missing close.
     for macro in noformat quote anchor; do
-        local mcount=$(grep -oE "\{${macro}[}:]" <<< "$content" | wc -l)
+        local mcount
+        mcount=$(grep -oE "(^|[^\\\\])\{${macro}[}:]" <<< "$content" | wc -l)
         if [ $((mcount % 2)) -ne 0 ]; then
             warning "Potential unclosed {${macro}} tag (odd number of occurrences)"
         fi
     done
+
+    # Check for block-markup tags used inline. {code}, {noformat}, {quote} and
+    # {panel} are block-level macros: the tag must stand alone on its own line.
+    # An unescaped tag with other text on the same line opens the block
+    # mid-prose and swallows the rest of the line (classic case: writing
+    # *about* {code} in a sentence). Escape literal mentions as \{code\}.
+    # Excluded: escaped tags (\{code\}) and {{monospace}} content such as
+    # {{code}} (tag preceded by another brace or a backslash).
+    local inline_hits
+    inline_hits=$(grep -nE '\{(code|noformat|quote|panel)(:[^}]*)?\}' <<< "$content" \
+        | grep -vE '^[0-9]+:[[:space:]]*\{(code|noformat|quote|panel)(:[^}]*)?\}[[:space:]]*$' \
+        | grep -vE '(\\|\{)\{(code|noformat|quote|panel)' || true)
+    if [ -n "$inline_hits" ]; then
+        error "Block tag used inline — {code}/{noformat}/{quote}/{panel} must stand alone on their own line; escape literal mentions as \\{code\\}"
+        echo "   Lines with issue:"
+        head -3 <<< "$inline_hits"
+    fi
 
     # Check for Markdown-style lists (- item instead of * item)
     if echo "$content" | grep -qE "^- [^-]"; then

--- a/skills/jira-syntax/templates/bug-report-template.md
+++ b/skills/jira-syntax/templates/bug-report-template.md
@@ -153,8 +153,8 @@ uv run scripts/workflow/jira-create.py issue PROJ \
 - [ ] h3. headings for subsections
 - [ ] Numbered list (#) for Steps to Reproduce
 - [ ] Bulleted list (*) for Environment details
-- [ ] {panel} for error messages with appropriate bgColor
-- [ ] {code:language} for code snippets with correct language
+- [ ] \{panel\} for error messages with appropriate bgColor
+- [ ] \{code:language\} for code snippets with correct language
 - [ ] [^filename] format for attachment references
 - [ ] [PROJ-XXX] format for issue links
 - [ ] [~username] format for user mentions

--- a/skills/jira-syntax/templates/feature-request-template.md
+++ b/skills/jira-syntax/templates/feature-request-template.md
@@ -242,8 +242,8 @@ uv run scripts/workflow/jira-create.py issue PROJ \
 - [ ] Bulleted lists (*) for requirements and criteria
 - [ ] Numbered lists (#) for Acceptance Criteria
 - [ ] Tables (||header|| syntax) for Success Metrics
-- [ ] {code:language} blocks for technical details
-- [ ] {panel} for important launch/timeline information
+- [ ] \{code:language\} blocks for technical details
+- [ ] \{panel\} for important launch/timeline information
 - [ ] [^filename] for mockup/wireframe references
 - [ ] [PROJ-XXX] format for dependency links
 - [ ] [~username] format for stakeholder mentions

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -1,0 +1,79 @@
+"""Tests for ``lib.markup.lint_wiki_markup`` — the wiki-markup linter."""
+
+import sys
+from pathlib import Path
+
+# Add scripts to path for lib imports (mirrors tests/test_input.py).
+_test_dir = Path(__file__).parent
+_scripts_path = _test_dir.parent / "skills" / "jira-communication" / "scripts"
+sys.path.insert(0, str(_scripts_path))
+
+from lib.markup import lint_wiki_markup
+
+
+class TestClean:
+    """Inputs that must produce no findings."""
+
+    def test_plain_prose(self):
+        assert lint_wiki_markup("Just a sentence with *bold* and {{mono}}.") == []
+
+    def test_clean_code_block(self):
+        assert lint_wiki_markup("{code:bash}\nls -l\n{code}") == []
+
+    def test_clean_quote_block(self):
+        assert lint_wiki_markup("{quote}\ncited text\n{quote}") == []
+
+    def test_escaped_literal_in_prose(self):
+        assert lint_wiki_markup("escape literal mentions as \\{code\\} in prose") == []
+
+    def test_inline_monospace_lookalike(self):
+        # {{code}} / {{panel}} are inline monospace, not block tags.
+        assert lint_wiki_markup("Use {{code}} for inline monospace and {{panel}} too") == []
+
+    def test_other_tags_inside_open_block_ignored(self):
+        assert lint_wiki_markup("{code}\nexample shows {noformat} inside code\n{code}") == []
+
+    def test_tag_with_params(self):
+        assert lint_wiki_markup("{panel:title=Note}\ncontent\n{panel}") == []
+
+
+class TestInline:
+    """Block tags used inline must be flagged."""
+
+    def test_tag_in_prose(self):
+        findings = lint_wiki_markup("(/) icons, {code} blocks together")
+        assert any("used inline" in f for f in findings)
+
+    def test_one_line_pair(self):
+        findings = lint_wiki_markup("bad {code}one-liner{code} inline")
+        assert any("used inline" in f for f in findings)
+
+    def test_two_tags_whitespace_separated(self):
+        # Several tags on one line are inline usage even when the
+        # remainder is whitespace (review finding on this PR).
+        findings = lint_wiki_markup("{code} {panel}")
+        assert any("used inline" in f for f in findings)
+
+
+class TestBalance:
+    """Unbalanced or unclosed blocks must be flagged."""
+
+    def test_odd_tag_count(self):
+        findings = lint_wiki_markup("text with {code} blocks\n{code}\nls\n{code}")
+        assert any("unbalanced {code}" in f for f in findings)
+
+    def test_unclosed_block(self):
+        findings = lint_wiki_markup("{noformat}\nstuff")
+        assert any("unclosed {noformat}" in f for f in findings)
+
+
+class TestRendererSemantics:
+    """Same-tag occurrences inside an open block close it — matching the
+    Jira Server 9.12 renderer (verified via /rest/api/1.0/render)."""
+
+    def test_text_after_closing_tag(self):
+        findings = lint_wiki_markup("{code}\nfoo {code} bar\nnext\n{code}\n{code}")
+        assert any("text after closing {code}" in f for f in findings)
+
+    def test_closing_tag_alone_is_fine(self):
+        assert lint_wiki_markup("{code}\nfoo\n{code}") == []


### PR DESCRIPTION
## Summary

Tool-layer enforcement for a recurring authoring error (from the NRS-4455 QA retro): writing *about* `{code}` blocks in a Jira comment with an unescaped tag opens a real block mid-prose and breaks the rendered comment. Block tags (`{code}`, `{noformat}`, `{quote}`, `{panel}`) are block-level — any inline occurrence is a smell.

- **`lib/markup.py`** — `lint_wiki_markup()`: flags inline block tags (incl. several tags on one line) and unbalanced tag counts; ignores escaped literals (`\{code\}`), inline-monospace lookalikes (`{{code}}`) and other tags inside open blocks. Same-tag-inside-block closes it — renderer-verified semantics (Jira Server 9.12 `/rest/api/1.0/render`).
- **`jira-comment.py add`/`edit`** — lint the body before posting; abort with findings, `--force` overrides (findings demoted to warnings). Lint runs before any network call.
- **`validate-jira-syntax.sh`** — same inline check for composed text files; parity counters, the `{code:LANG}` extractor and the no-language check skip escaped literals and `{{...}}` lookalikes; new unescaped-`*`-inside-`{{...}}` warning; brace-in-monospace check honours `\{ \}` escapes (render-verified).
- **Docs** — quick-reference "Block Tags Are Never Inline" section; cross-project-refs escaping-beats-splitting update; gotchas distributed into `references/{attachments,intent-verbs,links,comments}.md` (SKILL.md stays under the 500-word cap at 499); comments.md doc-drift fix (`edit`/`delete` take a positional comment ID — there is no `--id` flag).
- **Templates** — escape literal `{panel}`/`{code:language}` mentions; fixes the pre-existing odd-tag-count validator errors.
- **Evals** — `escape_literal_block_tag_mention`.

## Test plan

- Unit-tested `lint_wiki_markup()` against the real broken comment plus escaped / `{{code}}`-monospace / multi-tag-per-line / unclosed / same-tag-closes cases — all correct.
- `jira-comment.py add FAKE-1 "see the {code} blocks here"` aborts with findings before any network call (exit 1).
- `validate-jira-syntax.sh`: monospace-heavy sample yields 0 errors / 0 warnings; genuine no-language case still warns; templates at 4 pre-existing errors (untouched `##`/code-fence findings).
- `ruff format` + `ruff check` clean; shellcheck clean on all touched lines; SKILL.md word count 499/500.
