### PR TITLE
docs(jira-communication): transition-by-status-name + [~mention] username gotchas

### DIFF
--- a/skills/jira-communication/references/fields-and-users.md
+++ b/skills/jira-communication/references/fields-and-users.md
@@ -19,7 +19,7 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py me
 
 Useful when `--assignee`, `--reporter`, or `--user` rejects a value: search returns the canonical username (Server/DC) or accountId (Cloud) the API expects.
 
-**`[~mention]` in comments needs the canonical username, not a guess.** The mention token resolves on the account's `name`/`key` — which can differ from **both** the display name and the email local-part (renamed accounts are common: e.g. display "Jane Doe", email `jane.doe@…`, but `name=jane.smith` after a rename). Guessing from the display name or email silently produces a non-notifying mention. Resolve it first — `jira-user.py search "<display name>"`, or read the `name` field of an existing comment's author — then write `[~<name>]`. If someone says "your mention pinged the wrong/no user", this is why.
+**`[~mention]` in comments needs the canonical username, not a guess.** The mention token resolves on the account's `name`/`key` — which can differ from **both** the display name and the email local-part (renamed accounts are common: e.g. display "Jane Doe", email `jane.doe@…`, but `name=jane.smith` after a rename). Guessing from the display name or email silently produces a non-notifying mention. Resolve it first — `jira-user.py search "<display name>"`, or read the `name` field of an existing comment's author — then write `[~<name>]`. If someone says "your mention pinged the wrong/no user", this is why. (Jira **Cloud** uses `[~accountId:<accountId>]` instead of `[~username]`; resolve the `accountId` the same way and use that form.)
 
 ## Custom fields
 

--- a/skills/jira-communication/references/fields-and-users.md
+++ b/skills/jira-communication/references/fields-and-users.md
@@ -19,6 +19,8 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-user.py me
 
 Useful when `--assignee`, `--reporter`, or `--user` rejects a value: search returns the canonical username (Server/DC) or accountId (Cloud) the API expects.
 
+**`[~mention]` in comments needs the canonical username, not a guess.** The mention token resolves on the account's `name`/`key` — which can differ from **both** the display name and the email local-part (renamed accounts are common: e.g. display "Jane Doe", email `jane.doe@…`, but `name=jane.smith` after a rename). Guessing from the display name or email silently produces a non-notifying mention. Resolve it first — `jira-user.py search "<display name>"`, or read the `name` field of an existing comment's author — then write `[~<name>]`. If someone says "your mention pinged the wrong/no user", this is why.
+
 ## Custom fields
 
 ```bash

--- a/skills/jira-communication/references/troubleshooting.md
+++ b/skills/jira-communication/references/troubleshooting.md
@@ -117,6 +117,20 @@ uv run scripts/core/jira-issue.py get PROJ-123 --json
 uv run scripts/core/jira-issue.py --json get PROJ-123
 ```
 
+### "Transition 'X' not available" (passing the transition ID)
+
+**Cause**: `jira-transition.py do` expects the **target status name**, not the numeric transition ID that `jira-transition.py list` prints in its leftmost column.
+
+**Fix**: Pass the destination status, in quotes:
+```bash
+# Wrong — 311 is the transition ID from `list`
+uv run scripts/workflow/jira-transition.py do PROJ-123 311
+
+# Correct — the To-Status name
+uv run scripts/workflow/jira-transition.py do PROJ-123 "Resolved"
+```
+When two transitions share a name but differ by icon (e.g. "✅ QA" → Resolved vs "❌ QA" → Reopened), disambiguate by passing the **target status** ("Resolved" / "Reopened"), which is unique.
+
 ### "Issue does not exist"
 
 **Cause**: Wrong key or no permission.


### PR DESCRIPTION
## What

Two CLI gotchas hit in practice, added to the existing references (no new behaviour):

- **`troubleshooting.md`** — `jira-transition.py do` takes the **target status name**, not the numeric transition ID that `list` prints in its leftmost column. Includes the same-name/different-icon disambiguation (pass the unique target status, e.g. "Resolved" vs "Reopened").
- **`fields-and-users.md`** — `[~mention]` resolves on the account's canonical `name`/`key`, which can differ from **both** the display name and the email local-part (renamed accounts). Guessing produces a silently non-notifying mention; resolve via `jira-user.py` or an existing comment author's `name` first.

The two other gotchas from the same session (`--json` before the subcommand, `--assignee` username resolution) were already documented, so they are not duplicated here.

## Scope

References only; `SKILL.md` and scripts untouched. No version bump (separate release flow). Additive.
