### PR TITLE
chore(release): v3.18.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.18.0] - 2026-06-18
+
+### Added
+
+- `jira-attachment download-all`: bulk-download every attachment on an issue in one call, with per-file progress and resilient error handling ([#134](https://github.com/netresearch/jira-skill/pull/134)).
+- `jira-issue transition`: tolerant, Unicode-safe transition-name matching — transitions resolve case- and whitespace-insensitively (and across Unicode normalisation forms) instead of requiring an exact label match ([#136](https://github.com/netresearch/jira-skill/pull/136)).
+
+### Fixed
+
+- `jira-communication`: surface the comment count and never render requested fields silently — when a field is requested but absent it is reported rather than dropped without notice ([#127](https://github.com/netresearch/jira-skill/pull/127), [#130](https://github.com/netresearch/jira-skill/pull/130)).
+
+### Documentation
+
+- `jira-syntax`: clarified wiki-markup escaping rules and fixed table pipe (`|`) escaping in the reference ([#133](https://github.com/netresearch/jira-skill/pull/133)).
+- `jira-syntax`: warn that a bare GitLab `!N` reference renders as image markup in Jira wiki syntax ([#138](https://github.com/netresearch/jira-skill/pull/138)).
+
 ## [3.17.0] - 2026-06-11
 
 ### Added

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.17.0"
+  version: "3.18.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.17.0"
+  version: "3.18.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Release v3.18.0 — minor.

Bumps plugin.json + jira-communication/jira-syntax SKILL.md metadata 3.17.0 → 3.18.0 and adds the CHANGELOG entry. (The evals baseline-skill fixture stays pinned at 3.15.0 by design.)

### Added
- `jira-attachment download-all`: bulk attachment download (#134)
- Tolerant, Unicode-safe transition-name matching (#136)
### Fixed
- Surface comment count; never render requested fields silently (#127, #130)
### Documentation
- jira-syntax escaping rules + table pipe escaping (#133); bare GitLab `!N` renders as image markup (#138)