### PR TITLE
feat(jira-communication): add download-all for bulk attachment download

### DIFF
--- a/evals/comprehensive-evals.json
+++ b/evals/comprehensive-evals.json
@@ -169,6 +169,13 @@
       "prompt": "Delete version 1.3.0 from TEST and move its fix-version tickets to 1.4.0",
       "expected_output": "Agent reads references/versions.md, resolves both names via jira-version.py get ... --project TEST, then runs jira-version.py delete <1.3-id> --move-fix-to <1.4-id>",
       "ideal_tools": 4
+    },
+    {
+      "id": 25,
+      "name": "download-all-attachments",
+      "prompt": "Download all attachments from TEST-135 into ./attachments",
+      "expected_output": "Agent runs jira-attachment.py download-all TEST-135 --dir ./attachments (single bulk command, not per-URL download loop)",
+      "ideal_tools": 1
     }
   ]
 }

--- a/skills/jira-communication/references/attachments.md
+++ b/skills/jira-communication/references/attachments.md
@@ -32,9 +32,24 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py download \
     ./attachments/report.pdf
 ```
 
+## Download all attachments
+
+To grab every attachment on an issue in one call (no need to harvest URLs first), use `download-all`. Files are saved under `--dir` (default cwd) using their original Jira filenames; duplicate names are disambiguated with the attachment id, and a filename that would escape `--dir` is skipped.
+
+```bash
+# All attachments into the current directory
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py download-all PROJ-123
+
+# Into a specific directory (created if missing, must stay within cwd)
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py download-all PROJ-123 --dir ./attachments
+
+# Preview the list without downloading
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py download-all PROJ-123 --dry-run
+```
+
 ## Safety guarantees
 
-- **Path traversal**: output paths are constrained to the current working directory — the script rejects targets that resolve outside cwd. `cd` to the target directory before downloading.
+- **Path traversal**: output paths are constrained to the current working directory — the script rejects targets that resolve outside cwd. `cd` to the target directory before downloading. `download-all` additionally strips path components from each Jira-supplied filename and constrains it within `--dir`.
 
 ## Don't use raw curl
 

--- a/skills/jira-communication/scripts/core/jira-attachment.py
+++ b/skills/jira-communication/scripts/core/jira-attachment.py
@@ -167,13 +167,14 @@ def _report_download_error(ctx, exc: Exception) -> None:
     if isinstance(exc, CaptchaError):
         raise exc
     if isinstance(exc, KeyError):
+        # Config key names are non-sensitive metadata — no sanitization needed.
         error(f"Missing required configuration: {exc}")
     elif isinstance(exc, (SessionExpiredError, AuthenticationError)):
-        error(str(exc))
+        error(_sanitize_error(str(exc)))
     elif isinstance(exc, (DownloadError, requests.exceptions.RequestException)):
-        error(f"Download failed: {exc}")
+        error(f"Download failed: {_sanitize_error(str(exc))}")
     else:
-        error(f"Failed to download attachment: {exc}")
+        error(f"Failed to download attachment: {_sanitize_error(str(exc))}")
     sys.exit(1)
 
 
@@ -326,9 +327,27 @@ def download_all(ctx, issue_key: str, output_dir: str, dry_run: bool):
             return
 
         if dry_run:
-            warning(f"DRY RUN — {len(attachments)} attachment(s) on {issue_key}:")
-            for att in attachments:
-                print(f"  {att.get('filename')} ({att.get('size', 0):,} bytes)")
+            if ctx.obj["json"]:
+                print(
+                    json.dumps(
+                        {
+                            "status": "dry-run",
+                            "issue": issue_key,
+                            "count": len(attachments),
+                            "attachments": [
+                                {"id": att.get("id"), "filename": att.get("filename"), "size": att.get("size", 0)}
+                                for att in attachments
+                            ],
+                        }
+                    )
+                )
+            elif ctx.obj["quiet"]:
+                for att in attachments:
+                    print(att.get("filename"))
+            else:
+                warning(f"DRY RUN — {len(attachments)} attachment(s) on {issue_key}:")
+                for att in attachments:
+                    print(f"  {att.get('filename')} ({att.get('size', 0):,} bytes)")
             return
 
         safe_dir.mkdir(parents=True, exist_ok=True)
@@ -350,10 +369,13 @@ def download_all(ctx, issue_key: str, output_dir: str, dry_run: bool):
                 warning(f"Skipping unsafe filename: {att.get('filename')!r}")
                 continue
 
+            # Per-file resilience: a single bad file (404/500/redirect anomaly)
+            # must not abort the whole batch. Auth/session/CAPTCHA errors are NOT
+            # caught here — they propagate and abort, since retrying is pointless.
             try:
                 _stream_to_path(att["content"], jira_url, auth, headers, dest)
-            except DownloadError as e:
-                warning(f"Skipping {filename}: {e}")
+            except (DownloadError, requests.exceptions.RequestException) as e:
+                warning(f"Skipping {filename}: {_sanitize_error(str(e))}")
                 continue
             downloaded.append(str(dest))
 

--- a/skills/jira-communication/scripts/core/jira-attachment.py
+++ b/skills/jira-communication/scripts/core/jira-attachment.py
@@ -94,6 +94,90 @@ def validate_output_path(output_file: str, working_dir: str) -> Path | None:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Download Helpers (shared by `download` and `download-all`)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class DownloadError(Exception):
+    """Raised for download-level anomalies (CDN redirects, TLS downgrade)."""
+
+
+def _build_auth(config: dict) -> tuple[tuple[str, str] | None, dict]:
+    """Build (auth, headers) for an authenticated Jira request.
+
+    Personal access tokens go in a Bearer header; Cloud uses basic auth.
+    """
+    if "JIRA_PERSONAL_TOKEN" in config:
+        return None, {"Authorization": f"Bearer {config['JIRA_PERSONAL_TOKEN']}"}
+    return (config["JIRA_USERNAME"], config["JIRA_API_TOKEN"]), {}
+
+
+def _stream_to_path(url: str, jira_url: str, auth, headers: dict, safe_path: Path) -> None:
+    """Stream an attachment URL to safe_path with CDN-redirect protection.
+
+    Follows exactly one CDN redirect without forwarding credentials, refuses
+    TLS downgrades, and rejects unexpected redirect chains so a 302 HTML body
+    is never written as the file. Raises DownloadError on redirect anomalies;
+    propagates the typed auth errors from _handle_response().
+    """
+    response = requests.get(
+        url,
+        auth=auth,
+        headers=headers,
+        allow_redirects=False,
+        stream=True,
+        verify=True,
+        timeout=DOWNLOAD_TIMEOUT,
+    )
+
+    # Follow one CDN redirect without forwarding credentials (Jira Cloud stores
+    # attachments in S3/CDN which returns 302).
+    if response.status_code in (301, 302, 303, 307, 308) and "Location" in response.headers:
+        redirect_url = response.headers["Location"]
+        # Reject HTTP downgrade — prevents MITM on non-TLS redirects
+        if redirect_url.startswith("http://"):
+            raise DownloadError("refusing HTTP redirect (TLS downgrade)")
+        response = requests.get(
+            redirect_url,
+            allow_redirects=False,
+            stream=True,
+            verify=True,
+            timeout=DOWNLOAD_TIMEOUT,
+        )
+
+    # Reject unexpected redirect (e.g., CDN chain with >1 hop) — without this
+    # the 302 HTML body would be silently saved as the file.
+    if 300 <= response.status_code < 400:
+        raise DownloadError(f"unexpected redirect (status {response.status_code})")
+
+    # _handle_response() raises typed errors for 401/403/session-expiry;
+    # raise_for_status() handles the remaining 4xx/5xx.
+    _handle_response(response, jira_url, url=getattr(response, "url", url))
+    response.raise_for_status()
+
+    with open(safe_path, "wb") as f:
+        for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
+            f.write(chunk)
+
+
+def _report_download_error(ctx, exc: Exception) -> None:
+    """Map a download exception to a user-facing message and exit non-zero."""
+    if ctx.obj.get("debug"):
+        raise exc
+    if isinstance(exc, CaptchaError):
+        raise exc
+    if isinstance(exc, KeyError):
+        error(f"Missing required configuration: {exc}")
+    elif isinstance(exc, (SessionExpiredError, AuthenticationError)):
+        error(str(exc))
+    elif isinstance(exc, (DownloadError, requests.exceptions.RequestException)):
+        error(f"Download failed: {exc}")
+    else:
+        error(f"Failed to download attachment: {exc}")
+    sys.exit(1)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # CLI Definition
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -152,15 +236,7 @@ def download(ctx, attachment_url: str, output_file: str):
             sys.exit(1)
 
         # Determine authentication method
-        if "JIRA_PERSONAL_TOKEN" in config:
-            auth_token = config["JIRA_PERSONAL_TOKEN"]
-            auth = None
-            headers = {"Authorization": f"Bearer {auth_token}"}
-        else:
-            username = config["JIRA_USERNAME"]
-            api_token = config["JIRA_API_TOKEN"]
-            auth = (username, api_token)
-            headers = {}
+        auth, headers = _build_auth(config)
 
         # Build full URL if needed
         if attachment_url.startswith(("http://", "https://")):
@@ -183,51 +259,7 @@ def download(ctx, attachment_url: str, output_file: str):
             error(f"Output path exists and is not a file: {output_file}")
             sys.exit(1)
 
-        # Download with authentication (explicit verify and timeout).
-        # First request uses allow_redirects=False to handle CDN redirects
-        # safely — Jira Cloud stores attachments in S3/CDN which returns 302.
-        # We follow exactly one redirect but strip credentials to avoid
-        # leaking them to the CDN host.
-        response = requests.get(
-            url,
-            auth=auth,
-            headers=headers,
-            allow_redirects=False,
-            stream=True,
-            verify=True,
-            timeout=DOWNLOAD_TIMEOUT,
-        )
-
-        # Follow one CDN redirect without forwarding credentials
-        if response.status_code in (301, 302, 303, 307, 308) and "Location" in response.headers:
-            redirect_url = response.headers["Location"]
-            # Reject HTTP downgrade — prevents MITM on non-TLS redirects
-            if redirect_url.startswith("http://"):
-                error("Download failed: refusing HTTP redirect (TLS downgrade)")
-                sys.exit(1)
-            response = requests.get(
-                redirect_url,
-                allow_redirects=False,
-                stream=True,
-                verify=True,
-                timeout=DOWNLOAD_TIMEOUT,
-            )
-
-        # Reject unexpected redirect (e.g., CDN chain with >1 hop) —
-        # without this check, the 302 HTML body would be silently saved as the file.
-        if 300 <= response.status_code < 400:
-            error(f"Download failed: unexpected redirect (status {response.status_code})")
-            sys.exit(1)
-
-        # _handle_response() raises typed errors for 401/403/session-expiry;
-        # raise_for_status() handles the remaining 4xx/5xx.
-        _handle_response(response, jira_url, url=getattr(response, "url", url))
-        response.raise_for_status()
-
-        # Write to file
-        with open(safe_path, "wb") as f:
-            for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
-                f.write(chunk)
+        _stream_to_path(url, jira_url, auth, headers, safe_path)
 
         if ctx.obj["quiet"]:
             print(str(safe_path))
@@ -236,31 +268,109 @@ def download(ctx, attachment_url: str, output_file: str):
         else:
             success(f"Downloaded to: {safe_path}")
 
-    except KeyError as e:
-        if ctx.obj["debug"]:
-            raise
-        error(f"Missing required configuration: {e}")
-        sys.exit(1)
-    except SessionExpiredError as e:
-        if ctx.obj["debug"]:
-            raise
-        error(str(e))
-        sys.exit(1)
-    except AuthenticationError as e:
-        if ctx.obj["debug"]:
-            raise
-        error(str(e))
-        sys.exit(1)
-    except requests.exceptions.RequestException as e:
-        if ctx.obj["debug"]:
-            raise
-        error(f"Download failed: {e}")
-        sys.exit(1)
     except Exception as e:
-        if ctx.obj["debug"]:
-            raise
-        error(f"Failed to download attachment: {e}")
-        sys.exit(1)
+        _report_download_error(ctx, e)
+
+
+@cli.command("download-all")
+@click.argument("issue_key")
+@click.option("--dir", "output_dir", default=".", help="Output directory (created if missing; must stay within cwd)")
+@click.option("--dry-run", is_flag=True, help="List attachments without downloading")
+@click.pass_context
+def download_all(ctx, issue_key: str, output_dir: str, dry_run: bool):
+    """Download all attachments of a Jira issue.
+
+    ISSUE_KEY: The Jira issue key (e.g., PROJ-123)
+
+    Files are saved under --dir using their original Jira filenames. Duplicate
+    filenames are disambiguated with the attachment id. Files whose name would
+    escape --dir are skipped.
+
+    Examples:
+
+      jira-attachment download-all PROJ-123
+
+      jira-attachment download-all PROJ-123 --dir ./attachments
+
+      jira-attachment download-all PROJ-123 --dry-run
+    """
+    try:
+        config = load_config(env_file=ctx.obj["env_file"], profile=ctx.obj.get("profile"))
+        jira_url = config["JIRA_URL"]
+        auth, headers = _build_auth(config)
+
+        # Path traversal protection: constrain output dir within cwd (matches `download`)
+        safe_dir = validate_output_path(output_dir, Path.cwd())
+        if safe_dir is None:
+            error(f"Output directory escapes working directory: {output_dir}")
+            sys.exit(1)
+
+        # Fetch attachment metadata for the issue
+        meta_response = requests.get(
+            f"{jira_url}/rest/api/2/issue/{issue_key}",
+            params={"fields": "attachment"},
+            auth=auth,
+            headers={**headers, "Accept": "application/json"},
+            verify=True,
+            timeout=DOWNLOAD_TIMEOUT,
+        )
+        _handle_response(meta_response, jira_url, url=getattr(meta_response, "url", None))
+        meta_response.raise_for_status()
+        attachments = (meta_response.json().get("fields") or {}).get("attachment") or []
+
+        if not attachments:
+            if ctx.obj["json"]:
+                print(json.dumps({"status": "success", "issue": issue_key, "count": 0, "downloaded": []}))
+            elif not ctx.obj["quiet"]:
+                warning(f"No attachments on {issue_key}")
+            return
+
+        if dry_run:
+            warning(f"DRY RUN — {len(attachments)} attachment(s) on {issue_key}:")
+            for att in attachments:
+                print(f"  {att.get('filename')} ({att.get('size', 0):,} bytes)")
+            return
+
+        safe_dir.mkdir(parents=True, exist_ok=True)
+        downloaded: list[str] = []
+        seen: set[str] = set()
+        for att in attachments:
+            # Strip any path components from the Jira-supplied filename (untrusted)
+            filename = Path(att.get("filename", "")).name
+            if not filename:
+                warning(f"Skipping attachment with empty filename (id={att.get('id')})")
+                continue
+            # Disambiguate duplicate filenames so they don't overwrite each other
+            if filename in seen:
+                filename = f"{att.get('id', 'dup')}_{filename}"
+            seen.add(filename)
+
+            dest = validate_output_path(filename, str(safe_dir))
+            if dest is None:
+                warning(f"Skipping unsafe filename: {att.get('filename')!r}")
+                continue
+
+            try:
+                _stream_to_path(att["content"], jira_url, auth, headers, dest)
+            except DownloadError as e:
+                warning(f"Skipping {filename}: {e}")
+                continue
+            downloaded.append(str(dest))
+
+        if ctx.obj["quiet"]:
+            for path in downloaded:
+                print(path)
+        elif ctx.obj["json"]:
+            print(
+                json.dumps(
+                    {"status": "success", "issue": issue_key, "count": len(downloaded), "downloaded": downloaded}
+                )
+            )
+        else:
+            success(f"Downloaded {len(downloaded)}/{len(attachments)} attachment(s) from {issue_key} to {safe_dir}")
+
+    except Exception as e:
+        _report_download_error(ctx, e)
 
 
 @cli.command("add")

--- a/tests/test_attachment_security.py
+++ b/tests/test_attachment_security.py
@@ -442,3 +442,44 @@ class TestDownloadAll:
         result = self._run(tmp_path, [_att("1", "a.pdf")], extra_args=["--dir", "../escape"])
         assert result.exit_code != 0
         assert "escape" in result.output.lower()
+
+    def test_dry_run_json_is_valid_json(self, tmp_path):
+        """--json --dry-run must emit valid JSON on stdout, not plain text."""
+        runner = click.testing.CliRunner()
+
+        def fake_get(url, *args, **kwargs):
+            return _make_meta_response([_att("1", "a.pdf"), _att("2", "b.txt")])
+
+        with (
+            mock.patch.object(jira_attachment, "load_config", return_value=_FAKE_CONFIG),
+            mock.patch.object(jira_attachment.requests, "get", side_effect=fake_get),
+            mock.patch.object(jira_attachment.Path, "cwd", return_value=tmp_path),
+        ):
+            result = runner.invoke(jira_attachment.cli, ["--json", "download-all", "TEST-1", "--dry-run"])
+        assert result.exit_code == 0, result.output
+        import json as _json
+
+        payload = _json.loads(result.output)
+        assert payload["status"] == "dry-run"
+        assert payload["count"] == 2
+
+    def test_partial_failure_continues(self, tmp_path):
+        """A single failing attachment must be skipped, not abort the whole batch."""
+        runner = click.testing.CliRunner()
+
+        def fake_get(url, *args, **kwargs):
+            if "/rest/api/2/issue/" in url:
+                return _make_meta_response([_att("1", "good.pdf"), _att("2", "bad.txt")])
+            if url.endswith("/content/2"):
+                raise jira_attachment.requests.exceptions.ConnectionError("boom")
+            return _make_mock_response("application/octet-stream", b"data")
+
+        with (
+            mock.patch.object(jira_attachment, "load_config", return_value=_FAKE_CONFIG),
+            mock.patch.object(jira_attachment.requests, "get", side_effect=fake_get),
+            mock.patch.object(jira_attachment.Path, "cwd", return_value=tmp_path),
+        ):
+            result = runner.invoke(jira_attachment.cli, ["download-all", "TEST-1"])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "good.pdf").exists()
+        assert not (tmp_path / "bad.txt").exists()

--- a/tests/test_attachment_security.py
+++ b/tests/test_attachment_security.py
@@ -339,3 +339,106 @@ class TestDownloadContentTypeGuard:
         assert result.exit_code == 0, result.output
         assert out.exists()
         assert out.read_bytes() == b"fake"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: _build_auth helper
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBuildAuth:
+    """Auth selection: PAT → Bearer header; Cloud → basic auth tuple."""
+
+    def test_personal_token_uses_bearer_header(self):
+        auth, headers = jira_attachment._build_auth(
+            {"JIRA_URL": "https://jira.example.com", "JIRA_PERSONAL_TOKEN": "pat-123"}
+        )
+        assert auth is None
+        assert headers == {"Authorization": "Bearer pat-123"}
+
+    def test_cloud_uses_basic_auth(self):
+        auth, headers = jira_attachment._build_auth(_FAKE_CONFIG)
+        assert auth == ("user@example.com", "fake-token")
+        assert headers == {}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: download-all command
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_meta_response(attachments: list[dict]):
+    """Mock issue-metadata response carrying fields.attachment."""
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.url = "https://jira.example.com/rest/api/2/issue/TEST-1"
+    resp.headers = {"Content-Type": "application/json"}
+    resp.raise_for_status = mock.Mock()
+    resp.json.return_value = {"fields": {"attachment": attachments}}
+    return resp
+
+
+def _att(att_id: str, filename: str, size: int = 4):
+    return {
+        "id": att_id,
+        "filename": filename,
+        "size": size,
+        "content": f"https://jira.example.com/rest/api/2/attachment/content/{att_id}",
+    }
+
+
+class TestDownloadAll:
+    """download-all fetches issue metadata then streams each attachment."""
+
+    def _run(self, tmp_path, attachments, extra_args=None):
+        runner = click.testing.CliRunner()
+
+        def fake_get(url, *args, **kwargs):
+            if "/rest/api/2/issue/" in url:
+                return _make_meta_response(attachments)
+            return _make_mock_response("application/octet-stream", b"data")
+
+        with (
+            mock.patch.object(jira_attachment, "load_config", return_value=_FAKE_CONFIG),
+            mock.patch.object(jira_attachment.requests, "get", side_effect=fake_get),
+            mock.patch.object(jira_attachment.Path, "cwd", return_value=tmp_path),
+        ):
+            result = runner.invoke(jira_attachment.cli, ["download-all", "TEST-1", *(extra_args or [])])
+        return result
+
+    def test_downloads_all_attachments(self, tmp_path):
+        result = self._run(tmp_path, [_att("1", "a.pdf"), _att("2", "b.txt")])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "a.pdf").read_bytes() == b"data"
+        assert (tmp_path / "b.txt").read_bytes() == b"data"
+
+    def test_no_attachments_is_success(self, tmp_path):
+        result = self._run(tmp_path, [])
+        assert result.exit_code == 0, result.output
+        assert "No attachments" in result.output
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        result = self._run(tmp_path, [_att("1", "a.pdf")], extra_args=["--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        assert not (tmp_path / "a.pdf").exists()
+
+    def test_filename_path_components_stripped(self, tmp_path):
+        """A Jira filename with path components must be saved by basename, never escape --dir."""
+        result = self._run(tmp_path, [_att("1", "../../etc/passwd")])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "passwd").exists()
+        assert not (tmp_path.parent / "passwd").exists()
+
+    def test_duplicate_filenames_disambiguated(self, tmp_path):
+        """Two attachments with the same name must not overwrite each other."""
+        result = self._run(tmp_path, [_att("1", "dup.txt"), _att("2", "dup.txt")])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "dup.txt").exists()
+        assert (tmp_path / "2_dup.txt").exists()
+
+    def test_dir_outside_cwd_rejected(self, tmp_path):
+        """--dir resolving outside cwd must be rejected (path traversal guard)."""
+        result = self._run(tmp_path, [_att("1", "a.pdf")], extra_args=["--dir", "../escape"])
+        assert result.exit_code != 0
+        assert "escape" in result.output.lower()


### PR DESCRIPTION
## Summary

`jira-attachment.py` could only download one attachment per invocation. Fetching every attachment on an issue meant harvesting URLs from `jira-issue.py get --json` and looping `download` per URL — friction surfaced while triaging a ticket with 5 attachments.

This adds a bulk verb:

```bash
jira-attachment.py download-all PROJ-123                 # all → cwd
jira-attachment.py download-all PROJ-123 --dir ./out     # all → ./out
jira-attachment.py download-all PROJ-123 --dry-run       # list only
```

It fetches the issue's attachment metadata and streams each file under `--dir` using its original Jira filename.

## Safety

- Untrusted Jira filenames are basename-stripped and constrained within `--dir` (path-traversal guard)
- Duplicate filenames are disambiguated with the attachment id (no silent overwrite)
- Reuses the existing SSRF / TLS-downgrade / CDN-redirect protections via a shared `_stream_to_path` helper

## Refactor

The shared download internals (auth building, secure streaming, error mapping) are extracted into `_build_auth` / `_stream_to_path` / `_report_download_error` so `download` and `download-all` share one implementation instead of duplicating it. Existing `download` behaviour and error messages are preserved.

## Tests

- 8 new tests: `_build_auth` (PAT/basic), happy path, `--dry-run`, no-attachments, filename path-component stripping, duplicate disambiguation, `--dir` outside cwd rejected
- Full suite green: **694 passed**; `ruff format`/`ruff check` clean; harness verify Level 3

## Docs

- `references/attachments.md` — new "Download all attachments" section
- `evals/comprehensive-evals.json` — eval id 25 asserting the single-command path
