### PR TITLE
docs: validation is a gate; document clearing a field

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -48,11 +48,17 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py get PROJ-123
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py query "assignee = currentUser() AND status != Closed" -n 5 -f key,summary,status
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py update PROJ-123 --assignee me --priority Critical
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py add PROJ-123 "Comment text"
+cat body.txt | uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py add PROJ-123 -
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-transition.py do PROJ-123 "In Progress"
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-worklog.py add PROJ-123 2h --comment "Work done"
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py issue PROJ "Summary" --type Task
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screenshot.png
 ```
+
+> **Easy to guess wrong**: a comment body from a file is piped to `-` (there is no
+> `--file`); clear a field with `--fields-json '{"assignee": null}'` (`--assignee ""`
+> is rejected); `download-all` takes `--dir`, while `download` takes an attachment
+> URL, not an issue key.
 
 > **Terminal transitions**: always pass `--resolution <value>` (e.g. `Done`, `Won't do`, `Duplicate`) or the
 > resolution field stays empty and the ticket appears unresolved. See `references/intent-verbs.md`.

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -48,17 +48,11 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py get PROJ-123
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py query "assignee = currentUser() AND status != Closed" -n 5 -f key,summary,status
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py update PROJ-123 --assignee me --priority Critical
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py add PROJ-123 "Comment text"
-cat body.txt | uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-comment.py add PROJ-123 -
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-transition.py do PROJ-123 "In Progress"
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-worklog.py add PROJ-123 2h --comment "Work done"
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py issue PROJ "Summary" --type Task
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screenshot.png
 ```
-
-> **Easy to guess wrong**: a comment body from a file is piped to `-` (there is no
-> `--file`); clear a field with `--fields-json '{"assignee": null}'` (`--assignee ""`
-> is rejected); `download-all` takes `--dir`, while `download` takes an attachment
-> URL, not an issue key.
 
 > **Terminal transitions**: always pass `--resolution <value>` (e.g. `Done`, `Won't do`, `Duplicate`) or the
 > resolution field stays empty and the ticket appears unresolved. See `references/intent-verbs.md`.
@@ -76,9 +70,9 @@ In tickets, comments and worklog notes, state what happened, not how good it is;
 - `references/jql-quick-reference.md`, `references/jql-cookbook.md`
 - `references/multi-profile.md` — `--profile`
 - `references/troubleshooting.md` — auth, 401/403
-- `references/issue-editing.md` — edit, delete, custom fields via `--fields-json` (no `--field` flag)
+- `references/issue-editing.md` — edit, delete, clear fields, `--fields-json`
 - `references/creation.md` — create, `--parent`, fields
-- `references/comments.md` — edit, delete, lint
+- `references/comments.md` — edit, delete, lint, body via `-`
 - `references/worklog.md` — `--started`, ranges, `--tempo-account`
 - `references/attachments.md` — upload, download
 - `references/links.md` — links

--- a/skills/jira-communication/references/issue-editing.md
+++ b/skills/jira-communication/references/issue-editing.md
@@ -18,9 +18,31 @@ cat body.txt | uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py update PROJ
 
 The body is Jira wiki markup (see the `jira-syntax` skill).
 
+## Clearing a field
+
+Typed flags cannot clear a field — `--assignee ""` contributes nothing and the
+CLI reports `✗ No fields specified for update`, so the field keeps its old
+value and nothing signals that the clear was a no-op. Pass an explicit `null`
+via `--fields-json`:
+
+```bash
+# Unassign (back to the team queue)
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py update PROJ-123 \
+    --fields-json '{"assignee": null}'
+
+# Clear a due date and a custom user-picker field in one call
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py update PROJ-123 \
+    --fields-json '{"duedate": null, "customfield_12608": null}'
+```
+
+Not every field can be cleared this way — the field must be on the issue's edit
+screen. Assignee on a transition-only screen needs the dedicated
+`/rest/api/2/issue/KEY/assignee` endpoint, and `parent` cannot be cleared at all
+(see the sub-task note below).
+
 ## `--fields-json` for custom fields and structured payloads
 
-`jira-issue.py update` accepts a raw JSON object to set any field the Jira REST API exposes — reach for it when the typed flags don't cover the field:
+`jira-issue.py update` accepts a raw JSON object to set any field the Jira REST API exposes — reach for it when the typed flags don't cover the field. There is **no** `--field` flag; `--fields-json` is the only generic setter:
 
 ```bash
 # Custom fields (Sprint ID as integer, Epic Link as issue key)

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -49,6 +49,11 @@ Run before submitting to Jira:
 ${CLAUDE_SKILL_DIR}/scripts/validate-jira-syntax.sh path/to/content.txt
 ```
 
+**Validation is a gate.** Run it as its own step and read the result before
+posting — never chain it with the posting command, since `;` posts the broken
+comment anyway and `&&` hides the report. Frequent catch: `${VAR}` inside a
+`{{...}}` span breaks the span.
+
 ### Validation Checklist
 - [ ] Headings: `h2. Title` (space after period)
 - [ ] Bold: `*text*` (single asterisk)
@@ -70,6 +75,7 @@ ${CLAUDE_SKILL_DIR}/scripts/validate-jira-syntax.sh path/to/content.txt
 | `- bullet` | `* bullet` |
 | `h2.Title` | `h2. Title` |
 | `MR !42` (bare GitLab ref) | `[MR 42\|url]` or full `group/project!42` — a bare `!…!` is image markup |
+| `{{cmd --flag=${VAR}}}` | escape as `\{ \}`, or use a `{code}` block — braces inside `{{...}}` break the span |
 | `(/)` on an open/proposed item | `(x)` — `(/)` renders as a green check (done); use `(x)` for open items |
 | `( )` as a checkbox | `(x)` — `( )` is not a macro and renders literally |
 

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -49,10 +49,8 @@ Run before submitting to Jira:
 ${CLAUDE_SKILL_DIR}/scripts/validate-jira-syntax.sh path/to/content.txt
 ```
 
-**Validation is a gate.** Run it as its own step and read the result before
-posting — never chain it with the posting command, since `;` posts the broken
-comment anyway and `&&` hides the report. Frequent catch: `${VAR}` inside a
-`{{...}}` span breaks the span.
+**It gates the post** — run it as its own step, never chained with the
+posting command.
 
 ### Validation Checklist
 - [ ] Headings: `h2. Title` (space after period)
@@ -75,7 +73,6 @@ comment anyway and `&&` hides the report. Frequent catch: `${VAR}` inside a
 | `- bullet` | `* bullet` |
 | `h2.Title` | `h2. Title` |
 | `MR !42` (bare GitLab ref) | `[MR 42\|url]` or full `group/project!42` — a bare `!…!` is image markup |
-| `{{cmd --flag=${VAR}}}` | escape as `\{ \}`, or use a `{code}` block — braces inside `{{...}}` break the span |
 | `(/)` on an open/proposed item | `(x)` — `(/)` renders as a green check (done); use `(x)` for open items |
 | `( )` as a checkbox | `(x)` — `( )` is not a macro and renders literally |
 

--- a/skills/jira-syntax/references/jira-syntax-quick-reference.md
+++ b/skills/jira-syntax/references/jira-syntax-quick-reference.md
@@ -278,3 +278,39 @@ item, `(x)` for an open one. Use them only with that meaning.
 * (/) Migration script written and tested
 * (x) Rollback procedure documented
 ```
+
+## Validation is a gate, not a formality
+
+`scripts/validate-jira-syntax.sh` only helps if its **result** is read before
+the content is posted. Run it as its own step:
+
+```bash
+validate-jira-syntax.sh comment.txt   # read the result
+# only then:
+jira-comment.py add PROJ-123 -        # body piped from the same file
+```
+
+Never chain it with the posting command. With `;` the comment posts even
+though validation failed; with `&&` the report scrolls past unread. Either way
+the broken comment is already on the ticket and needs a follow-up edit —
+visible to everyone watching it.
+
+### Frequent catch: braces inside a monospace span
+
+`${VAR}` (or any `{`/`}`) inside `{{...}}` breaks the span — the Jira parser
+renders it as raw text:
+
+```
+{{traefik.http.middlewares.office-allow-${ENVIRONMENT}.ipallowlist.sourcerange}}
+```
+
+The validator reports:
+
+```
+ERROR: Found unescaped { or } inside {{...}} monospace block — Jira parser
+will render it as raw text. Escape as \{ \} or split the reference.
+```
+
+Escape the braces as `\{ \}`, split the reference, or move the whole line into
+a `{code}` block — a `{code}` block is usually the most readable for anything
+command-shaped.


### PR DESCRIPTION
## Summary

Two documentation fixes from a `/retro` pass: make explicit that the syntax validator gates the post, and document how to clear a field. Both SKILL.md files sat at the 500-word cap, so the prose lives in reference files and SKILL.md only carries the one-line rule and sharper reference descriptors.

## Came from

`/retro` session on 2026-07-23: `9beb8958-4776-4083-a5a7-b77ba29a5029`

### Finding 1 — A13, validation ran but did not gate

- **Symptom:** The validator and the posting command were issued in one shell call separated by `;`. The validator printed `Errors: 1`, the comment posted anyway with a broken monospace span (`${ENVIRONMENT}` inside `{{...}}`), and it needed a follow-up edit on a ticket a colleague was already reading.
- **Cause:** `jira-syntax` said "Run before submitting to Jira" but never that the *result* gates the post, so chaining it with the mutating command looked equivalent.
- **Required behavior:** Run the validator as its own step and read the result before posting.
- **Change:** One-line rule in SKILL.md; the reasoning, the `;` vs `&&` failure modes and the brace-in-monospace case go to `references/jira-syntax-quick-reference.md`.

Verified against the real script — the documented case reproduces:

```
$ printf 'h3. Test\n\nSee {{cmd --flag=${VAR}}} here.\n' > vtest.txt
$ validate-jira-syntax.sh vtest.txt
❌ ERROR: Found unescaped { or } inside {{...}} monospace block …
```

The reference is worded to match the validator's own remediation message rather than inventing a different fix.

### Finding 2 — A1 cluster, flags guessed wrong

Four failed invocations in one session: `--file` on `jira-comment.py add`, `--output-dir` and `-d` on `download-all`, and `--assignee ""` to clear an assignee.

Checking the references before writing changed what this finding actually is:

- The stdin form (`… add PROJ-123 -`) is **already documented** in `references/comments.md`, with HEREDOC and `cat file |` examples.
- `--dir` is **already documented** in `references/attachments.md`.
- Clearing a field with an explicit `null` was **not** documented anywhere.

So most of this was a discoverability problem, not missing content — the SKILL.md reference descriptors (`comments.md — edit, delete, lint`) gave no hint the answers were there. The change is therefore:

- **New** in `references/issue-editing.md`: a "Clearing a field" section. `--assignee ""` does not clear — it contributes nothing and the CLI reports `✗ No fields specified for update`, so the old value silently survives.
- Moved the "no `--field` flag" hint from the SKILL.md descriptor into `issue-editing.md`, which frees the words to point at the stdin form.
- No duplicated prose for the parts already covered.

## Word cap

The gate counts the whole file with `wc -w` including frontmatter — my first push failed CI at 547 / 554 because I measured with a counter that stripped frontmatter. Now: `jira-syntax` 497, `jira-communication` 498.

## Test plan

- [x] `wc -w` on both SKILL.md files ≤ 500 (497 / 498)
- [x] `skill-repo/scripts/validate-skill.sh .` — 0 errors
- [x] `scripts/verify-harness.sh` — Level 3 COMPLETE, 0 errors
- [x] Documented brace case reproduces against `validate-jira-syntax.sh`
- [ ] No reference duplicates content already in `comments.md` / `attachments.md`
