### PR TITLE
feat(jira-communication): flag '||' inside table data rows in wiki-markup lint

### DIFF
--- a/skills/jira-communication/scripts/lib/markup.py
+++ b/skills/jira-communication/scripts/lib/markup.py
@@ -8,10 +8,11 @@ Catches the most damaging authoring mistakes before text is sent to Jira:
   line. Literal mentions must be escaped as \\{code\\}.
 - Unbalanced block tags (odd occurrence count), which leave an unclosed
   block that swallows everything after it.
-- Table data rows containing ``||`` inside a cell. In a table ``|`` is the
-  cell and ``||`` the header-cell delimiter, so a ``||`` in a normal ``|``
-  row (typically a Composer constraint like ``^12.4 || ^13.4``) splits the
-  row and shifts every following column. Rewrite the cell without pipes.
+- Table data rows containing an unescaped ``||`` inside a cell. In a table
+  ``|`` is the cell and ``||`` the header-cell delimiter, so a ``||`` in a
+  normal ``|`` row (typically a Composer constraint like ``^12.4 || ^13.4``)
+  splits the row and shifts every following column. An escaped ``\\|`` is a
+  literal pipe and is left alone. Rewrite the cell without unescaped pipes.
 
 Escaped tags (\\{code\\}), inline-monospace lookalikes ({{code}}) and
 *other* tags inside an open block are ignored. An occurrence of the
@@ -52,15 +53,16 @@ def lint_wiki_markup(text: str) -> list[str]:
                 in_block = None
             continue
 
-        # Table data row (starts with a single `|`) must not contain `||`:
-        # `||` is the header-cell delimiter and splits the row mid-cell.
+        # Table data row (starts with a single `|`) must not contain an
+        # unescaped `||`: `||` is the header-cell delimiter and splits the row
+        # mid-cell. An escaped `\|` is a literal pipe, so ignore it.
         stripped = line.strip()
-        if stripped.startswith("|") and not stripped.startswith("||") and "||" in stripped:
+        if stripped.startswith("|") and not stripped.startswith("||") and re.search(r"(?<!\\)\|\|", stripped):
             findings.append(
-                f"line {lineno}: table data row contains '||' inside a cell "
-                f"(e.g. a Composer constraint '^12.4 || ^13.4') - '|' is the cell "
-                f"delimiter, so this splits the row; rewrite the cell without "
-                f"pipes: {stripped[:80]!r}"
+                f"line {lineno}: table data row contains an unescaped '||' inside "
+                f"a cell (e.g. a Composer constraint '^12.4 || ^13.4') - '|' is the "
+                f"cell delimiter, so this splits the row; rewrite the cell without "
+                f"unescaped pipes: {stripped[:80]!r}"
             )
 
         if not matches:

--- a/skills/jira-communication/scripts/lib/markup.py
+++ b/skills/jira-communication/scripts/lib/markup.py
@@ -57,7 +57,7 @@ def lint_wiki_markup(text: str) -> list[str]:
         # unescaped `||`: `||` is the header-cell delimiter and splits the row
         # mid-cell. An escaped `\|` is a literal pipe, so ignore it.
         stripped = line.strip()
-        if stripped.startswith("|") and not stripped.startswith("||") and re.search(r"(?<!\\)\|\|", stripped):
+        if stripped.startswith("|") and not stripped.startswith("||") and re.search(r"(?<!\\)(?:\\\\)*\|\|", stripped):
             findings.append(
                 f"line {lineno}: table data row contains an unescaped '||' inside "
                 f"a cell (e.g. a Composer constraint '^12.4 || ^13.4') - '|' is the "

--- a/skills/jira-communication/scripts/lib/markup.py
+++ b/skills/jira-communication/scripts/lib/markup.py
@@ -8,6 +8,10 @@ Catches the most damaging authoring mistakes before text is sent to Jira:
   line. Literal mentions must be escaped as \\{code\\}.
 - Unbalanced block tags (odd occurrence count), which leave an unclosed
   block that swallows everything after it.
+- Table data rows containing ``||`` inside a cell. In a table ``|`` is the
+  cell and ``||`` the header-cell delimiter, so a ``||`` in a normal ``|``
+  row (typically a Composer constraint like ``^12.4 || ^13.4``) splits the
+  row and shifts every following column. Rewrite the cell without pipes.
 
 Escaped tags (\\{code\\}), inline-monospace lookalikes ({{code}}) and
 *other* tags inside an open block are ignored. An occurrence of the
@@ -47,6 +51,17 @@ def lint_wiki_markup(text: str) -> list[str]:
                     )
                 in_block = None
             continue
+
+        # Table data row (starts with a single `|`) must not contain `||`:
+        # `||` is the header-cell delimiter and splits the row mid-cell.
+        stripped = line.strip()
+        if stripped.startswith("|") and not stripped.startswith("||") and "||" in stripped:
+            findings.append(
+                f"line {lineno}: table data row contains '||' inside a cell "
+                f"(e.g. a Composer constraint '^12.4 || ^13.4') - '|' is the cell "
+                f"delimiter, so this splits the row; rewrite the cell without "
+                f"pipes: {stripped[:80]!r}"
+            )
 
         if not matches:
             continue

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -77,3 +77,21 @@ class TestRendererSemantics:
 
     def test_closing_tag_alone_is_fine(self):
         assert lint_wiki_markup("{code}\nfoo\n{code}") == []
+
+
+class TestTablePipes:
+    """`||` inside a normal `|` table row splits the row and must be flagged."""
+
+    def test_header_row_is_clean(self):
+        assert lint_wiki_markup("|| Paket || Constraint || PT ||") == []
+
+    def test_plain_data_row_is_clean(self):
+        assert lint_wiki_markup("| news | ^13.1 | 1 |") == []
+
+    def test_double_pipe_in_data_cell_flagged(self):
+        findings = lint_wiki_markup("| luxletter | 29.0.1, ^12.4 || ^13.4 | 2 |")
+        assert any("table data row contains '||'" in f for f in findings)
+
+    def test_double_pipe_in_prose_is_not_a_table(self):
+        # A line that does not start with `|` is prose, not a table row.
+        assert lint_wiki_markup("supports ^12.4 || ^13.4 in composer.json") == []

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -90,8 +90,16 @@ class TestTablePipes:
 
     def test_double_pipe_in_data_cell_flagged(self):
         findings = lint_wiki_markup("| luxletter | 29.0.1, ^12.4 || ^13.4 | 2 |")
-        assert any("table data row contains '||'" in f for f in findings)
+        assert any("splits the row" in f for f in findings)
 
     def test_double_pipe_in_prose_is_not_a_table(self):
         # A line that does not start with `|` is prose, not a table row.
         assert lint_wiki_markup("supports ^12.4 || ^13.4 in composer.json") == []
+
+    def test_escaped_double_pipe_in_data_cell_is_clean(self):
+        # A cell may hold a literal `||` written as the escaped `\|\|`.
+        assert lint_wiki_markup(r"| luxletter | 29.0.1, ^12.4 \|\| ^13.4 | 2 |") == []
+
+    def test_escaped_pipe_before_delimiter_is_clean(self):
+        # `\|` is a literal pipe; `\||` is literal-pipe + delimiter, not broken.
+        assert lint_wiki_markup(r"| a\|| b |") == []

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -103,3 +103,8 @@ class TestTablePipes:
     def test_escaped_pipe_before_delimiter_is_clean(self):
         # `\|` is a literal pipe; `\||` is literal-pipe + delimiter, not broken.
         assert lint_wiki_markup(r"| a\|| b |") == []
+
+    def test_escaped_backslash_before_double_pipe_flagged(self):
+        # `\\` is a literal backslash, so the following `||` is unescaped.
+        findings = lint_wiki_markup(r"| luxletter | 29.0.1, ^12.4 \\|| ^13.4 | 2 |")
+        assert any("splits the row" in f for f in findings)


### PR DESCRIPTION
## Problem

A Jira table uses `|` for cells and `||` for header cells. A `||` inside a normal `|` data row, most commonly a Composer constraint like `^12.4 || ^13.4`, splits the row mid-cell and shifts every following column, silently corrupting the rendered table. This bit real comment authoring twice (constraint cells in an estimate table).

## Change

`lint_wiki_markup` now flags any table **data** row (starts with a single `|`) that contains `||`, pointing at the offending line and suggesting a pipe-free rewrite. Header rows (`|| ... ||`) and prose lines containing `||` are not flagged. The check runs only outside `{code}`/`{noformat}` blocks (verbatim content is untouched).

Since `add`/`edit` already lint via `lint_wiki_markup` before posting, the guard is active on both paths (overridable with `--force`).

## Tests

`TestTablePipes` (4 cases: clean header row, clean data row, flagged `||` in a data cell, prose `||` not treated as a table). Full suite green.

- `uvx ruff check` / `ruff format --check`: clean
- `pytest tests/test_markup.py`: 18 passed