### PR TITLE
docs(jira-syntax): document (/) and (x) status emoticons and checklist semantics

### DIFF
--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -70,6 +70,8 @@ ${CLAUDE_SKILL_DIR}/scripts/validate-jira-syntax.sh path/to/content.txt
 | `- bullet` | `* bullet` |
 | `h2.Title` | `h2. Title` |
 | `MR !42` (bare GitLab ref) | `[MR 42\|url]` or full `group/project!42` — a bare `!…!` is image markup |
+| `(/)` on an open/proposed item | `(x)` — `(/)` renders as a green check (done); use `(x)` for open items |
+| `( )` as a checkbox | `(x)` — `( )` is not a macro and renders literally |
 
 ## Integration with jira-communication Skill
 

--- a/skills/jira-syntax/references/jira-syntax-quick-reference.md
+++ b/skills/jira-syntax/references/jira-syntax-quick-reference.md
@@ -315,6 +315,24 @@ A quick sanity check before posting: run `skills/jira-syntax/scripts/validate-ji
 | `(on)` | 💡 | Light bulb on |
 | `(off)` | 🔌 | Light bulb off |
 | `(*)` | ⭐ | Star |
+| `(/)` | ✅ | Green check / done |
+| `(x)` | ❌ | Red cross / not done |
+
+### Checklists with `(/)` and `(x)`
+
+`(/)` and `(x)` are the conventional checklist markers: `(/)` for a completed
+item, `(x)` for an open one. Use them only with that meaning.
+
+- Do not put `(/)` on items that are merely proposed or not yet implemented.
+  It renders as a green check and reads as "done".
+- `( )` (empty parentheses) is **not** a macro. It renders literally as two
+  parentheses, so it conveys nothing. For an open item use `(x)`, or a plain
+  bullet when no status is intended.
+
+```
+* (/) Migration script written and tested
+* (x) Rollback procedure documented
+```
 
 ## Common Patterns
 


### PR DESCRIPTION
## What

Document the `(/)` and `(x)` status emoticons in the `jira-syntax` skill and clarify their checklist semantics.

## Why

The Emoticons table listed `(y) (n) (!) (?) (on) (off) (*)` but not `(/)` (green check) and `(x)` (red cross), the two most relevant for status/checklist use. Without that, it is easy to reach for `(/)` as a generic checkbox on open or merely proposed items, where it renders as a green check and reads as "done". Likewise `( )` (empty parentheses) is mistaken for a checkbox, but it is not a macro and renders literally.

This came up in real use: `(/)` was placed on not-yet-implemented proposal items in a ticket, which read as completed work.

## Changes

- `references/jira-syntax-quick-reference.md`: add `(/)` and `(x)` rows to the Emoticons table, plus a short "Checklists" subsection with an example and the `( )`-is-not-a-macro note.
- `SKILL.md`: two rows in the Common Mistakes table (`(/)` on open items, `( )` as a checkbox).

Docs only. `markdownlint-cli2` passes with 0 errors. Commit is DCO signed-off.
