### PR TITLE
docs: jira-attachment download auth + size-check gotchas

### DIFF
--- a/skills/jira-communication/references/attachments.md
+++ b/skills/jira-communication/references/attachments.md
@@ -36,15 +36,17 @@ The output location is the **second positional argument** (`OUTPUT_FILE`), not a
 
 ### Verify the download succeeded
 
-`jira-attachment.py download` carries Jira authentication (PAT via `Authorization: Bearer`, or Cloud basic auth) and refuses to save a redirect/login body as the file. But if an attachment is ever fetched **without** auth (e.g. a hand-rolled `curl`/`wget`, or a CDN redirect followed without credentials), the request lands on the login page or an empty response and you get a **0-byte file that looks like success**. Always check the size after downloading:
+`jira-attachment.py download` carries Jira authentication (PAT via `Authorization: Bearer`, or Cloud basic auth) and refuses to save a redirect/login body as the file, exiting non-zero on failure. When scripting, always check the command's exit status to detect failures:
 
 ```bash
 out=./attachments/report.pdf
-uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py download "$url" "$out"
-[ -s "$out" ] || { echo "ERROR: empty download — check authentication" >&2; exit 1; }
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py download "$url" "$out" || {
+    echo "ERROR: download failed" >&2
+    exit 1
+}
 ```
 
-`[ -s FILE ]` is true only when the file exists and is non-empty. A 0-byte result almost always means the request was unauthenticated.
+An unauthenticated or redirected fetch (e.g. a hand-rolled `curl`/`wget` that lands on the login page) yields a bad or empty file — but rely on the command's exit status, not a size test, to detect it: a size check masks the script's real error and falsely fails on legitimate 0-byte attachments.
 
 ## Download all attachments
 

--- a/skills/jira-communication/references/attachments.md
+++ b/skills/jira-communication/references/attachments.md
@@ -32,6 +32,20 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py download \
     ./attachments/report.pdf
 ```
 
+The output location is the **second positional argument** (`OUTPUT_FILE`), not an option. There is **no `--output-dir` flag** on `download` — passing one fails with `Error: No such option: --output-dir` (exit 2). To choose a directory, either include it in the `OUTPUT_FILE` path (as above) or use `download-all --dir <dir>` (the `--dir` flag exists only on the `download-all` subcommand, not on `download`).
+
+### Verify the download succeeded
+
+`jira-attachment.py download` carries Jira authentication (PAT via `Authorization: Bearer`, or Cloud basic auth) and refuses to save a redirect/login body as the file. But if an attachment is ever fetched **without** auth (e.g. a hand-rolled `curl`/`wget`, or a CDN redirect followed without credentials), the request lands on the login page or an empty response and you get a **0-byte file that looks like success**. Always check the size after downloading:
+
+```bash
+out=./attachments/report.pdf
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py download "$url" "$out"
+[ -s "$out" ] || { echo "ERROR: empty download — check authentication" >&2; exit 1; }
+```
+
+`[ -s FILE ]` is true only when the file exists and is non-empty. A 0-byte result almost always means the request was unauthenticated.
+
 ## Download all attachments
 
 To grab every attachment on an issue in one call (no need to harvest URLs first), use `download-all`. Files are saved under `--dir` (default cwd) using their original Jira filenames; duplicate names are disambiguated with the attachment id, and a filename that would escape `--dir` is skipped.


### PR DESCRIPTION
From a cross-session retrospective (2026-06-27): two recurring friction points when downloading Jira attachments are now documented in `references/attachments.md`.

## Observed friction
- The `download` subcommand was called with a non-existent `--output-dir` flag (Click rejects it: `Error: No such option '--output-dir'.`, exit 2).
- An attachment saved as a 0-byte file because the HTTP request reached the login page / followed a redirect without credentials — a 0-byte file looks like success but isn't.

## What the docs now say (verified against the real script)
The script is Click-based (`scripts/core/jira-attachment.py`), verified by running `--help` and the bad-flag case:
- `download ATTACHMENT_URL OUTPUT_FILE` — output location is the **second positional argument**; the subcommand has **only** `--help`. **`--output-dir` does not exist** (confirmed: exit 2, `No such option '--output-dir'`).
- The only directory flag is `--dir`, and it lives on the separate `download-all` subcommand — not on `download`.
- Attachment downloads must carry Jira auth (PAT Bearer / Cloud basic auth); an unauthenticated request or credential-less redirect yields a 0-byte file.
- Always verify file size > 0 after download (`[ -s FILE ]`) — ties to the team's "verify file ops / empty file" discipline.

## Notes
- References-only change. **No version bump**: version is managed in `.claude-plugin/plugin.json` / `SKILL.md` metadata and this edit touches neither, so the CI version-consistency check is unaffected.
- Local validation: `markdownlint-cli2` on the changed file → 0 errors. Script claims re-verified by running `jira-attachment.py download --help` and the `--output-dir` failure (exit 2).