### PR TITLE
feat(jira-communication): flag inline emphasis glued mid-word in wiki-markup lint

### DIFF
--- a/skills/jira-communication/scripts/lib/markup.py
+++ b/skills/jira-communication/scripts/lib/markup.py
@@ -13,6 +13,18 @@ Catches the most damaging authoring mistakes before text is sent to Jira:
   normal ``|`` row (typically a Composer constraint like ``^12.4 || ^13.4``)
   splits the row and shifts every following column. An escaped ``\\|`` is a
   literal pipe and is left alone. Rewrite the cell without unescaped pipes.
+- Inline emphasis (``_italic_``, ``*bold*``) glued to the middle of a word.
+  Jira only opens emphasis at a word boundary, so ``Konzept_qualität_`` is
+  rendered with literal underscores rather than italics. Only the clearly
+  broken shape is flagged (a marker preceded by a word char whose matching
+  closer lands on a clause boundary - space, sentence punctuation, a closing
+  bracket or quote, or line end - not before a connector like % or /); the body
+  must be non-empty, so
+  symmetric double-marker tokens (``__LINE__``, ``**bold**``) and snake_case
+  identifiers such as ``be_acl`` or ``sys_file_reference`` are left alone.
+  Content inside ``{{monospace}}`` and ``[links]`` is ignored. Known blind spot:
+  a bare trailing-underscore prefix (``tx_news_``) is flagged like broken
+  emphasis - wrap identifiers in ``{{monospace}}`` to silence it.
 
 Escaped tags (\\{code\\}), inline-monospace lookalikes ({{code}}) and
 *other* tags inside an open block are ignored. An occurrence of the
@@ -22,12 +34,42 @@ inside a code block terminates the block there).
 """
 
 import re
+import unicodedata
 
 BLOCK_TAGS = ("code", "noformat", "quote", "panel")
 
 # Unescaped block tag, optionally with parameters ({code:bash}, {panel:title=x}).
 # (?<!\{) keeps {{code}} / {{panel}} (inline monospace content) out of scope.
 _TAG_RE = re.compile(r"(?<!\\)(?<!\{)\{(code|noformat|quote|panel)(?::[^}\n]*)?\}")
+
+# Spans where markers are literal, blanked before the emphasis scan so their
+# content ({{sys_file_reference}}, [foo_bar_|url]) never trips the check.
+_INLINE_SPAN_RE = re.compile(r"\{\{.*?\}\}|\[[^\]\n]*\]")
+
+# The closer must sit before a real clause boundary: whitespace, sentence
+# punctuation, a closing bracket, a closing quote, or line end - NOT before a
+# connector like % $ / @, which would wrongly match a format-string or path
+# segment (%d_%m_%Y, some_dir_/f). Closing quotes are included because German
+# prose quotes UI/field labels; `/` and dashes stay excluded on purpose to keep
+# paths/format strings clean. The quote codepoints (ASCII " ', curly quotes,
+# guillemets) are built via chr() so this source stays ASCII-only.
+_CLOSE_QUOTES = "".join(map(chr, (0x22, 0x27, 0x2018, 0x2019, 0x201C, 0x201D, 0xAB, 0xBB)))
+_EMPH_CLOSE = "(?=[\\s.,;:!?)\\]}" + _CLOSE_QUOTES + "]|$)"
+
+# A marker preceded by a word char whose matching closer sits at a clause boundary
+# is broken-but-intended emphasis (Konzept_qualität_). The body is NON-EMPTY
+# ([^\s<m>]+): an empty body would make the trailing pair of every symmetric
+# double-marker token match, false-flagging PHP magic constants / dunders
+# (__LINE__, __CLASS__, __init__) and Markdown bold (**x**, __x__) - all common in
+# TYPO3/dev text. The body also cannot span another marker, so snake_case
+# identifiers (be_acl, sf_event_mgt), whose closer never lands on a boundary, do
+# not match. Known blind spot: a bare trailing-underscore prefix (tx_news_) is
+# structurally identical to broken emphasis and is still flagged - wrap identifiers
+# in {{monospace}} (good Jira practice) to silence it.
+_MIDWORD_EMPHASIS_RES = {
+    "_": re.compile(r"(?<=\w)_[^\s_]+_" + _EMPH_CLOSE),
+    "*": re.compile(r"(?<=\w)\*[^\s*]+\*" + _EMPH_CLOSE),
+}
 
 
 def lint_wiki_markup(text: str) -> list[str]:
@@ -64,6 +106,21 @@ def lint_wiki_markup(text: str) -> list[str]:
                 f"cell delimiter, so this splits the row; rewrite the cell without "
                 f"unescaped pipes: {stripped[:80]!r}"
             )
+
+        # Inline emphasis glued mid-word renders as a literal marker. NFC-normalise
+        # first so a word ending in a decomposed accent (NFD "e"+combining acute)
+        # still presents a word char before the marker, then blank out {{monospace}}
+        # and [link] spans, where the markers are literal.
+        scan = _INLINE_SPAN_RE.sub(" ", unicodedata.normalize("NFC", line))
+        for marker, emphasis_re in _MIDWORD_EMPHASIS_RES.items():
+            if emphasis_re.search(scan):
+                findings.append(
+                    f"line {lineno}: inline '{marker}' emphasis starts mid-word - "
+                    f"Jira only renders {marker}text{marker} at a word boundary, so "
+                    f"this shows the literal marker; emphasize the whole token at a "
+                    f"boundary (e.g. '{marker}Wort{marker}', not "
+                    f"'Prefix{marker}Wort{marker}'): {stripped[:80]!r}"
+                )
 
         if not matches:
             continue

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -108,3 +108,65 @@ class TestTablePipes:
         # `\\` is a literal backslash, so the following `||` is unescaped.
         findings = lint_wiki_markup(r"| luxletter | 29.0.1, ^12.4 \\|| ^13.4 | 2 |")
         assert any("splits the row" in f for f in findings)
+
+
+class TestInlineEmphasis:
+    """Emphasis markers glued mid-word render literally and must be flagged,
+    while snake_case identifiers and boundary-correct emphasis stay clean."""
+
+    def test_underscore_midword_flagged(self):
+        findings = lint_wiki_markup("§4.1 bewertet die Konzept_qualität_, nicht den Preis.")
+        assert any("starts mid-word" in f for f in findings)
+
+    def test_star_midword_flagged(self):
+        findings = lint_wiki_markup("das ist Fett*wort* im Satz")
+        assert any("starts mid-word" in f for f in findings)
+
+    def test_boundary_italic_is_clean(self):
+        assert lint_wiki_markup("das ist _wichtig_ und bleibt sauber") == []
+
+    def test_boundary_bold_is_clean(self):
+        assert lint_wiki_markup("das ist *fett* und bleibt sauber") == []
+
+    def test_snake_case_identifiers_are_clean(self):
+        # be_acl, sys_file_reference, sf_event_mgt: no closer lands on a boundary.
+        assert lint_wiki_markup("Extensions be_acl, sys_file_reference und sf_event_mgt bleiben.") == []
+
+    def test_trailing_underscore_identifier_is_clean(self):
+        assert lint_wiki_markup("wir nutzen leuphana_solr am Ende.") == []
+
+    def test_emphasis_after_hyphen_is_clean(self):
+        # `-` is a non-word boundary, so AG-_Entscheidung_ opens correctly.
+        assert lint_wiki_markup("die AG-_Entscheidung_ war eindeutig") == []
+
+    def test_underscores_in_monospace_are_clean(self):
+        assert lint_wiki_markup("siehe {{Prefix_Wort_}} im Backend") == []
+
+    def test_underscores_in_link_are_clean(self):
+        assert lint_wiki_markup("[Prefix_Wort_|https://example.com/x] ansehen") == []
+
+    def test_php_magic_constants_are_clean(self):
+        # Symmetric double-marker tokens must not match (non-empty body required).
+        assert lint_wiki_markup("__LINE__, __FILE__, __CLASS__ und __init__ bleiben.") == []
+
+    def test_markdown_double_marker_is_clean(self):
+        # Carried-over Markdown bold **x** / __x__ must not be flagged.
+        assert lint_wiki_markup("Text **bold** und __kursiv__ sowie foo**bar** bleiben.") == []
+
+    def test_format_string_and_path_segments_are_clean(self):
+        # An inner _seg_/…*seg* whose next segment starts with a connector
+        # (% $ /) is a format string / path, not a clause-boundary closer.
+        assert lint_wiki_markup("Ordner %d_%m_%Y, Zeit %H_%M_%S und path/to/some_dir_/file.") == []
+        assert lint_wiki_markup("Key user_$id_$tenant lesen.") == []
+
+    def test_nfd_combining_accent_before_marker_flagged(self):
+        # "café_wert_" in decomposed form (e + U+0301) must still be caught;
+        # the scan NFC-normalises so the accented letter counts as a word char.
+        assert any("starts mid-word" in f for f in lint_wiki_markup("café_wert_ Ende."))
+
+    def test_broken_emphasis_before_closing_quote_flagged(self):
+        # Quoted UI/field labels with a glued marker: the closer sits before
+        # a quote, a real clause boundary (common in German prose).
+        assert any("starts mid-word" in f for f in lint_wiki_markup('Das Label "Konzept_qualitaet_" ist falsch.'))
+        german = "Im Feld " + chr(0x201E) + "Anmelden_jetzt_" + chr(0x201C) + " fehlt."
+        assert any("starts mid-word" in f for f in lint_wiki_markup(german))


### PR DESCRIPTION
## What

`lint_wiki_markup` now flags inline emphasis (`_italic_`, `*bold*`) glued to the middle of a word. Jira only opens emphasis at a word boundary, so `Konzept_qualität_` renders the literal underscores instead of italics — a silent authoring error the linter previously missed.

## Design: boundary-aware to stay false-positive-safe

The regexes are deliberately narrow so they do **not** fire on the snake_case identifiers, format strings and Markdown that pervade TYPO3/dev text:

- **Non-empty body** (`[^\s_]+`): a marker preceded by a word char whose matching closer lands on a clause boundary. This structurally spares symmetric double-marker tokens — PHP magic constants / dunders (`__LINE__`, `__init__`) and Markdown bold (`**x**`, `__x__`).
- **Curated closer set** (`_EMPH_CLOSE`): the closer must sit before whitespace, sentence punctuation, a closing bracket, a closing quote, or line end — **not** before a connector like `%`/`$`/`/`/`@`. This keeps format strings (`%d_%m_%Y`) and paths (`some_dir_/file`) clean.
- **Closing quotes included** (ASCII, curly, guillemets) so a quoted field/UI label with a glued marker is caught (`"Konzept_qualität_"`, `„Anmelden_jetzt_"`).
- **NFC-normalisation** before scanning so a word ending in a decomposed accent (NFD `e`+combining acute) still presents a word char before the marker.
- `{{monospace}}` and `[link]` spans are blanked before scanning (markers are literal there).

## Known, documented limitation

A bare trailing-underscore prefix in prose (`tx_news_`) is structurally identical to broken emphasis and is still flagged — wrap identifiers in `{{monospace}}` (good Jira practice) to silence it. Documented in the docstring and comments.

## Tests

14 new cases in `TestInlineEmphasis` pin every rationale: the broken shapes flagged, and dunders / Markdown / snake_case / format strings / paths / boundary-correct emphasis / hyphen-preceded emphasis / monospace+link spans / NFD / closing quotes all clean. Full suite: 35 passing, `ruff check` + `ruff format --check` clean.