### PR TITLE
docs(jira-syntax): note powershell has no code-block lexer

### DIFF
--- a/skills/jira-syntax/references/jira-syntax-quick-reference.md
+++ b/skills/jira-syntax/references/jira-syntax-quick-reference.md
@@ -125,7 +125,7 @@ The Jira Server source-code formatter accepts ONLY this fixed list. Using any ot
 
 **Notes:**
 - Use `c#` / `c++` literally, not `csharp` / `cplusplus` (though `cpp` is also accepted).
-- There is no `typescript`, `rust`, `kotlin`, `dart`, `shell`, `yml`, `dockerfile`, `terraform`, or `typoscript` formatter.
+- There is no `typescript`, `rust`, `kotlin`, `dart`, `powershell`, `shell`, `yml`, `dockerfile`, `terraform`, or `typoscript` formatter. PowerShell in particular has no lexer — use `{code:none}`.
 - For unsupported languages, fall back to `{code:none}` (or `{noformat}`) to preserve the block without highlighting.
 
 ```

--- a/skills/jira-syntax/references/jira-syntax-quick-reference.md
+++ b/skills/jira-syntax/references/jira-syntax-quick-reference.md
@@ -125,7 +125,7 @@ The Jira Server source-code formatter accepts ONLY this fixed list. Using any ot
 
 **Notes:**
 - Use `c#` / `c++` literally, not `csharp` / `cplusplus` (though `cpp` is also accepted).
-- There is no `typescript`, `rust`, `kotlin`, `dart`, `powershell`, `shell`, `yml`, `dockerfile`, `terraform`, or `typoscript` formatter. PowerShell in particular has no lexer — use `{code:none}`.
+- There is no `typescript`, `rust`, `kotlin`, `dart`, `powershell`, `shell`, `yml`, `dockerfile`, `terraform`, or `typoscript` formatter.
 - For unsupported languages, fall back to `{code:none}` (or `{noformat}`) to preserve the block without highlighting.
 
 ```

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -155,6 +155,7 @@ validate_file() {
                 kotlin|kt)                           hint="{code:java} (Kotlin lexes acceptably as Java) or {code:none}" ;;
                 typescript|ts|tsx)                   hint="{code:javascript} or {code:none}" ;;
                 shell|zsh|fish|console)              hint="{code:bash} or {code:none}" ;;
+                powershell|ps1|pwsh)                 hint="{code:none} for PowerShell" ;;
                 make|makefile)                       hint="{code:none} for Makefile" ;;
                 ini|toml|conf|properties)            hint="{code:none} for INI / TOML / config" ;;
                 diff|patch)                          hint="{code:none}" ;;


### PR DESCRIPTION
The Jira Server/DC source-code formatter has no `powershell` lexer — `{code:powershell}` renders a visible "Unable to find source-code formatter for language: powershell" error instead of the code.

This adds `powershell` to the unsupported-identifiers list in `references/jira-syntax-quick-reference.md` with an explicit pointer to the `{code:none}` fallback, so agents authoring Jira comments/descriptions with PowerShell snippets pick the right block.

Found via a real session where three PowerShell code blocks rendered the error in a posted Jira comment.