### PR TITLE
feat(worklog): add --tempo-account to query a customer account's worked time

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -73,7 +73,7 @@ In tickets, comments and worklog notes, state what happened, not how good the wo
 - `references/issue-editing.md` — edit, delete
 - `references/creation.md` — create, `--parent`, fields
 - `references/comments.md` — edit, delete, lint
-- `references/worklog.md` — `--started`, ranges
+- `references/worklog.md` — `--started`, ranges, `--tempo-account`
 - `references/attachments.md` — upload, download
 - `references/links.md` — links
 - `references/agile.md` — sprints/boards
@@ -81,7 +81,7 @@ In tickets, comments and worklog notes, state what happened, not how good the wo
 - `references/fields-and-users.md` — custom field IDs, users, issue types
 - `references/watchers.md` — watch, subscribe, list watchers
 - `references/versions.md` — fix/affects versions, releases, version CRUD
-- `references/qa-gather.md` — comprehensive audit bundle (siblings, prose URLs)
+- `references/qa-gather.md` — audit bundle (siblings, prose URLs)
 - `references/intent-verbs.md` — `work / qa / qa-fail / act`, exact transition names
 
 ## Authentication

--- a/skills/jira-communication/references/worklog.md
+++ b/skills/jira-communication/references/worklog.md
@@ -37,6 +37,30 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-worklog-query.py --sprint 916
 
 `--detail` shows individual worklog entries grouped by issue. Default output groups by issue with per-issue and grand totals. `--json` emits the raw worklog list — pipe to `jq` for custom reports.
 
+## By Tempo account (customer worked-time)
+
+To get the worked time booked to a **Tempo account** (a customer) for a month — across *all* workers, not just yourself — use `--tempo-account`:
+
+```bash
+# Total worked time for a customer account in a month (all workers)
+uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-worklog-query.py \
+    --tempo-account ACME --from 2026-06-01 --to 2026-06-30 --detail
+```
+
+`--tempo-account` forces the Tempo backend and ignores `--user`/`--issue`/`--epic`/`--sprint`/`--project` (the account *is* the filter). Accepts a comma-separated list of account keys.
+
+> **Requires Tempo Timesheets on Jira Server/DC** — the whole Tempo backend (`--tempo-account`, `--backend tempo`, and `--backend auto`'s detection) talks to `/rest/tempo-timesheets/4`. Tempo **Cloud** exposes a different API (`api.tempo.io`) and is **not** supported: `--tempo-account`/`--backend tempo` fail with a clear message, and `--backend auto` falls back to the JQL backend.
+
+Why this exists: the plain worklog query (JQL or the Tempo `/worklogs` endpoint) can only filter by **worker**, issue, project or date — **not by Tempo account**. Time a customer books via a standby/support package is often logged by someone else on an issue you wouldn't guess, so a per-issue or per-user query silently returns nothing. Under the hood `--tempo-account` calls `POST /rest/tempo-timesheets/4/worklogs/search` with an `accountKey` array — the only endpoint that resolves a whole account. When a wrapper flag is missing, reach for the underlying REST before concluding the data is unreachable:
+
+```bash
+set -a; source ~/.env.jira; set +a
+curl -sS -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" -H "Content-Type: application/json" \
+  -X POST "${JIRA_URL%/}/rest/tempo-timesheets/4/worklogs/search" \
+  -d '{"from":"2026-06-01","to":"2026-06-30","accountKey":["ACME"]}'
+# account lookup (key/name/lead): GET /rest/tempo-accounts/1/account/<id>
+```
+
 ## Relative dates
 
 `--from` and `--to` accept plain `YYYY-MM-DD`. For rolling queries, compute the dates in the shell:

--- a/skills/jira-communication/scripts/utility/jira-worklog-query.py
+++ b/skills/jira-communication/scripts/utility/jira-worklog-query.py
@@ -29,6 +29,12 @@ from lib.output import comment_to_text, error, format_json, warning
 # Backwards-compatible alias (older code paths/tests refer to the private name)
 _jql_escape = jql_escape
 
+# Hard cap on Tempo worklog pagination. A malformed/mocked response whose
+# metadata never signals "last page" would otherwise loop forever, accumulating
+# entries until the process exhausts memory. 1000 pages × 1000/page = 1M
+# worklogs is far beyond any real query.
+MAX_PAGES = 1000
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Query building
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -201,6 +207,24 @@ def search_issues(client, jql: str) -> list[dict]:
     return issues
 
 
+def _build_issue_map(client, worklogs: list[dict]) -> dict[str, str]:
+    """Map issue keys → summaries via one batched JQL search (avoids N+1 fetches).
+
+    Falls back to empty summaries if the batch lookup fails.
+    """
+    issue_keys = {key for wl in worklogs if (key := wl.get("_issue_key", "Unknown")) != "Unknown"}
+    if not issue_keys:
+        return {}
+    quoted = ", ".join(f'"{_jql_escape(k)}"' for k in sorted(issue_keys))
+    jql = f"issueKey in ({quoted})"
+    try:
+        found = search_issues(client, jql)
+        return {i["key"]: i["summary"] for i in found}
+    except Exception:
+        # Fallback: empty summaries if batch fetch fails
+        return {k: "" for k in issue_keys}
+
+
 def fetch_worklogs(client, issue_key: str) -> list[dict]:
     """Fetch all worklogs for a single issue. Returns raw worklog dicts."""
     result = client.issue_get_worklog(issue_key)
@@ -233,19 +257,23 @@ def fetch_all_worklogs(client, issues: list[dict]) -> list[dict]:
 
 
 def detect_tempo(client) -> bool:
-    """Check if Tempo Timesheets plugin is available.
+    """Check if the Tempo Timesheets (Server/DC) plugin is installed.
 
-    Tries a minimal request to the Tempo REST API. Returns True if Tempo
-    responds (200), False if the endpoint doesn't exist (404) or auth fails.
+    Probes the Tempo REST namespace. Note: the v4 ``/worklogs`` resource only
+    accepts POST (``/worklogs/search``); a GET returns **405**, so we must NOT
+    require a 200 here — that misdetects real Tempo Server instances as "no
+    Tempo" and silently falls back to the JQL backend (which cannot see
+    Tempo-only worklogs). A 404 means the plugin is absent (e.g. Tempo Cloud,
+    which uses the separate api.tempo.io API); a 401/403 means we can't use the
+    endpoint anyway, and a 5xx means Jira/Tempo is unhealthy — all treated as "not
+    available" so we don't select the Tempo backend only to fail on the real query.
+    Anything else (200, 400, 405, …) means the plugin is present and reachable.
     """
     try:
         base_url = client.url.rstrip("/")
         url = f"{base_url}/rest/tempo-timesheets/4/worklogs"
-        today = date.today().isoformat()
-        params = {"dateFrom": today, "dateTo": today, "limit": 1}
-
-        response = client._session.get(url, params=params, timeout=5)
-        return response.status_code == 200
+        response = client._session.get(url, timeout=5)
+        return response.status_code < 500 and response.status_code not in (401, 403, 404)
     except Exception:
         return False
 
@@ -276,38 +304,27 @@ def fetch_worklogs_tempo(
         params["projectKey"] = project
 
     all_worklogs = []
-    while True:
+    for _ in range(MAX_PAGES):
         response = client._session.get(url, params=params, timeout=30)
         response.raise_for_status()
         data = response.json()
 
         # Handle both array response and paginated object response
         if isinstance(data, list):
-            entries = data
-            all_worklogs.extend(normalize_tempo_worklog(wl) for wl in entries)
+            all_worklogs.extend(normalize_tempo_worklog(wl) for wl in data)
             break  # Array response = no pagination
-        else:
-            entries = data.get("results", data.get("worklogs", []))
-            all_worklogs.extend(normalize_tempo_worklog(wl) for wl in entries)
-            metadata = data.get("metadata", {})
-            if not metadata.get("next"):
-                break
-            params["offset"] = metadata.get("offset", 0) + metadata.get("limit", 1000)
+        entries = data.get("results") or data.get("worklogs") or []
+        all_worklogs.extend(normalize_tempo_worklog(wl) for wl in entries)
+        metadata = data.get("metadata", {})
+        if not metadata.get("next"):
+            break
+        params["offset"] = metadata.get("offset", 0) + metadata.get("limit", 1000)
+    else:
+        raise RuntimeError(
+            f"Tempo worklog pagination exceeded {MAX_PAGES} pages — aborting to avoid unbounded memory use."
+        )
 
-    # Build issue_map via batch JQL instead of N+1 individual fetches
-    issue_keys = {wl["_issue_key"] for wl in all_worklogs if wl["_issue_key"] != "Unknown"}
-    issue_map: dict[str, str] = {}
-    if issue_keys:
-        quoted = ", ".join(f'"{_jql_escape(k)}"' for k in sorted(issue_keys))
-        jql = f"issueKey in ({quoted})"
-        try:
-            found = search_issues(client, jql)
-            issue_map = {i["key"]: i["summary"] for i in found}
-        except Exception:
-            # Fallback: empty summaries if batch fetch fails
-            issue_map = {k: "" for k in issue_keys}
-
-    return all_worklogs, issue_map
+    return all_worklogs, _build_issue_map(client, all_worklogs)
 
 
 def normalize_tempo_worklog(tempo_wl: dict) -> dict:
@@ -321,15 +338,92 @@ def normalize_tempo_worklog(tempo_wl: dict) -> dict:
     if len(started) == 10:
         started = f"{started}T00:00:00.000+0000"
 
+    # The /worklogs endpoint returns a user object in "author"; /worklogs/search returns "worker".
+    # Normalize both so filter/format see a consistent shape.
+    # Guarantee author is always a dict so filter_worklogs/format_detail can
+    # safely call .get() on it.
+    author = tempo_wl.get("author")
+    if isinstance(author, str) and author:
+        # Some payloads put the username directly in "author".
+        author = {"name": author, "displayName": author}
+    elif not isinstance(author, dict) or not author:
+        # No usable author object → derive from worker/updater (search endpoint).
+        author = {}
+        worker = tempo_wl.get("worker") or tempo_wl.get("updater")
+        if isinstance(worker, dict):
+            author = {
+                "name": worker.get("name") or worker.get("accountId", ""),
+                "accountId": worker.get("accountId", ""),
+                "displayName": worker.get("displayName") or worker.get("name") or worker.get("accountId", ""),
+            }
+        elif isinstance(worker, str) and worker:
+            author = {"name": worker, "displayName": worker}
+    elif not author.get("displayName"):
+        # author dict present but missing displayName → fall back to name so
+        # format_detail doesn't render "Unknown" for a known user.
+        author["displayName"] = author.get("name") or "Unknown"
+
     return {
         "id": str(tempo_wl.get("tempoWorklogId", "")),
         "started": started,
         "timeSpentSeconds": tempo_wl.get("timeSpentSeconds", 0),
         "timeSpent": "",
         "comment": tempo_wl.get("comment", ""),
-        "author": tempo_wl.get("author", {}),
+        "author": author,
         "_issue_key": tempo_wl.get("issue", {}).get("key", "Unknown"),
     }
+
+
+def fetch_worklogs_tempo_account(
+    client,
+    from_date: str,
+    to_date: str,
+    account_keys: list[str],
+) -> tuple[list[dict], dict[str, str]]:
+    """Fetch worklogs for one or more Tempo *accounts* via the search endpoint.
+
+    The plain ``/worklogs`` endpoint filters by worker/project/date but NOT by
+    Tempo account, so the worked time booked to a customer account (across all
+    workers) is only reachable through ``POST /worklogs/search`` with
+    ``accountKey``. Returns ``(worklogs, issue_map)`` in the same shape as
+    :func:`fetch_worklogs_tempo`.
+    """
+    base_url = client.url.rstrip("/")
+    url = f"{base_url}/rest/tempo-timesheets/4/worklogs/search"
+    payload: dict = {
+        "from": from_date,
+        "to": to_date,
+        "accountKey": account_keys,
+        "limit": 1000,
+        "offset": 0,
+    }
+
+    all_worklogs: list[dict] = []
+    for _ in range(MAX_PAGES):
+        response = client._session.post(url, json=payload, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+
+        if isinstance(data, list):
+            all_worklogs.extend(normalize_tempo_worklog(wl) for wl in data)
+            break
+
+        entries = data.get("results") or data.get("worklogs") or []
+        all_worklogs.extend(normalize_tempo_worklog(wl) for wl in entries)
+
+        metadata = data.get("metadata", {})
+        next_offset = metadata.get("nextOffset")
+        if next_offset is not None:
+            payload["offset"] = next_offset
+        elif metadata.get("next") or metadata.get("hasMore"):
+            payload["offset"] = metadata.get("offset", 0) + metadata.get("limit", payload["limit"])
+        else:
+            break
+    else:
+        raise RuntimeError(
+            f"Tempo account worklog pagination exceeded {MAX_PAGES} pages — aborting to avoid unbounded memory use."
+        )
+    return all_worklogs, _build_issue_map(client, all_worklogs)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -341,6 +435,14 @@ def normalize_tempo_worklog(tempo_wl: dict) -> dict:
 @click.option("--from", "from_date", help="Start date YYYY-MM-DD (default: Monday of current week)")
 @click.option("--to", "to_date", help="End date YYYY-MM-DD (default: today)")
 @click.option("--user", help="Username or accountId (default: current user)")
+@click.option(
+    "--tempo-account",
+    help=(
+        "Tempo account key(s), comma-separated (e.g. ACME) — worked time "
+        "for a customer ACCOUNT across ALL workers. Forces the Tempo backend; "
+        "ignores --user/--issue/--epic/--sprint/--project."
+    ),
+)
 @click.option("--project", help="Project key (e.g., HMKG)")
 @click.option("--issue", help="Issue key(s), comma-separated")
 @click.option("--epic", help="Epic key (e.g., HMKG-1940)")
@@ -361,6 +463,7 @@ def cli(
     from_date,
     to_date,
     user,
+    tempo_account,
     project,
     issue,
     epic,
@@ -402,22 +505,55 @@ def cli(
         if context_key:
             client.with_context(issue_key=context_key)
 
-        # Resolve user default
+        # Tempo account mode spans all workers → no per-user resolution/filter
+        account_keys = [k.strip() for k in tempo_account.split(",") if k.strip()] if tempo_account is not None else None
+        if tempo_account is not None and not account_keys:
+            raise click.BadParameter(
+                "must contain at least one non-empty account key",
+                param_hint="--tempo-account",
+            )
+
+        # Resolve user default (not used in account mode)
         effective_user = user
-        if not effective_user:
+        if not account_keys and not effective_user:
             me = client.myself()
             effective_user = me.get("name") or me.get("accountId", "")
 
-        # Determine backend
+        # Subject shown in output headers
+        subject = f"account {', '.join(account_keys)}" if account_keys else effective_user
+
+        # Determine backend (account mode is Tempo-only)
         use_tempo = False
-        if backend == "tempo":
+        if account_keys or backend == "tempo":
             use_tempo = True
         elif backend == "auto":
             use_tempo = detect_tempo(client)
             if use_tempo and debug:
                 click.echo("Tempo detected — using Tempo API", err=True)
 
-        if use_tempo:
+        # Forced Tempo paths (--tempo-account, --backend tempo) still need the
+        # Tempo Server/DC REST API to actually be present. --backend auto already
+        # reflects detection above, so only re-check when Tempo was forced.
+        if use_tempo and (account_keys or backend == "tempo") and not detect_tempo(client):
+            error(
+                "Tempo Timesheets REST API (/rest/tempo-timesheets/4) is not available or not "
+                "reachable on this Jira (plugin absent, auth failure, or a server error). "
+                "'--tempo-account' and '--backend tempo' require Tempo on Jira Server/DC; "
+                "Tempo Cloud (api.tempo.io) is a different API and is not supported."
+            )
+            sys.exit(1)
+
+        if use_tempo and account_keys:
+            # Tempo account path: worked time for a customer account, all workers
+            if user or issue_list or epic or sprint or project:
+                warning("--tempo-account ignores --user/--issue/--epic/--sprint/--project filters.")
+            if debug:
+                click.echo(f"Tempo account query: {from_date} to {to_date}, accounts={account_keys}", err=True)
+
+            all_worklogs, issue_map = fetch_worklogs_tempo_account(client, from_date, to_date, account_keys)
+            # Account query is already scoped by account; filter by date only.
+            filtered = filter_worklogs(all_worklogs, user=None, from_date=from_date, to_date=to_date)
+        elif use_tempo:
             # Tempo path: native filtering, no JQL needed
             # Note: Tempo doesn't support issue/epic/sprint filters natively,
             # so we warn if those are specified
@@ -472,13 +608,13 @@ def cli(
             click.echo(seconds_to_human(total_seconds))
         elif detail:
             backend_label = " (via Tempo)" if use_tempo else ""
-            header = f"Worklogs for {effective_user} | {from_date} -> {to_date}{backend_label}"
+            header = f"Worklogs for {subject} | {from_date} -> {to_date}{backend_label}"
             click.echo(header)
             click.echo()
             click.echo(format_detail(filtered))
         else:
             backend_label = " (via Tempo)" if use_tempo else ""
-            header = f"Worklogs for {effective_user} | {from_date} -> {to_date}{backend_label}"
+            header = f"Worklogs for {subject} | {from_date} -> {to_date}{backend_label}"
             click.echo(header)
             click.echo()
             click.echo(format_summary(filtered, issue_map))

--- a/tests/test_worklog_query.py
+++ b/tests/test_worklog_query.py
@@ -4,6 +4,7 @@ import json
 from unittest import mock
 
 import click.testing
+import pytest
 from conftest import load_script
 
 _mod = load_script("jira-worklog-query", "utility")
@@ -270,6 +271,25 @@ class TestDetectTempo:
         mock_client._session.get.side_effect = Exception("Connection refused")
         assert _mod.detect_tempo(mock_client) is False
 
+    def test_tempo_server_error_not_available(self):
+        # A 5xx means Jira/Tempo is unhealthy — do not select the Tempo backend
+        # only to fail on the real query.
+        mock_client = mock.MagicMock()
+        mock_client.url = "https://jira.example.com"
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 503
+        mock_client._session.get.return_value = mock_response
+        assert _mod.detect_tempo(mock_client) is False
+
+    def test_tempo_method_not_allowed_is_available(self):
+        # v4 /worklogs only accepts POST; a GET returns 405 → plugin present.
+        mock_client = mock.MagicMock()
+        mock_client.url = "https://jira.example.com"
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 405
+        mock_client._session.get.return_value = mock_response
+        assert _mod.detect_tempo(mock_client) is True
+
 
 class TestNormalizeTempoWorklog:
     """Test Tempo-to-Jira worklog normalization."""
@@ -316,6 +336,27 @@ class TestNormalizeTempoWorklog:
         assert result["_issue_key"] == "Unknown"
         assert result["timeSpentSeconds"] == 0
         assert result["comment"] == ""
+
+    def test_string_author_coerced_to_dict(self):
+        # A truthy non-dict author must not leak downstream where .get() is called.
+        result = _mod.normalize_tempo_worklog({"issue": {"key": "X-1"}, "author": "psiedler"})
+        assert result["author"] == {"name": "psiedler", "displayName": "psiedler"}
+
+    def test_worker_object_mapped_to_author(self):
+        # /worklogs/search returns "worker"; map it to an author dict.
+        result = _mod.normalize_tempo_worklog(
+            {"issue": {"key": "X-1"}, "worker": {"name": "psiedler", "displayName": "Paul Siedler"}}
+        )
+        assert result["author"]["name"] == "psiedler"
+        assert result["author"]["displayName"] == "Paul Siedler"
+
+    def test_worker_string_mapped_to_author(self):
+        result = _mod.normalize_tempo_worklog({"issue": {"key": "X-1"}, "worker": "psiedler"})
+        assert result["author"] == {"name": "psiedler", "displayName": "psiedler"}
+
+    def test_author_missing_displayname_falls_back_to_name(self):
+        result = _mod.normalize_tempo_worklog({"issue": {"key": "X-1"}, "author": {"name": "psiedler"}})
+        assert result["author"]["displayName"] == "psiedler"
 
 
 SAMPLE_TEMPO_RESPONSE = [
@@ -410,6 +451,22 @@ class TestFetchWorklogsTempo:
         assert len(worklogs) == 2
         assert mock_client._session.get.call_count == 2
 
+    def test_pagination_is_bounded(self):
+        # A response whose metadata always reports another page must not loop
+        # forever — the MAX_PAGES cap raises instead of exhausting memory.
+        mock_client = mock.MagicMock()
+        mock_client.url = "https://jira.example.com"
+        never_ending = mock.MagicMock()
+        never_ending.json.return_value = {
+            "results": SAMPLE_TEMPO_RESPONSE[:1],
+            "metadata": {"offset": 0, "limit": 1, "next": "/more"},
+        }
+        mock_client._session.get.return_value = never_ending
+
+        with mock.patch.object(_mod, "MAX_PAGES", 5), pytest.raises(RuntimeError, match="pagination exceeded"):
+            _mod.fetch_worklogs_tempo(mock_client, "2026-04-01", "2026-04-02")
+        assert mock_client._session.get.call_count == 5
+
     def test_empty_result(self):
         mock_client = mock.MagicMock()
         mock_client.url = "https://jira.example.com"
@@ -448,6 +505,61 @@ class TestFetchWorklogsTempo:
         output = _mod.format_detail(worklogs)
         assert "HMKG-100" in output
         assert "Paul Siedler" in output
+
+
+class TestFetchWorklogsTempoAccount:
+    """Test the Tempo account (customer) worklog search path."""
+
+    def test_fetches_and_normalizes(self):
+        mock_client = mock.MagicMock()
+        mock_client.url = "https://jira.example.com"
+        post_response = mock.MagicMock()
+        post_response.json.return_value = SAMPLE_TEMPO_RESPONSE
+        mock_client._session.post.return_value = post_response
+        mock_client.jql.return_value = {
+            "issues": [
+                {"key": "HMKG-100", "fields": {"summary": "Fix login"}},
+                {"key": "HMKG-200", "fields": {"summary": "Review"}},
+            ],
+            "total": 2,
+            "startAt": 0,
+            "maxResults": 50,
+        }
+
+        worklogs, issue_map = _mod.fetch_worklogs_tempo_account(mock_client, "2026-04-01", "2026-04-30", ["ACME"])
+        assert len(worklogs) == 2
+        assert issue_map["HMKG-100"] == "Fix login"
+        # POST body carries the accountKey array and date range
+        payload = mock_client._session.post.call_args.kwargs["json"]
+        assert payload["accountKey"] == ["ACME"]
+        assert payload["from"] == "2026-04-01"
+        assert payload["to"] == "2026-04-30"
+
+    def test_empty_result(self):
+        mock_client = mock.MagicMock()
+        mock_client.url = "https://jira.example.com"
+        post_response = mock.MagicMock()
+        post_response.json.return_value = []
+        mock_client._session.post.return_value = post_response
+
+        worklogs, issue_map = _mod.fetch_worklogs_tempo_account(mock_client, "2026-04-01", "2026-04-30", ["ACME"])
+        assert worklogs == []
+        assert issue_map == {}
+
+    def test_pagination_is_bounded(self):
+        # metadata that always reports another page must raise, not OOM.
+        mock_client = mock.MagicMock()
+        mock_client.url = "https://jira.example.com"
+        never_ending = mock.MagicMock()
+        never_ending.json.return_value = {
+            "results": SAMPLE_TEMPO_RESPONSE[:1],
+            "metadata": {"offset": 0, "limit": 1, "hasMore": True},
+        }
+        mock_client._session.post.return_value = never_ending
+
+        with mock.patch.object(_mod, "MAX_PAGES", 5), pytest.raises(RuntimeError, match="pagination exceeded"):
+            _mod.fetch_worklogs_tempo_account(mock_client, "2026-04-01", "2026-04-30", ["ACME"])
+        assert mock_client._session.post.call_count == 5
 
 
 class TestSearchIssues:
@@ -553,6 +665,10 @@ class TestCli:
             "total": 1,
             "maxResults": 1048576,
         }
+        # No Tempo plugin installed → default (auto) backend resolves to JQL.
+        no_tempo = mock.MagicMock()
+        no_tempo.status_code = 404
+        mock_client._session.get.return_value = no_tempo
 
         with mock.patch.object(_mod, "LazyJiraClient", return_value=mock_client):
             runner = click.testing.CliRunner()
@@ -564,6 +680,10 @@ class TestCli:
         mock_client = mock.MagicMock()
         mock_client.myself.return_value = {"name": "psiedler"}
         mock_client.jql.return_value = {"issues": [], "total": 0, "startAt": 0, "maxResults": 50}
+        # No Tempo plugin installed → default (auto) backend resolves to JQL.
+        no_tempo = mock.MagicMock()
+        no_tempo.status_code = 404
+        mock_client._session.get.return_value = no_tempo
 
         with mock.patch.object(_mod, "LazyJiraClient", return_value=mock_client):
             runner = click.testing.CliRunner()
@@ -670,3 +790,48 @@ class TestCliTempo:
         result = runner.invoke(_mod.cli, ["--backend", "tempo"])
         assert result.exit_code == 0
         assert "No worklogs found" in result.output
+
+    @mock.patch.object(_mod, "LazyJiraClient")
+    def test_tempo_account_path(self, mock_client_cls):
+        mock_client = mock.MagicMock()
+        mock_client_cls.return_value = mock_client
+        self._make_tempo_client(mock_client)  # detect_tempo → 200; jql → issue_map
+        post_response = mock.MagicMock()
+        post_response.status_code = 200
+        post_response.json.return_value = SAMPLE_TEMPO_RESPONSE
+        mock_client._session.post.return_value = post_response
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_mod.cli, ["--tempo-account", "ACME", "--from", "2026-04-01", "--to", "2026-04-30"])
+        assert result.exit_code == 0, f"CLI failed: {result.output}\n{result.exception}"
+        assert "HMKG-100" in result.output
+        assert "via Tempo" in result.output
+        payload = mock_client._session.post.call_args.kwargs["json"]
+        assert payload["accountKey"] == ["ACME"]
+
+    @mock.patch.object(_mod, "LazyJiraClient")
+    def test_tempo_account_empty_keys_rejected(self, mock_client_cls):
+        mock_client = mock.MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.url = "https://jira.example.com"
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_mod.cli, ["--tempo-account", ",", "--from", "2026-04-01", "--to", "2026-04-30"])
+        assert result.exit_code != 0
+        assert "account key" in result.output.lower()
+
+    @mock.patch.object(_mod, "LazyJiraClient")
+    def test_forced_tempo_unavailable_errors(self, mock_client_cls):
+        # --backend tempo on a Jira without Tempo (404) must error, not fall back.
+        mock_client = mock.MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.url = "https://jira.example.com"
+        mock_client.myself.return_value = {"name": "psiedler"}
+        no_tempo = mock.MagicMock()
+        no_tempo.status_code = 404
+        mock_client._session.get.return_value = no_tempo
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(_mod.cli, ["--backend", "tempo", "--from", "2026-04-01", "--to", "2026-04-01"])
+        assert result.exit_code != 0
+        assert "not available" in result.output.lower()


### PR DESCRIPTION
## What

Adds `--tempo-account KEY[,KEY...]` to `jira-worklog-query.py` to report the worked time booked to a **Tempo account** (a customer) over a date range — across **all** workers.

## Why

The query could only filter by worker, issue, project, epic or sprint — **never by Tempo account**. Time booked to an account is often logged by a *different* worker on an issue you wouldn't guess, so `--issue`/`--user` queries silently return nothing. The only endpoint that resolves a whole account is `POST /rest/tempo-timesheets/4/worklogs/search` with an `accountKey` array; this flag wraps it.

## Changes

- `--tempo-account` — forces the Tempo backend, spans all workers (no per-user filter), accepts a comma-separated list of account keys; rejects a value that parses to no non-empty keys.
- Gate the forced Tempo paths (`--tempo-account`, `--backend tempo`) on availability, with a clear Server/DC-vs-Cloud message.
- Fix `detect_tempo()`: it required HTTP 200 from `GET /worklogs`, but the v4 resource only accepts POST and returns **405** to a GET — so real Tempo **Server** instances were misdetected as "no Tempo" and `--backend auto` silently fell back to JQL. Now treats the plugin as present unless the probe returns 404 (absent) or 401/403 (auth failure).
- `normalize_tempo_worklog` maps the search endpoint's `worker` field to `author`, handling both string and user-object shapes, and falls back `displayName` → `name` when an author object lacks a display name.
- Bound Tempo worklog pagination with a `MAX_PAGES` cap so a response whose metadata never signals the last page raises instead of looping forever and exhausting memory.
- `references/worklog.md`: new "By Tempo account" section incl. the raw REST recipe.

## Testing

`pytest tests/` — 736 passing, including a regression test that the pagination cap raises rather than looping. Verified against a Tempo Timesheets **Server/DC** instance: `--tempo-account` / `--quiet` / `--json` reproduce the account's Tempo report totals.

Came from /retro.
