### PR TITLE
docs(jira-communication): trigger on keyless Jira intent; clarify MCP-connector access

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jira-communication
-description: "Use when interacting with Jira issues - searching, creating, updating, moving, transitioning, commenting, logging work, downloading attachments, managing sprints, boards, issue links, web links, fields, or users. Auto-triggers on Jira URLs and issue keys (PROJ-123). Also use when MCP Atlassian tools fail or are unavailable for Jira Server/DC."
+description: "Use when handling Jira issues, sprints, boards, links, fields, worklogs, attachments, or users, or on any Jira intent without a key (create/find a ticket, pick a project). Auto-triggers on Jira URLs and issue keys (PROJ-123). Also use when MCP Atlassian tools fail or are unavailable for Jira Server/DC."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jira-communication
-description: "Use when handling Jira issues, sprints, boards, links, fields, worklogs, attachments, or users, or on any Jira intent without a key (create/find a ticket, pick a project). Auto-triggers on Jira URLs and issue keys (PROJ-123). Also use when MCP Atlassian tools fail or are unavailable for Jira Server/DC."
+description: "Use when handling Jira issues, sprints, boards, links, fields, worklogs, attachments, or users, or on any Jira intent without a key (\"create/find a ticket\", \"pick a project\"). Auto-triggers on Jira URLs and issue keys (PROJ-123). Also use when MCP Atlassian tools fail or are unavailable for Jira Server/DC."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:

--- a/skills/jira-communication/evals/evals.json
+++ b/skills/jira-communication/evals/evals.json
@@ -249,5 +249,24 @@
         "pattern": "(\\./)?attachments"
       }
     ]
+  },
+  {
+    "name": "create_ticket_from_intent_without_key",
+    "prompt": "We just decided on this work - please create a Jira task in project ACME titled 'Document the new export API'. I don't have an issue key yet.",
+    "assertions": [
+      {
+        "type": "tool_use",
+        "tool": "Bash",
+        "pattern": "jira-create\\.py"
+      },
+      {
+        "type": "content",
+        "pattern": "(--type|--issuetype).*(Task|task)"
+      },
+      {
+        "type": "content",
+        "pattern": "ACME"
+      }
+    ]
   }
 ]

--- a/skills/jira-communication/evals/evals.json
+++ b/skills/jira-communication/evals/evals.json
@@ -257,7 +257,7 @@
       {
         "type": "tool_use",
         "tool": "Bash",
-        "pattern": "jira-create\\.py"
+        "pattern": "jira-create\\.py\\s+issue"
       },
       {
         "type": "content",

--- a/skills/jira-communication/references/intent-verbs.md
+++ b/skills/jira-communication/references/intent-verbs.md
@@ -4,7 +4,7 @@
 
 ## Access — this skill IS the Jira path
 
-Reach for these scripts on **any** Jira intent, even with no issue key — "create a ticket in the right project", "find the ticket for X", or just naming Jira. You do not need a key to start (`jira-search.py` locates issues/projects; `jira-create.py` opens new ones).
+Reach for these scripts on **any** Jira intent, even with no issue key — "create a ticket in the right project", "find the ticket for X", or just naming Jira. You do not need a key to start (`jira-search.py` finds existing issues by JQL; `jira-create.py` opens new ones; the right project comes from your project conventions, e.g. the `netresearch-jira` skill's routing reference).
 
 Do **not** conclude "no Jira access" from an MCP connector's scopes. A Confluence/Atlassian MCP connector — e.g. a cloud `*.atlassian.net` connector limited to Confluence — is a **separate system** from these scripts, which talk to Jira Server/DC (or Cloud) directly via `~/.env.jira`. A connector being Confluence-only says nothing about Jira reachability. If Jira genuinely seems unreachable, run `jira-setup.py` to check config — and tell the user up front, immediately, rather than burying it in options.
 

--- a/skills/jira-communication/references/intent-verbs.md
+++ b/skills/jira-communication/references/intent-verbs.md
@@ -2,6 +2,12 @@
 
 `jira-issue.py work / qa / qa-fail / act` — single-call context bundles for the four common intents.
 
+## Access — this skill IS the Jira path
+
+Reach for these scripts on **any** Jira intent, even with no issue key — "create a ticket in the right project", "find the ticket for X", or just naming Jira. You do not need a key to start (`jira-search.py` locates issues/projects; `jira-create.py` opens new ones).
+
+Do **not** conclude "no Jira access" from an MCP connector's scopes. A Confluence/Atlassian MCP connector — e.g. a cloud `*.atlassian.net` connector limited to Confluence — is a **separate system** from these scripts, which talk to Jira Server/DC (or Cloud) directly via `~/.env.jira`. A connector being Confluence-only says nothing about Jira reachability. If Jira genuinely seems unreachable, run `jira-setup.py` to check config — and tell the user up front, immediately, rather than burying it in options.
+
 ## When to load
 
 Whenever you have a Jira issue key and need more than just meta. Each verb composes the right bundle for one intent. Empirically replaces 3–6 separate calls.


### PR DESCRIPTION
## Problem

A Jira request phrased as *intent without an explicit issue key* — e.g. "create a ticket in the right project" — did not surface this skill (auto-trigger was keyed on URLs/keys only). In the same session a **Confluence-only MCP connector's scopes** were mistaken for a global "no Jira access", although this skill is exactly the Jira path for Server/DC.

## Change

- **SKILL.md description:** now also triggers on any Jira intent without a key (create/find a ticket, pick a project). Verb list compressed so the file stays at the 500-word cap (validated).
- **references/intent-verbs.md:** new *Access* section — these scripts ARE the Jira path (Server/DC/Cloud via `~/.env.jira`); a Confluence/Atlassian MCP connector is a separate system and never implies "no Jira access"; surface a genuine access gap immediately, don't bury it.
- **evals:** keyless-intent ticket creation exercises `jira-create.py`.

## Validation

- `Validate skill repo structure` passes (SKILL.md = 500 words, description starts with 'Use when').
- Version parity, markdownlint, JSON checks pass. No version bump (docs-only; release flow owns versioning).