### PR TITLE
docs(jira-syntax): warn that a bare GitLab !N ref is image markup

### DIFF
--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -69,6 +69,7 @@ ${CLAUDE_SKILL_DIR}/scripts/validate-jira-syntax.sh path/to/content.txt
 | `[text](url)` | `[text\|url]` |
 | `- bullet` | `* bullet` |
 | `h2.Title` | `h2. Title` |
+| `MR !42` (bare GitLab ref) | `[MR 42\|url]` or full `group/project!42` — a bare `!…!` is image markup |
 
 ## Integration with jira-communication Skill
 


### PR DESCRIPTION
Adds a Common Mistakes row: a bare `!42`/`MR !42` in a Jira comment triggers wiki image-embed (`!…!`); use `[MR 42|url]` or the full `group/project!42` cross-ref. From a retro after nearly mangling an MR link in a Jira comment.