### PR TITLE
chore(release): v3.20.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.20.0] - 2026-07-13
+
+### Added
+
+- `jira-communication`: wiki-markup lint flags `||` (header separators) inside table data rows, with escaped-pipe handling ([#153](https://github.com/netresearch/jira-skill/pull/153)).
+
+### Changed
+
+- `jira-syntax`: trimmed generic content from the quick-reference; fixed TOC links and the inline-code placeholder ([#156](https://github.com/netresearch/jira-skill/pull/156)).
+
+### Documentation
+
+- `jira-communication`: skill triggers on keyless Jira intent ("create/find a ticket", "pick a project"); clarified MCP-connector access ([#154](https://github.com/netresearch/jira-skill/pull/154)).
+- `jira-syntax`: noted PowerShell has no code-block lexer; added validator hint ([#155](https://github.com/netresearch/jira-skill/pull/155)).
+
 ## [3.19.0] - 2026-07-06
 
 ### Added

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.19.0"
+  version: "3.20.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.19.0"
+  version: "3.20.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Release v3.20.0 (minor) — changes since https://github.com/netresearch/jira-skill/releases/tag/v3.19.0:

- feat(jira-communication): wiki-markup lint flags `||` inside table data rows, with escaped-pipe handling (https://github.com/netresearch/jira-skill/pull/153)
- chore(jira-syntax): trim generic content from quick-reference; fix TOC links and inline-code placeholder (https://github.com/netresearch/jira-skill/pull/156)
- docs(jira-communication): trigger on keyless Jira intent; clarify MCP-connector access (https://github.com/netresearch/jira-skill/pull/154)
- docs(jira-syntax): note PowerShell has no code-block lexer (https://github.com/netresearch/jira-skill/pull/155)

Bumps `.claude-plugin/plugin.json` and both `skills/*/SKILL.md` metadata versions to 3.20.0; adds the CHANGELOG section.