### PR TITLE
chore(release): v3.18.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.18.2",
+  "version": "3.18.3",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.18.3] - 2026-07-01
+
+### Documentation
+
+- All skills: added a "no editorializing" rule for written output — commit messages, PR/MR descriptions, review comments, tickets, and chat state what changed, not how good it is ([#150](https://github.com/netresearch/jira-skill/pull/150)).
+- `AGENTS.md`: documented the `atlassian-python-api >=3.41,<4` pin rationale (no Jira Cloud test tenant) ([#148](https://github.com/netresearch/jira-skill/pull/148)).
+
+## [3.18.2] - 2026-06-27
+
+### Fixed
+
+- `hooks`: the Jira-key guard no longer flags `CWE`/`CVE`/encoding IDs or `PROJ-123`-style placeholders as real keys, and blocks the `PROJ`/`EXAMPLE`/`AES`/`TLS` prefixes ([#146](https://github.com/netresearch/jira-skill/pull/146)).
+
+### Documentation
+
+- `jira-communication`: check `jira-attachment download` exit status instead of file size, and document its auth requirement ([#145](https://github.com/netresearch/jira-skill/pull/145)); document unassigning an issue ([#144](https://github.com/netresearch/jira-skill/pull/144)).
+- `jira-syntax`: document the `(/)` and `(x)` status emoticons and checklist semantics ([#141](https://github.com/netresearch/jira-skill/pull/141)).
+
+## [3.18.1] - 2026-06-24
+
+### Documentation
+
+- `jira-communication`: note the Jira Cloud `[~accountId]` mention form, transition-by-status-name, and `[~mention]` username gotchas ([#140](https://github.com/netresearch/jira-skill/pull/140)).
+- `jira-editing`: epic-link is edit-screen-only; subtask↔standard conversion is via the UI "Convert to Issue" ([#142](https://github.com/netresearch/jira-skill/pull/142)).
+
 ## [3.18.0] - 2026-06-18
 
 ### Added

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.18.2"
+  version: "3.18.3"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.18.2"
+  version: "3.18.3"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Patch release.

- No-editorializing rule for ticket/comment/worklog text: a `## No editorializing` note plus `references/no-editorializing.md`. (#150)
- Pin rationale for atlassian-python-api <4 in AGENTS.

Tag v3.18.3 after merge to publish.