### PR TITLE
feat(jira-communication): tolerant transition-name matching

### DIFF
--- a/evals/comprehensive-evals.json
+++ b/evals/comprehensive-evals.json
@@ -176,6 +176,13 @@
       "prompt": "Download all attachments from TEST-135 into ./attachments",
       "expected_output": "Agent runs jira-attachment.py download-all TEST-135 --dir ./attachments (single bulk command, not per-URL download loop)",
       "ideal_tools": 1
+    },
+    {
+      "id": 26,
+      "name": "transition-emoji-tolerant",
+      "prompt": "Resolve TEST-135 (its transition is labelled '✅ Resolve')",
+      "expected_output": "Agent runs jira-transition.py do TEST-135 'Resolve' (or 'Resolved') — the resolver tolerates the emoji prefix; no need to guess the exact emoji string",
+      "ideal_tools": 1
     }
   ]
 }

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -41,6 +41,53 @@ def _get_to_status(transition: dict) -> str:
     return str(to_value)
 
 
+def _normalize_transition_name(name: str) -> str:
+    """Normalize a transition/status name for tolerant matching.
+
+    Strips leading non-alphanumeric noise (emoji, symbols, whitespace) and
+    lowercases, so a user-supplied "Resolve" matches a Jira transition labelled
+    "✅ Resolve".
+    """
+    return re.sub(r"^[^0-9a-zA-Z]+", "", name or "").strip().lower()
+
+
+def find_matching_transition(transitions: list[dict], status_name: str) -> tuple[dict | None, list[dict]]:
+    """Resolve a user-supplied name to a transition, tolerating emoji prefixes.
+
+    Tiers, first hit wins: (1) exact case-insensitive on transition name or
+    target status; (2) normalized equality (emoji/symbol prefix stripped);
+    (3) unique normalized-substring match. Returns (match, candidates): match is
+    the resolved transition or None; candidates lists the >1 transitions that an
+    ambiguous substring matched (empty otherwise), so the caller can report them.
+    """
+    target = status_name.lower()
+    for t in transitions:
+        if t.get("name", "").lower() == target or _get_to_status(t).lower() == target:
+            return t, []
+
+    norm_target = _normalize_transition_name(status_name)
+    if norm_target:
+        for t in transitions:
+            if norm_target in (
+                _normalize_transition_name(t.get("name", "")),
+                _normalize_transition_name(_get_to_status(t)),
+            ):
+                return t, []
+
+        substring = [
+            t
+            for t in transitions
+            if norm_target in _normalize_transition_name(t.get("name", ""))
+            or norm_target in _normalize_transition_name(_get_to_status(t))
+        ]
+        if len(substring) == 1:
+            return substring[0], []
+        if len(substring) > 1:
+            return None, substring
+
+    return None, []
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # CLI Definition
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -144,22 +191,18 @@ def do_transition(ctx, issue_key: str, status_name: str, comment: str | None, re
         # Get available transitions
         transitions = client.get_issue_transitions(issue_key)
 
-        # Find matching transition (case-insensitive)
-        matching = None
-        for t in transitions:
-            if t.get("name", "").lower() == status_name.lower():
-                matching = t
-                break
-            # Also check target status name
-            to_status = _get_to_status(t)
-            if to_status.lower() == status_name.lower():
-                matching = t
-                break
+        # Find matching transition (exact → emoji-tolerant → unique substring)
+        matching, ambiguous = find_matching_transition(transitions, status_name)
 
         if not matching:
-            available = [t.get("name", "") for t in transitions]
-            error(f"Transition '{status_name}' not available for {issue_key}")
-            print(f"\nAvailable transitions: {', '.join(available)}")
+            if ambiguous:
+                names = [t.get("name", "") for t in ambiguous]
+                error(f"Transition '{status_name}' is ambiguous for {issue_key}")
+                print(f"\nMatches: {', '.join(names)} — use the exact name")
+            else:
+                available = [t.get("name", "") for t in transitions]
+                error(f"Transition '{status_name}' not available for {issue_key}")
+                print(f"\nAvailable transitions: {', '.join(available)}")
             sys.exit(1)
 
         # Dry run

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -42,13 +42,15 @@ def _get_to_status(transition: dict) -> str:
 
 
 def _normalize_transition_name(name: str) -> str:
-    """Normalize a transition/status name for tolerant matching.
+    r"""Normalize a transition/status name for tolerant matching.
 
-    Strips leading non-alphanumeric noise (emoji, symbols, whitespace) and
-    lowercases, so a user-supplied "Resolve" matches a Jira transition labelled
-    "✅ Resolve".
+    Strips leading non-word noise (emoji, symbols, whitespace) and case-folds,
+    so a user-supplied "Resolve" matches a Jira transition labelled "✅ Resolve".
+    Uses ``\W`` (Unicode-aware) rather than an ASCII class so localized names
+    (Cyrillic, Han, accented, …) are preserved instead of stripped to empty, and
+    ``casefold()`` for correct Unicode case-insensitive comparison.
     """
-    return re.sub(r"^[^0-9a-zA-Z]+", "", name or "").strip().lower()
+    return re.sub(r"^\W+", "", name or "", flags=re.UNICODE).strip().casefold()
 
 
 def find_matching_transition(transitions: list[dict], status_name: str) -> tuple[dict | None, list[dict]]:
@@ -60,9 +62,9 @@ def find_matching_transition(transitions: list[dict], status_name: str) -> tuple
     the resolved transition or None; candidates lists the >1 transitions that an
     ambiguous substring matched (empty otherwise), so the caller can report them.
     """
-    target = status_name.lower()
+    target = status_name.casefold()
     for t in transitions:
-        if t.get("name", "").lower() == target or _get_to_status(t).lower() == target:
+        if t.get("name", "").casefold() == target or _get_to_status(t).casefold() == target:
             return t, []
 
     norm_target = _normalize_transition_name(status_name)

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -56,3 +56,20 @@ class TestFindMatchingTransition:
         match, ambiguous = _mod.find_matching_transition(ts, "Review")
         assert match["name"] == "Review"
         assert ambiguous == []
+
+    def test_non_latin_name_not_stripped_to_empty(self):
+        """Localized (non-ASCII) transition names must survive normalization.
+
+        Regression: an ASCII-only strip class would reduce a fully-Cyrillic name
+        to '' and break matching. '\\W'-based stripping keeps Unicode letters.
+        """
+        ts = [_t("✅ Решить", "Решено"), _t("▶ Начать", "В работе")]
+        match, ambiguous = _mod.find_matching_transition(ts, "Решить")
+        assert match["name"] == "✅ Решить"
+        assert ambiguous == []
+
+    def test_unicode_casefold_equality(self):
+        """German ß should casefold-match 'ss' (Unicode-correct comparison)."""
+        ts = [_t("Abschließen", "Done")]
+        match, _ = _mod.find_matching_transition(ts, "ABSCHLIESSEN")
+        assert match["name"] == "Abschließen"

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -1,0 +1,58 @@
+"""Tests for jira-transition.py `find_matching_transition` — tolerant name resolver.
+
+Jira transitions are often labelled with emoji prefixes (e.g. "✅ Resolve"), so
+exact-equality matching forces the caller to reproduce the emoji. The resolver
+adds emoji-tolerant and unique-substring fallbacks on top of exact matching.
+"""
+
+from conftest import load_script
+
+_mod = load_script("jira-transition", "workflow")
+
+
+def _t(name: str, to: str):
+    return {"id": name, "name": name, "to": to}
+
+
+class TestFindMatchingTransition:
+    def test_exact_case_insensitive_name(self):
+        ts = [_t("Start work", "In Progress"), _t("Resolve", "Resolved")]
+        match, ambiguous = _mod.find_matching_transition(ts, "resolve")
+        assert match["name"] == "Resolve"
+        assert ambiguous == []
+
+    def test_exact_on_target_status(self):
+        ts = [_t("Done it", "Resolved")]
+        match, _ = _mod.find_matching_transition(ts, "Resolved")
+        assert match["name"] == "Done it"
+
+    def test_emoji_prefixed_name_matched_by_plain_name(self):
+        """The regression: '✅ Resolve' must match a plain 'Resolve'."""
+        ts = [_t("▶ Start work", "In Progress"), _t("✅ Resolve", "Resolved"), _t("⏳️ Waiting", "Waiting")]
+        match, ambiguous = _mod.find_matching_transition(ts, "Resolve")
+        assert match["name"] == "✅ Resolve"
+        assert ambiguous == []
+
+    def test_unique_substring_match(self):
+        ts = [_t("Start work", "In Progress"), _t("Send to QA review", "QA")]
+        match, _ = _mod.find_matching_transition(ts, "QA review")
+        assert match["name"] == "Send to QA review"
+
+    def test_ambiguous_substring_returns_candidates(self):
+        ts = [_t("Resolve as fixed", "Resolved"), _t("Resolve as duplicate", "Resolved")]
+        match, ambiguous = _mod.find_matching_transition(ts, "resolve as")
+        assert match is None
+        assert {t["name"] for t in ambiguous} == {"Resolve as fixed", "Resolve as duplicate"}
+
+    def test_no_match_returns_empty(self):
+        ts = [_t("Start work", "In Progress")]
+        match, ambiguous = _mod.find_matching_transition(ts, "Resolve")
+        assert match is None
+        assert ambiguous == []
+
+    def test_exact_wins_over_substring(self):
+        """An exact name must win even when it is a substring of another transition."""
+        ts = [_t("Review", "In Review"), _t("Review and approve", "Approved")]
+        match, ambiguous = _mod.find_matching_transition(ts, "Review")
+        assert match["name"] == "Review"
+        assert ambiguous == []


### PR DESCRIPTION
## Summary

`jira-transition.py do` matched the target name by **case-insensitive exact equality** only. Jira transitions are frequently labelled with an emoji prefix (e.g. `✅ Resolve`, `▶ Start work`), so `do KEY "Resolve"` failed — the caller had to reproduce the exact emoji string. (Real friction: three attempts to resolve one issue.)

## Change

New `find_matching_transition()` resolves a user-supplied name in three tiers (first hit wins):

1. **Exact** case-insensitive on transition name or target status — unchanged behaviour.
2. **Emoji-tolerant**: normalized equality with leading emoji/symbol/whitespace stripped (`✅ Resolve` → `resolve`).
3. **Unique substring**: normalized-substring match, but only when exactly one transition matches.

Ambiguous substring matches return the candidate list, so the command reports them and asks for the exact name instead of silently guessing.

## Tests

- 7 unit tests in `tests/test_transition_match.py`: exact (name + target status), the `✅ Resolve`→`Resolve` regression, unique substring, ambiguous→candidates, no-match, and exact-wins-over-substring.
- `eval id 26` for emoji-tolerant transitions.
- Full suite green: **714 passed**; `ruff format`/`ruff check` clean.

## Notes

No behaviour change for callers already passing exact names; this only adds fallbacks when an exact match isn't found.
