### PR TITLE
docs(jira-syntax): clarify escaping rules and fix table pipe escaping

### DIFF
--- a/skills/jira-syntax/references/jira-syntax-quick-reference.md
+++ b/skills/jira-syntax/references/jira-syntax-quick-reference.md
@@ -277,7 +277,11 @@ Horizontal rule (4 dashes)
 \{escaped brace\}
 ```
 
-To escape special characters, use backslash: `\*`, `\{`, `\[`
+To escape special characters, use backslash: `\*`, `\{`, `\[`.
+
+- **Only escape characters Jira actually parses as markup** — `*`, `_`, `-`, `+`, `^`, `~`, `{`, `[`, `|`, `\`. Do **not** escape plain punctuation such as `.`, `,`, or `:` — `\.` renders the backslash literally and produces the wrong output.
+- **Never escape inline monospace** — `{{text}}` is not a macro, so `\{\{text\}\}` is wrong. Only escape the opening brace of a *macro name* shown as prose (e.g. `\{code\}`).
+- **Preserve existing backslash escapes** — a source `\*`, `\_`, or `\{` already suppresses Markdown markup; keep it as-is, because Jira uses the same `\` escape mechanism for the same characters.
 
 ### Common gotcha: macro names in prose
 
@@ -452,7 +456,7 @@ Before submitting, verify:
 | `- item` | `* item` | Use asterisk for bullets |
 | `h2.Title` | `h2. Title` | Missing space after period |
 | `{code}` | `{code:java}` | Missing language identifier |
-| `|Header|` | `||Header||` | Header needs double pipes |
+| `\|Header\|` | `\|\|Header\|\|` | Header needs double pipes |
 
 ## Resources
 


### PR DESCRIPTION
## Summary

Clarify the Jira wiki-markup **escaping** rules in the quick-reference, where the
current wording is under-specified, plus a small markdownlint fix. Documentation only.

## Changes

- **Escaping** — three rules that prevent common over-/mis-escaping:
  - Only escape characters Jira actually parses as markup (`*`, `_`, `-`, `+`, `^`,
    `~`, `{`, `[`, `|`, `\`). Do **not** escape plain punctuation (`.`, `,`, `:`) —
    `\.` renders the backslash *literally* and produces the wrong output.
  - Never escape inline monospace `{{…}}` — it is not a macro.
  - Preserve backslash escapes already present in the source.
- **Common Mistakes table** — escape the literal pipes in the pre-existing
  `|Header|` example row, clearing a pre-existing markdownlint **MD056**
  table-column error.

## Validation

The escaping rules are verified against Jira's **own** wiki renderer
(`POST /rest/api/1.0/render`, `atlassian-wiki-renderer`):

- `3 p\.m\.\,` → renders the backslashes **literally** (`3 p\.m\.\,`) — confirming
  `.` / `,` / `:` must not be escaped.
- `\{\{userId\}\}` → still renders as monospace `userId` — confirming `{{…}}`
  needs no escaping.

(Surfaced during a Markdown→Jira skill-optimisation experiment. The earlier
`{code:none}` "code-language fallback" proposal that this PR originally also carried
was **dropped** after review found it contradicted the skill's own
`validate-jira-syntax.sh`, which maps unsupported languages to real formatters.)

SKILL.md is unchanged (stays within the 500-word cap).

## Test plan

- [x] `markdownlint-cli2` clean (0 errors; also clears a pre-existing MD056)
- [x] skill-repo `validate-skill` passes
- [x] Documentation only — no behavioural / code change
