### PR TITLE
docs(jira-communication): note query options follow the query subcommand, not the JQL

### DIFF
--- a/skills/jira-communication/references/troubleshooting.md
+++ b/skills/jira-communication/references/troubleshooting.md
@@ -119,15 +119,17 @@ uv run scripts/core/jira-issue.py --json get PROJ-123
 
 ### "No such option: -f" / "-n" (query options before the subcommand)
 
-**Cause**: The inverse of the error above — a *subcommand* option placed before the subcommand. `-f/--fields`, `-n/--max-results`, and `--order-by` belong to `query`, so they must follow the JQL, not precede `query`. Global options (`--json`, `-q`) go before the subcommand; query options go after the positional JQL. A stub that ignores argument order hides this — verify the ordering against the live tool.
+**Cause**: The inverse of the error above — a *subcommand* option placed before the subcommand. `-f/--fields`, `-n/--max-results`, and `--order-by` belong to `query`, so they must come **after** the `query` token (before or after the positional JQL is fine), never before it. Global options (`--json`, `-q`) go before the subcommand. A stub that ignores argument order hides this — verify the ordering against the live tool.
 
-**Fix**: Move query flags after the JQL:
+**Fix**: Put query flags after the `query` subcommand:
 ```bash
 # Wrong — -f before the `query` subcommand → "Error: No such option: -f" (exit 2)
 uv run scripts/core/jira-search.py --json -f key,status query "project = OPS"
 
-# Correct — global flags before `query`, query flags after the JQL
+# Correct — global flags before `query`; query flags after `query`,
+# either before or after the JQL both work
 uv run scripts/core/jira-search.py --json query "project = OPS" -f key,status -n 500
+uv run scripts/core/jira-search.py --json query -f key,status -n 500 "project = OPS"
 ```
 
 ### "Transition 'X' not available" (passing the transition ID)

--- a/skills/jira-communication/references/troubleshooting.md
+++ b/skills/jira-communication/references/troubleshooting.md
@@ -117,6 +117,19 @@ uv run scripts/core/jira-issue.py get PROJ-123 --json
 uv run scripts/core/jira-issue.py --json get PROJ-123
 ```
 
+### "No such option: -f" / "-n" (query options before the subcommand)
+
+**Cause**: The inverse of the error above — a *subcommand* option placed before the subcommand. `-f/--fields`, `-n/--max-results`, and `--order-by` belong to `query`, so they must follow the JQL, not precede `query`. Global options (`--json`, `-q`) go before the subcommand; query options go after the positional JQL. A stub that ignores argument order hides this — verify the ordering against the live tool.
+
+**Fix**: Move query flags after the JQL:
+```bash
+# Wrong — -f before the `query` subcommand → "Error: No such option: -f" (exit 2)
+uv run scripts/core/jira-search.py --json -f key,status query "project = OPS"
+
+# Correct — global flags before `query`, query flags after the JQL
+uv run scripts/core/jira-search.py --json query "project = OPS" -f key,status -n 500
+```
+
 ### "Transition 'X' not available" (passing the transition ID)
 
 **Cause**: `jira-transition.py do` expects the **target status name**, not the numeric transition ID that `jira-transition.py list` prints in its leftmost column.


### PR DESCRIPTION
Companion to the existing troubleshooting entry *"No such option: --json"* (which covers a **global** option placed after the subcommand). This adds the inverse: a **query-subcommand** option (`-f/--fields`, `-n/--max-results`, `--order-by`) placed *before* `query`.

`jira-search.py --json -f key,status query "…"` → `Error: No such option: -f` (exit 2). Under `set -eu` in a calling script that kills the run on its first line.

Fix documented: global options before the subcommand, query options after the positional JQL.

Found in a real session where a reconcile script died in every run because `-f` preceded `query`; a stub that ignored argument order masked it — only a live invocation surfaced it (noted in the entry).