### PR TITLE
docs(skill): add no-editorializing rule for written output

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -61,18 +61,23 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screensh
 
 **jira-syntax**: For descriptions/comments. Jira uses wiki markup, not Markdown.
 
+## No editorializing
+
+In tickets, comments and worklog notes, state what happened, not how good the work is; no self-praise or narrating the expected. See `references/no-editorializing.md`.
+
 ## References
 
-- `references/jql-quick-reference.md`, `references/jql-cookbook.md` — JQL beyond simple filters
-- `references/multi-profile.md` — multiple Jira instances, `--profile`
-- `references/troubleshooting.md` — auth, SSL, 401, 403, connection
-- `references/issue-editing.md` — `--description`, `--fields-json`, reporter, deletes, moves
-- `references/creation.md` — `--parent`, components, custom fields
-- `references/comments.md` — edit, delete, list, markup lint / `--force`
-- `references/worklog.md` — `--started`, date ranges, `jira-worklog-query.py`
-- `references/attachments.md` — upload, download (cwd-only), inspect
-- `references/links.md` — issue/web links, instance-specific link types
-- `references/agile.md` — sprints, boards, `board --name`
+- `references/jql-quick-reference.md`, `references/jql-cookbook.md`
+- `references/multi-profile.md` — `--profile`
+- `references/troubleshooting.md` — auth, 401/403
+- `references/issue-editing.md` — edit, delete
+- `references/creation.md` — create, `--parent`, fields
+- `references/comments.md` — edit, delete, lint
+- `references/worklog.md` — `--started`, ranges
+- `references/attachments.md` — upload, download
+- `references/links.md` — links
+- `references/agile.md` — sprints/boards
+- `references/no-editorializing.md` — no self-praise
 - `references/fields-and-users.md` — custom field IDs, users, issue types
 - `references/watchers.md` — watch, subscribe, list watchers
 - `references/versions.md` — fix/affects versions, releases, version CRUD

--- a/skills/jira-communication/references/no-editorializing.md
+++ b/skills/jira-communication/references/no-editorializing.md
@@ -1,4 +1,4 @@
-## No editorializing — inform, don't sell (tone, not wordlist)
+# No editorializing — inform, don't sell (tone, not wordlist)
 
 Applies to every written artifact: commit messages, PR/MR descriptions, review
 comments, issue/ticket text, chat — and code comments, docstrings,
@@ -9,7 +9,7 @@ banned-word list catches it, and the same word can be fine or not depending on
 whether it carries a fact. The failure is writing about *how good, clean, or
 careful the work is* instead of *what it does*. The reader has the diff and the
 artifact; anything that only flatters the work or reassures them adds nothing,
-and to a reviewer it reads as salesmanship — it provokes a contra-reaction
+and to a reviewer it reads as salesmanship — it provokes a counter-reaction
 before they reach the substance.
 
 Apply three tests before a sentence stays:

--- a/skills/jira-communication/references/no-editorializing.md
+++ b/skills/jira-communication/references/no-editorializing.md
@@ -1,0 +1,41 @@
+## No editorializing — inform, don't sell (tone, not wordlist)
+
+Applies to every written artifact: commit messages, PR/MR descriptions, review
+comments, issue/ticket text, chat — and code comments, docstrings,
+documentation, README and changelog files.
+
+Editorializing is a matter of **tone and intent, not specific words** — no
+banned-word list catches it, and the same word can be fine or not depending on
+whether it carries a fact. The failure is writing about *how good, clean, or
+careful the work is* instead of *what it does*. The reader has the diff and the
+artifact; anything that only flatters the work or reassures them adds nothing,
+and to a reviewer it reads as salesmanship — it provokes a contra-reaction
+before they reach the substance.
+
+Apply three tests before a sentence stays:
+
+1. **Deletion** — remove the phrase. Did the reader lose a fact? If not, cut it.
+2. **Subject** — is the sentence about the change, or about *you / your work*
+   (its quality, your diligence)? The latter goes.
+3. **Voice** — would a terse maintainer write this, or does it read like a
+   cover letter?
+
+Two recurring failure modes:
+
+- **Announcing the expected.** Passing tests, clean linters, "documented", "no
+  regressions", "works as expected" are the baseline — do not narrate them.
+  State a check's status only to flag an *exception* (something knowingly
+  failing or skipped). In a test/verification list, say what was *added or
+  covered*, not that it is green.
+
+- **Self-praise and reassurance.** Grading your own output ("clean", "robust",
+  "elegant", "foolproof", "tidy", "genuinely new", "production-ready"); framings
+  that reassure ("the honest breaking change", "deliberately scoped, not
+  hidden", "where it belongs"); and the diligence humble-brag ("I carefully…",
+  "I made sure to…", "thoroughly tested"). These describe the author, not the
+  change. Show the fact; drop the framing. (The words are only symptoms — judge
+  by the three tests above, not by the word.)
+
+Use plain labels, not graded ones: "Breaking change", "Tests", "Limitations" —
+not "Tests (all green)" or "Breaking change (honest)". If a limitation's cause
+matters, it is already stated in the item.


### PR DESCRIPTION
Adds a `## No editorializing` note and `references/no-editorializing.md`: in tickets, comments and worklog notes, state what happened, not how good the work is — no self-praise or narrating expected results. Judged by tone (deletion / subject / voice tests), not a wordlist. SKILL.md kept under the 500-word limit. Mirrors netresearch/git-workflow-skill#83.