### PR TITLE
fix(hooks): don't flag CWE/CVE/encoding IDs and PROJ-123 placeholder as Jira keys

### DIFF
--- a/scripts/detect_jira_issues.py
+++ b/scripts/detect_jira_issues.py
@@ -17,12 +17,15 @@ from urllib.parse import urlparse
 ISSUE_KEY_PATTERN = r"\b([A-Z][A-Z0-9_]+-\d+)\b"
 
 # PREFIX-123 shapes that look like issue keys but never are: security
-# identifiers (CVE-2024, CWE-918, GHSA-…), encodings and standards
-# (UTF-8, SHA-256, ISO-8601, RFC-2119, MD5-…).
-NON_JIRA_KEY_PREFIXES = frozenset({"CVE", "CWE", "GHSA", "ISO", "RFC", "UTF", "SHA", "MD5"})
+# identifiers (CVE-2024, CWE-918, GHSA-…), encodings/standards/crypto
+# (UTF-8, SHA-256, ISO-8601, RFC-2119, MD5-…, AES-256, TLS-12), and the
+# universal doc placeholders PROJ-/EXAMPLE- (any number, e.g. PROJ-456).
+NON_JIRA_KEY_PREFIXES = frozenset(
+    {"CVE", "CWE", "GHSA", "ISO", "RFC", "UTF", "SHA", "MD5", "AES", "TLS", "PROJ", "EXAMPLE"}
+)
 
 # Literal placeholder keys used in docs and examples (not real tickets).
-PLACEHOLDER_KEYS = frozenset({"PROJ-123", "EXAMPLE-123", "ABC-123"})
+PLACEHOLDER_KEYS = frozenset({"ABC-123"})
 
 # Jira URL patterns
 JIRA_URL_PATTERNS = [

--- a/scripts/detect_jira_issues.py
+++ b/scripts/detect_jira_issues.py
@@ -16,6 +16,14 @@ from urllib.parse import urlparse
 # Common project prefixes for Netresearch
 ISSUE_KEY_PATTERN = r"\b([A-Z][A-Z0-9_]+-\d+)\b"
 
+# PREFIX-123 shapes that look like issue keys but never are: security
+# identifiers (CVE-2024, CWE-918, GHSA-…), encodings and standards
+# (UTF-8, SHA-256, ISO-8601, RFC-2119, MD5-…).
+NON_JIRA_KEY_PREFIXES = frozenset({"CVE", "CWE", "GHSA", "ISO", "RFC", "UTF", "SHA", "MD5"})
+
+# Literal placeholder keys used in docs and examples (not real tickets).
+PLACEHOLDER_KEYS = frozenset({"PROJ-123", "EXAMPLE-123", "ABC-123"})
+
 # Jira URL patterns
 JIRA_URL_PATTERNS = [
     r"https?://jira\.[^/]+/browse/([A-Z][A-Z0-9_]+-\d+)",
@@ -40,18 +48,37 @@ def _normalize_netloc(url: str) -> str:
     return host
 
 
+def _is_jira_key(key: str) -> bool:
+    """Return False for PREFIX-123 shapes that are never real Jira issue keys.
+
+    Filters out literal doc placeholders (PROJ-123) and non-Jira identifier
+    classes such as security IDs (CVE-2024-1234, CWE-918) and encodings or
+    standards (UTF-8, SHA-256, ISO-8601, RFC-2119). Real project keys such as
+    NRS-4477 are kept.
+    """
+    if key in PLACEHOLDER_KEYS:
+        return False
+    prefix = key.rsplit("-", 1)[0]
+    return prefix not in NON_JIRA_KEY_PREFIXES
+
+
 def extract_issue_keys(text: str) -> list[str]:
     """Extract unique Jira issue keys from text."""
     keys = set()
 
     # Direct issue keys
     for match in re.finditer(ISSUE_KEY_PATTERN, text):
-        keys.add(match.group(1))
+        key = match.group(1)
+        if _is_jira_key(key):
+            keys.add(key)
 
-    # Issue keys from URLs
+    # Issue keys from URLs (inherently Jira, but stay consistent and drop
+    # placeholder/non-Jira shapes like .../browse/PROJ-123 too).
     for pattern in JIRA_URL_PATTERNS:
         for match in re.finditer(pattern, text):
-            keys.add(match.group(1))
+            key = match.group(1)
+            if _is_jira_key(key):
+                keys.add(key)
 
     return sorted(keys)
 

--- a/tests/test_detect_jira_issues.py
+++ b/tests/test_detect_jira_issues.py
@@ -67,7 +67,12 @@ class TestExtractIssueKeysDenylist:
         "ISO-8601",
         "RFC-2119",
         "MD5-7",
+        "AES-256",
+        "TLS-12",
+        "PROJ-456",  # PROJ-/EXAMPLE- placeholders blocked by prefix, any number
+        "EXAMPLE-99",
         "PROJ-123",  # literal doc placeholder
+        "ABC-123",  # literal doc placeholder
     ]
 
     REAL_KEYS = [

--- a/tests/test_detect_jira_issues.py
+++ b/tests/test_detect_jira_issues.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 # Add scripts directory to path
 _test_dir = Path(__file__).parent
 _scripts_dir = _test_dir.parent / "scripts"
@@ -29,8 +31,9 @@ class TestExtractIssueKeys:
         assert extract_issue_keys("WEB-1381 and NRS-4167") == ["NRS-4167", "WEB-1381"]
 
     def test_key_from_url(self):
-        keys = extract_issue_keys("https://jira.example.com/browse/PROJ-123")
-        assert "PROJ-123" in keys
+        # Uses a non-placeholder key: PROJ-123 is a denylisted doc placeholder.
+        keys = extract_issue_keys("https://jira.example.com/browse/WEB-1381")
+        assert "WEB-1381" in keys
 
     def test_key_from_atlassian_url(self):
         keys = extract_issue_keys("https://company.atlassian.net/browse/CLOUD-42")
@@ -46,6 +49,49 @@ class TestExtractIssueKeys:
     def test_underscore_in_prefix(self):
         keys = extract_issue_keys("FIX_ME-123 is an issue")
         assert "FIX_ME-123" in keys
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: extract_issue_keys() denylist — non-Jira PREFIX-123 false positives
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestExtractIssueKeysDenylist:
+    """PREFIX-123 shapes that are not Jira keys must not trigger detection."""
+
+    NON_JIRA_TOKENS = [
+        "CWE-918",
+        "CVE-2024-1234",
+        "UTF-8",
+        "SHA-256",
+        "ISO-8601",
+        "RFC-2119",
+        "MD5-7",
+        "PROJ-123",  # literal doc placeholder
+    ]
+
+    REAL_KEYS = [
+        "NRS-4477",
+        "JIRA-42",
+        "WEB-1381",
+        "FIX_ME-123",
+    ]
+
+    @pytest.mark.parametrize("token", NON_JIRA_TOKENS)
+    def test_non_jira_token_not_detected(self, token):
+        assert extract_issue_keys(f"see {token} for details") == []
+
+    @pytest.mark.parametrize("key", REAL_KEYS)
+    def test_real_key_still_detected(self, key):
+        assert key in extract_issue_keys(f"work on {key} today")
+
+    def test_security_ids_filtered_real_key_kept_in_same_text(self):
+        text = "CWE-918 and CVE-2024-1234 relate to NRS-4477 and UTF-8 / SHA-256 encoding"
+        assert extract_issue_keys(text) == ["NRS-4477"]
+
+    def test_placeholder_filtered_from_url_too(self):
+        """The PROJ-123 placeholder is filtered even inside a Jira /browse/ URL."""
+        assert extract_issue_keys("https://jira.example.com/browse/PROJ-123") == []
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
The `UserPromptSubmit` hook (`scripts/detect_jira_issues.py`) used `ISSUE_KEY_PATTERN = \b([A-Z][A-Z0-9_]+-\d+)\b`, which matches any `PREFIX-123` shape and false-fired the "Detected Jira issue reference(s)" system-reminder on non-tickets: security IDs (`CWE-918`, `CVE-2024-1234`), encodings/standards (`UTF-8`, `SHA-256`, `ISO-8601`, `RFC-2119`), and the doc placeholder `PROJ-123`.

Fix: add a denylist (`NON_JIRA_KEY_PREFIXES` for security/encoding/standard prefixes, `PLACEHOLDER_KEYS` for literal doc placeholders) and a `_is_jira_key()` filter applied to both the bare-text and URL matchers in `extract_issue_keys`. Real project keys (e.g. `NRS-4477`, `JIRA-42`) still match.

Tests: new parametrized `TestExtractIssueKeysDenylist` covering the false-positive set and real keys; updated `test_key_from_url` to use a non-placeholder key. Full suite 730 passed; ruff clean. No version bump (internal hook bugfix; version-parity unaffected).

From a session retrospective, 2026-06-27.