### PR TITLE
chore(release): v3.17.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.17.0] - 2026-06-11
+
+### Added
+
+- `jira-comment add` / `edit`: comments are now linted for wiki-markup problems before posting. The new `lib/markup.py` `lint_wiki_markup()` helper catches the most damaging authoring mistakes: block-markup tags (`{code}`, `{noformat}`, `{quote}`, `{panel}`) used inline — these are block-level macros, so an unescaped tag with other text on the same line opens a real block mid-prose and swallows the rest of the line — plus unbalanced (odd-count) block tags and unclosed blocks. Escaped tags (`\{code\}`), inline-monospace lookalikes (`{{code}}`) and other tags inside an open block are ignored, matching the Jira Server 9.12 renderer. Findings abort the post with an explanatory error; `--force` posts anyway and downgrades findings to warnings. ([#131](https://github.com/netresearch/jira-skill/pull/131))
+- `validate-jira-syntax.sh`: new error for block tags used inline (same rule as the comment lint; escaped `\{code\}` literals and `{{code}}` monospace lookalikes are stripped per line before testing), and a new warning for unescaped `*` inside `{{...}}` monospace blocks, which turns bold mid-token (e.g. `{{jira-*backup-*}}` renders "backup-" bold). Escape as `\*`.
+
+### Changed
+
+- `validate-jira-syntax.sh`: the unescaped-brace-inside-`{{...}}` check now skips backslash-escaped braces (`\{` `\}`), which render literally and are fine; the `{code}` language extraction and the tag-balance counts for `{code}`/`{panel}`/`{noformat}`/`{quote}`/`{anchor}` now ignore escaped literals (`\{code\}`) and inline-monospace lookalikes (`{{code}}`) — both are prose, not block markup.
+- `references/cross-project-refs.md` and the quick reference now document escaping (`\{` `\}` `\*`) as the primary fix for literal braces and `*` inside `{{...}}` monospace, verified against the Jira Server 9.12 wiki renderer; splitting into separate `{{...}}` references remains a fallback when escaping hurts readability.
+
 ## [3.16.0] - 2026-06-09
 
 ### Added
@@ -597,7 +609,10 @@ First stable release providing comprehensive Jira integration through Claude Cod
 - [Claude Code Marketplace](https://github.com/netresearch/claude-code-marketplace)
 - [Jira Wiki Markup Reference](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
 
-[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.13.1...HEAD
+[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.17.0...HEAD
+[3.17.0]: https://github.com/netresearch/jira-skill/compare/v3.16.0...v3.17.0
+[3.16.0]: https://github.com/netresearch/jira-skill/compare/v3.15.0...v3.16.0
+[3.15.0]: https://github.com/netresearch/jira-skill/compare/v3.14.0...v3.15.0
 [3.13.1]: https://github.com/netresearch/jira-skill/compare/v3.13.0...v3.13.1
 [3.13.0]: https://github.com/netresearch/jira-skill/compare/v3.12.0...v3.13.0
 [3.12.0]: https://github.com/netresearch/jira-skill/compare/v3.11.0...v3.12.0

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.16.0"
+  version: "3.17.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.16.0"
+  version: "3.17.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Release v3.17.0 (minor: PR #131 wiki-markup lint feature).

Bumped: `.claude-plugin/plugin.json`, both `skills/*/SKILL.md` `metadata.version`. CHANGELOG: new `[3.17.0]` section covering the pre-post comment lint (`lib/markup.py`, `--force` override) and the `validate-jira-syntax.sh` escape-aware checks; compare-link definitions updated (Unreleased, 3.17.0, plus missing 3.16.0/3.15.0).
