### PR TITLE
feat(workflow): add project creation and Tempo Accounts management

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -158,8 +158,9 @@ To enable future migration to standalone scripts:
 ```python
 # lib/client.py
 # === INLINE_START: client ===
-def get_jira_client(env_file=None):
-    ...
+def get_jira_client(env_file=None): ...
+
+
 # === INLINE_END: client ===
 ```
 
@@ -175,15 +176,17 @@ All scripts MUST use Click for CLI definition:
 ```python
 import click
 
+
 @click.group()
 @click.pass_context
 def cli(ctx):
     """Jira operations."""
     ctx.ensure_object(dict)
-    ctx.obj['client'] = get_jira_client()
+    ctx.obj["client"] = get_jira_client()
+
 
 @cli.command()
-@click.argument('issue_key')
+@click.argument("issue_key")
 @click.pass_context
 def get(ctx, issue_key):
     """Get issue details."""
@@ -635,49 +638,53 @@ from lib.output import format_output
 # CLI Definition
 # ═══════════════════════════════════════════════════════════════════════════════
 
+
 @click.group()
-@click.option('--json', 'output_json', is_flag=True, help='Output as JSON')
-@click.option('--env-file', type=click.Path(), help='Environment file path')
-@click.option('--debug', is_flag=True, help='Show debug information on errors')
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.option("--env-file", type=click.Path(), help="Environment file path")
+@click.option("--debug", is_flag=True, help="Show debug information on errors")
 @click.pass_context
 def cli(ctx, output_json, env_file, debug):
     """Jira worklog operations."""
     ctx.ensure_object(dict)
-    ctx.obj['json'] = output_json
-    ctx.obj['debug'] = debug
+    ctx.obj["json"] = output_json
+    ctx.obj["debug"] = debug
     try:
-        ctx.obj['client'] = get_jira_client(env_file)
+        ctx.obj["client"] = get_jira_client(env_file)
     except Exception as e:
         if debug:
             raise
         raise click.ClickException(str(e))
 
+
 @cli.command()
-@click.argument('issue_key')
-@click.argument('time_spent')
-@click.option('--comment', '-c', help='Worklog comment')
-@click.option('--started', help='Start time (ISO format, default: now)')
+@click.argument("issue_key")
+@click.argument("time_spent")
+@click.option("--comment", "-c", help="Worklog comment")
+@click.option("--started", help="Start time (ISO format, default: now)")
 @click.pass_context
 def add(ctx, issue_key, time_spent, comment, started):
     """Add worklog entry to an issue.
 
     TIME_SPENT format: '2h', '2h 30m', '1d', '30m'
     """
-    client = ctx.obj['client']
+    client = ctx.obj["client"]
     result = client.issue_worklog(issue_key, time_spent, comment=comment, started=started)
-    format_output(result, ctx.obj['json'])
+    format_output(result, ctx.obj["json"])
 
-@cli.command('list')
-@click.argument('issue_key')
-@click.option('--limit', '-n', default=10, help='Max entries to show')
+
+@cli.command("list")
+@click.argument("issue_key")
+@click.option("--limit", "-n", default=10, help="Max entries to show")
 @click.pass_context
 def list_worklogs(ctx, issue_key, limit):
     """List worklog entries for an issue."""
-    client = ctx.obj['client']
+    client = ctx.obj["client"]
     result = client.issue_get_worklog(issue_key)
-    format_output(result[:limit], ctx.obj['json'])
+    format_output(result[:limit], ctx.obj["json"])
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     cli()
 ```
 

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -52,25 +52,18 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-transition.py do PROJ-123 "In P
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-worklog.py add PROJ-123 2h --comment "Work done"
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py issue PROJ "Summary" --type Task
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screenshot.png
-uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py project PROJ "Project Name" --from-project OTHERPROJ --lead jdoe
-uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/tempo-account.py account link 42 PROJ --default
 ```
 
-> **Admin-scope commands**: `jira-create.py project` and `tempo-account.py` exercise
-> Jira Administrator / Tempo Administrator rights on whichever PAT is configured. On
-> Jira Server a PAT carries the full permission set of the user who created it — check
-> before running these against an instance where that is not expected.
->
 > **Terminal transitions**: always pass `--resolution <value>` (e.g. `Done`, `Won't do`, `Duplicate`) or the
 > resolution field stays empty and the ticket appears unresolved. See `references/intent-verbs.md`.
 
 ## Related Skills
 
-**jira-syntax**: For descriptions/comments. Jira uses wiki markup, not Markdown.
+**jira-syntax**: descriptions/comments use Jira wiki markup, not Markdown.
 
 ## No editorializing
 
-In tickets, comments and worklog notes, state what happened, not how good it is; no self-praise. See `references/no-editorializing.md`.
+In tickets, comments and worklog notes, state what happened, not how good it is. See `references/no-editorializing.md`.
 
 ## References
 
@@ -78,7 +71,7 @@ In tickets, comments and worklog notes, state what happened, not how good it is;
 - `references/multi-profile.md` — `--profile`
 - `references/troubleshooting.md` — auth, 401/403
 - `references/issue-editing.md` — edit, delete, clear fields, `--fields-json`
-- `references/creation.md` — create, `--parent`, fields
+- `references/creation.md` — create, `--parent`, fields, admin-scope (`project`, `tempo-account.py`)
 - `references/comments.md` — edit, delete, lint, body via `-`
 - `references/worklog.md` — `--started`, ranges, `--tempo-account`
 - `references/attachments.md` — upload, download

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -34,7 +34,7 @@ Auth issues → `jira-setup.py`. **Anti-pattern:** `get` + `comment list` — us
 Under `${CLAUDE_SKILL_DIR}/scripts/{core,workflow,utility}/`.
 
 **Core**: `jira-issue.py`, `jira-search.py`, `jira-worklog.py`, `jira-attachment.py`, `jira-setup.py`, `jira-validate.py`
-**Workflow**: `jira-create.py`, `jira-transition.py`, `jira-comment.py`, `jira-move.py`, `jira-sprint.py`, `jira-board.py`, `jira-version.py`
+**Workflow**: `jira-create.py`, `jira-transition.py`, `jira-comment.py`, `jira-move.py`, `jira-sprint.py`, `jira-board.py`, `jira-version.py`, `tempo-account.py`
 **Utility**: `jira-user.py`, `jira-fields.py`, `jira-link.py`, `jira-weblink.py`, `jira-worklog-query.py`, `jira-watchers.py`, `jira-qa-gather.py`
 
 ## Execution Style
@@ -52,8 +52,15 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-transition.py do PROJ-123 "In P
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-worklog.py add PROJ-123 2h --comment "Work done"
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py issue PROJ "Summary" --type Task
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-attachment.py add PROJ-123 screenshot.png
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py project PROJ "Project Name" --from-project OTHERPROJ --lead jdoe
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/tempo-account.py account link 42 PROJ --default
 ```
 
+> **Admin-scope commands**: `jira-create.py project` and `tempo-account.py` exercise
+> Jira Administrator / Tempo Administrator rights on whichever PAT is configured. On
+> Jira Server a PAT carries the full permission set of the user who created it — check
+> before running these against an instance where that is not expected.
+>
 > **Terminal transitions**: always pass `--resolution <value>` (e.g. `Done`, `Won't do`, `Duplicate`) or the
 > resolution field stays empty and the ticket appears unresolved. See `references/intent-verbs.md`.
 

--- a/skills/jira-communication/references/creation.md
+++ b/skills/jira-communication/references/creation.md
@@ -45,3 +45,12 @@ Sprint ID is an integer, not an array. Epic Link is the epic's issue key as a st
 ## Combining flags
 
 `--fields-json` wins over typed flags (`--assignee`, `--priority`, `--labels`, `--reporter`, `--components`) when the same field is set in both — the script merges the JSON payload onto the typed-flag payload (`fields.update(extra_fields)`). Use typed flags for the fields the CLI exposes directly, and reach for `--fields-json` only for the long tail.
+
+## Admin-scope commands: `jira-create.py project` and `tempo-account.py`
+
+```bash
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py project PROJ "Project Name" --from-project OTHERPROJ --lead jdoe
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/tempo-account.py account link 42 PROJ --default
+```
+
+These exercise Jira Administrator / Tempo Administrator rights on whichever PAT is configured. On Jira Server a PAT carries the full permission set of the user who created it, so there is no separate, narrower credential for this — check before running these against an instance where that scope is not expected.

--- a/skills/jira-communication/scripts/workflow/jira-create.py
+++ b/skills/jira-communication/scripts/workflow/jira-create.py
@@ -189,5 +189,129 @@ def issue(
         sys.exit(1)
 
 
+@cli.command()
+@click.argument("key")
+@click.argument("name")
+@click.option(
+    "--from-project",
+    "source_project",
+    required=True,
+    help="Key or ID of an existing project whose configuration (schemes) to copy",
+)
+@click.option("--lead", required=True, help="Username of the new project's lead")
+@click.option(
+    "--bootstrap-issues",
+    is_flag=True,
+    help="Create the XXX-1/2/3 config-hub/PM-epic/deployment-epic issues after project creation",
+)
+@click.option("--dry-run", is_flag=True, help="Show what would be created without making changes")
+@click.pass_context
+def project(
+    ctx,
+    key: str,
+    name: str,
+    source_project: str,
+    lead: str,
+    bootstrap_issues: bool,
+    dry_run: bool,
+):
+    """Create a new Jira project by copying configuration from an existing project.
+
+    KEY: The new project's key (e.g., LSB)
+
+    NAME: The new project's display name (e.g., "Landessportbund Sachsen")
+
+    Uses Jira's "shared configuration" mechanism (the same one behind the UI's
+    "Share settings with an existing project" option) to copy the permission,
+    notification and workflow schemes from --from-project, so the new project
+    matches an existing convention without manually specifying scheme IDs.
+
+    Examples:
+
+      jira-create project LSB "Landessportbund Sachsen" --from-project OPSFX --lead thomas.wilhelm
+
+      jira-create project OPSLSB "LSB Operations" --from-project OPSFX --lead tobias.hein --bootstrap-issues
+    """
+    client = ctx.obj["client"]
+
+    try:
+        source = client.project(source_project)
+    except Exception as e:
+        error(f"Could not resolve --from-project '{source_project}': {e}")
+        sys.exit(1)
+
+    source_id = source.get("id") if isinstance(source, dict) else None
+    if not source_id:
+        error(f"Project '{source_project}' has no numeric id in the API response")
+        sys.exit(1)
+
+    if dry_run:
+        warning("DRY RUN - No project will be created")
+        print("\nWould create project:")
+        print(f"  Key: {key}")
+        print(f"  Name: {name}")
+        print(f"  Lead: {lead}")
+        print(f"  Copying schemes from: {source_project} (id={source_id})")
+        if bootstrap_issues:
+            print(
+                f"  Would create bootstrap issues: {key}-1 (Config Hub), {key}-2 (PM Epic), {key}-3 (Deployment Epic)"
+            )
+        return
+
+    try:
+        result = client.create_project_from_shared_template(source_id, key, name, lead)
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to create project: {e}")
+        sys.exit(1)
+
+    if ctx.obj["quiet"]:
+        print(key)
+    elif ctx.obj["json"]:
+        format_output(result, as_json=True)
+    else:
+        success(f"Created project: {key}")
+        print(f"  Name: {name}")
+        print(f"  Lead: {lead}")
+        print(f"  Configuration copied from: {source_project}")
+        print(f"  URL: {client.url}/browse/{key}")
+
+    if bootstrap_issues:
+        _create_bootstrap_issues(client, key, ctx.obj)
+
+
+def _create_bootstrap_issues(client, project_key: str, ctx_obj: dict) -> None:
+    """Create the XXX-1/2/3 convention issues (Config Hub, PM Epic, Deployment Epic).
+
+    Matches the NR-wide "New project structure — first issues" convention
+    (netresearch-jira skill, references/_global/project-routing.md). Each
+    creation is independent — a failure on one (e.g. an unavailable "Epic"
+    issue type) only warns, it does not abort the other two or the project
+    creation that already succeeded.
+    """
+    specs = [
+        (
+            "Task",
+            f"{project_key} — Project Config Hub",
+            "Mail-Handler-Adressen, Matrix-Webhook-URL und weitere Projekt-Einstellungen.",
+        ),
+        ("Epic", f"{project_key} — Project Management", "Sammel-Epic fuer Projektmanagement-Aufgaben."),
+        ("Epic", f"{project_key} — Deployment", "Sammel-Epic fuer Deployment-/Release-Aufgaben."),
+    ]
+    for issue_type, summary, description in specs:
+        fields = {
+            "project": {"key": project_key},
+            "summary": summary,
+            "issuetype": {"name": issue_type},
+            "description": description,
+        }
+        try:
+            result = client.create_issue(fields=fields)
+            success(f"Created {result['key']}: {summary}")
+        except Exception as e:
+            warning(f"Could not create bootstrap issue '{summary}': {e}")
+
+
 if __name__ == "__main__":
     cli()

--- a/skills/jira-communication/scripts/workflow/tempo-account.py
+++ b/skills/jira-communication/scripts/workflow/tempo-account.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "atlassian-python-api>=3.41.0,<4",
+#     "click>=8.1.0,<9",
+# ]
+# ///
+"""Tempo Accounts (Server/DC) - create customers/accounts and link them to projects.
+
+Tempo Accounts is a Jira plugin (rest/tempo-accounts/1/*), reachable with the
+same Jira Personal Access Token this skill already uses elsewhere - no
+separate credential. Requires the Tempo "Manage Accounts" permission, which
+is independent of plain Jira project permissions.
+"""
+
+import sys
+from pathlib import Path
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Shared library import (TR1.1.1 - PYTHONPATH approach)
+# ═══════════════════════════════════════════════════════════════════════════════
+_script_dir = Path(__file__).parent
+_lib_path = _script_dir.parent / "lib"
+if _lib_path.exists():
+    sys.path.insert(0, str(_lib_path.parent))
+
+import click
+from lib.client import LazyJiraClient
+from lib.output import error, format_output, success, warning
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CLI Definition
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@click.group()
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.option("--quiet", "-q", is_flag=True, help="Minimal output (just the created key/id)")
+@click.option("--env-file", type=click.Path(), help="Environment file path")
+@click.option("--profile", "-P", help="Jira profile name from ~/.jira/profiles.json")
+@click.option("--debug", is_flag=True, help="Show debug information on errors")
+@click.pass_context
+def cli(ctx, output_json: bool, quiet: bool, env_file: str | None, profile: str | None, debug: bool):
+    """Tempo Accounts management.
+
+    Create Tempo customers/accounts and link an account to a Jira project.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj["json"] = output_json
+    ctx.obj["quiet"] = quiet
+    ctx.obj["debug"] = debug
+    ctx.obj["client"] = LazyJiraClient(env_file=env_file, profile=profile)
+
+
+@cli.group()
+def customer():
+    """Tempo customer (billing entity) management."""
+
+
+@customer.command("create")
+@click.argument("key")
+@click.argument("name")
+@click.option("--dry-run", is_flag=True, help="Show what would be created without making changes")
+@click.pass_context
+def customer_create(ctx, key: str, name: str, dry_run: bool):
+    """Create a new Tempo customer.
+
+    KEY: Short, stable customer key (e.g., LSB)
+
+    NAME: Full customer display name (e.g., "Landessportbund Sachsen")
+
+    Example:
+
+      tempo-account customer create LSB "Landessportbund Sachsen"
+    """
+    client = ctx.obj["client"]
+
+    if dry_run:
+        warning("DRY RUN - No customer will be created")
+        print("\nWould create Tempo customer:")
+        print(f"  Key: {key}")
+        print(f"  Name: {name}")
+        return
+
+    try:
+        result = client.tempo_account_add_new_customer(key, name)
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to create Tempo customer: {e}")
+        sys.exit(1)
+
+    if ctx.obj["quiet"]:
+        print(key)
+    elif ctx.obj["json"]:
+        format_output(result, as_json=True)
+    else:
+        success(f"Created Tempo customer: {name}")
+        print(f"  Key: {key}")
+
+
+@cli.group()
+def account():
+    """Tempo account (cost-tracking entity) management."""
+
+
+@account.command("create")
+@click.argument("key")
+@click.argument("name")
+@click.option("--lead", required=True, help="Username of the account lead")
+@click.option("--customer-key", required=True, help="Key of an existing Tempo customer this account belongs to")
+@click.option("--dry-run", is_flag=True, help="Show what would be created without making changes")
+@click.pass_context
+def account_create(ctx, key: str, name: str, lead: str, customer_key: str, dry_run: bool):
+    """Create a new Tempo account.
+
+    KEY: Short, stable account key (e.g., LSB)
+
+    NAME: Full account display name (e.g., "Landessportbund Sachsen")
+
+    Requires an existing Tempo customer (see: tempo-account customer create).
+
+    Example:
+
+      tempo-account account create LSB "Landessportbund Sachsen" --lead tobias.hein --customer-key LSB
+    """
+    client = ctx.obj["client"]
+
+    data = {
+        "key": key,
+        "name": name,
+        "lead": {"name": lead},
+        "customer": {"key": customer_key},
+    }
+
+    if dry_run:
+        warning("DRY RUN - No account will be created")
+        print("\nWould create Tempo account:")
+        print(f"  Key: {key}")
+        print(f"  Name: {name}")
+        print(f"  Lead: {lead}")
+        print(f"  Customer: {customer_key}")
+        return
+
+    try:
+        result = client.tempo_account_add_account(data)
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to create Tempo account: {e}")
+        sys.exit(1)
+
+    if ctx.obj["quiet"]:
+        account_id = result.get("id") if isinstance(result, dict) else None
+        print(account_id if account_id is not None else key)
+    elif ctx.obj["json"]:
+        format_output(result, as_json=True)
+    else:
+        success(f"Created Tempo account: {name}")
+        print(f"  Key: {key}")
+        print(f"  Lead: {lead}")
+        print(f"  Customer: {customer_key}")
+        if isinstance(result, dict) and result.get("id") is not None:
+            print(f"  Account ID: {result['id']}")
+            print("  Note: use this Account ID with 'tempo-account account link' to attach it to a project.")
+
+
+@account.command("link")
+@click.argument("account_id", type=int)
+@click.argument("project_key")
+@click.option("--default", "default_account", is_flag=True, help="Mark this as the project's default account")
+@click.option("--dry-run", is_flag=True, help="Show what would be linked without making changes")
+@click.pass_context
+def account_link(ctx, account_id: int, project_key: str, default_account: bool, dry_run: bool):
+    """Link an existing Tempo account to a Jira project.
+
+    ACCOUNT_ID: Numeric Tempo account id (printed by 'account create')
+
+    PROJECT_KEY: Key of the Jira project to link the account to (e.g., LSB)
+
+    Example:
+
+      tempo-account account link 42 LSB --default
+    """
+    client = ctx.obj["client"]
+
+    try:
+        project = client.project(project_key)
+    except Exception as e:
+        error(f"Could not resolve project '{project_key}': {e}")
+        sys.exit(1)
+
+    project_id = project.get("id") if isinstance(project, dict) else None
+    if not project_id:
+        error(f"Project '{project_key}' has no numeric id in the API response")
+        sys.exit(1)
+
+    if dry_run:
+        warning("DRY RUN - No link will be created")
+        print("\nWould link Tempo account to project:")
+        print(f"  Account ID: {account_id}")
+        print(f"  Project: {project_key} (id={project_id})")
+        print(f"  Default account: {default_account}")
+        return
+
+    try:
+        result = client.tempo_account_associate_with_jira_project(
+            account_id, project_id, default_account=default_account
+        )
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to link Tempo account to project: {e}")
+        sys.exit(1)
+
+    if ctx.obj["quiet"]:
+        print(project_key)
+    elif ctx.obj["json"]:
+        format_output(result, as_json=True)
+    else:
+        success(f"Linked Tempo account {account_id} to project {project_key}")
+        if default_account:
+            print("  Marked as default account")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -30,6 +30,7 @@ _watchers_mod = load_script("jira-watchers", "utility")
 _version_mod = load_script("jira-version", "workflow")
 _qa_gather_mod = load_script("jira-qa-gather", "utility")
 _move_mod = load_script("jira-move", "workflow")
+_tempo_account_mod = load_script("tempo-account", "workflow")
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -61,6 +62,10 @@ class TestHelpOutput:
     def test_create_help(self):
         output = self._run_help(_create_mod.cli)
         assert "create" in output.lower() or "issue" in output.lower()
+
+    def test_tempo_account_help(self):
+        output = self._run_help(_tempo_account_mod.cli)
+        assert "tempo" in output.lower() or "account" in output.lower()
 
     def test_transition_help(self):
         output = self._run_help(_transition_mod.cli)

--- a/tests/test_project_and_tempo_create.py
+++ b/tests/test_project_and_tempo_create.py
@@ -1,0 +1,265 @@
+"""Tests for jira-create's `project` command and the tempo-account script.
+
+Follows the same `mock.patch("lib.client.get_jira_client", ...)` pattern used
+by the existing dry-run tests in test_cli_smoke.py's TestMockedCommands: the
+LazyJiraClient wrapper stays real, only the underlying client factory is
+swapped for a mock, so `ctx.obj["client"].project(...)` etc. resolve through
+the wrapper exactly as they would against a live Jira instance.
+"""
+
+from unittest import mock
+
+import click.testing
+from conftest import load_script
+
+_create_mod = load_script("jira-create", "workflow")
+_tempo_mod = load_script("tempo-account", "workflow")
+
+
+def _make_mock_client(url: str = "https://jira.example.com", **attrs):
+    mc = mock.Mock()
+    mc.url = url
+    for key, value in attrs.items():
+        setattr(mc, key, value)
+    return mc
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# jira-create project
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestProjectCreate:
+    def test_project_dry_run_resolves_source_but_does_not_create(self):
+        """Dry-run still resolves --from-project (read-only) but must not call
+        create_project_from_shared_template — same convention as jira-link's
+        dry-run resolving the link type without creating the link."""
+        mock_client = _make_mock_client()
+        mock_client.project.return_value = {"id": 10101}
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _create_mod.cli,
+                [
+                    "project",
+                    "LSB",
+                    "Landessportbund Sachsen",
+                    "--from-project",
+                    "OPSFX",
+                    "--lead",
+                    "tobias.hein",
+                    "--dry-run",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        mock_client.project.assert_called_once_with("OPSFX")
+        mock_client.create_project_from_shared_template.assert_not_called()
+
+    def test_project_create_success(self):
+        mock_client = _make_mock_client()
+        mock_client.project.return_value = {"id": 10101}
+        mock_client.create_project_from_shared_template.return_value = {"key": "LSB", "id": 20202}
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _create_mod.cli,
+                ["project", "LSB", "Landessportbund Sachsen", "--from-project", "OPSFX", "--lead", "tobias.hein"],
+            )
+        assert result.exit_code == 0, result.output
+        mock_client.create_project_from_shared_template.assert_called_once_with(
+            10101, "LSB", "Landessportbund Sachsen", "tobias.hein"
+        )
+        assert "LSB" in result.output
+
+    def test_project_create_unresolvable_source_errors_out(self):
+        mock_client = _make_mock_client()
+        mock_client.project.side_effect = Exception("404 project not found")
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _create_mod.cli,
+                [
+                    "project",
+                    "LSB",
+                    "Landessportbund Sachsen",
+                    "--from-project",
+                    "DOES-NOT-EXIST",
+                    "--lead",
+                    "tobias.hein",
+                ],
+            )
+        assert result.exit_code != 0
+        mock_client.create_project_from_shared_template.assert_not_called()
+
+    def test_project_create_with_bootstrap_issues(self):
+        mock_client = _make_mock_client()
+        mock_client.project.return_value = {"id": 10101}
+        mock_client.create_project_from_shared_template.return_value = {"key": "LSB", "id": 20202}
+        mock_client.create_issue.side_effect = [
+            {"key": "LSB-1"},
+            {"key": "LSB-2"},
+            {"key": "LSB-3"},
+        ]
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _create_mod.cli,
+                [
+                    "project",
+                    "LSB",
+                    "Landessportbund Sachsen",
+                    "--from-project",
+                    "OPSFX",
+                    "--lead",
+                    "tobias.hein",
+                    "--bootstrap-issues",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_client.create_issue.call_count == 3
+        for call in mock_client.create_issue.call_args_list:
+            assert call.kwargs["fields"]["project"] == {"key": "LSB"}
+
+    def test_project_create_bootstrap_issue_failure_does_not_abort(self):
+        """One failing bootstrap issue only warns — the project creation that
+        already succeeded, and the other two issues, are unaffected."""
+        mock_client = _make_mock_client()
+        mock_client.project.return_value = {"id": 10101}
+        mock_client.create_project_from_shared_template.return_value = {"key": "LSB", "id": 20202}
+        mock_client.create_issue.side_effect = [
+            {"key": "LSB-1"},
+            Exception("issue type Epic not available"),
+            {"key": "LSB-3"},
+        ]
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _create_mod.cli,
+                [
+                    "project",
+                    "LSB",
+                    "Landessportbund Sachsen",
+                    "--from-project",
+                    "OPSFX",
+                    "--lead",
+                    "tobias.hein",
+                    "--bootstrap-issues",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_client.create_issue.call_count == 3
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# tempo-account customer create
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestTempoCustomerCreate:
+    def test_customer_create_dry_run(self):
+        mock_client = _make_mock_client()
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _tempo_mod.cli, ["customer", "create", "LSB", "Landessportbund Sachsen", "--dry-run"]
+            )
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        mock_client.tempo_account_add_new_customer.assert_not_called()
+
+    def test_customer_create_success(self):
+        mock_client = _make_mock_client()
+        mock_client.tempo_account_add_new_customer.return_value = {"key": "LSB", "id": 55}
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_tempo_mod.cli, ["customer", "create", "LSB", "Landessportbund Sachsen"])
+        assert result.exit_code == 0, result.output
+        mock_client.tempo_account_add_new_customer.assert_called_once_with("LSB", "Landessportbund Sachsen")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# tempo-account account create / link
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestTempoAccountCreate:
+    def test_account_create_dry_run(self):
+        mock_client = _make_mock_client()
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _tempo_mod.cli,
+                [
+                    "account",
+                    "create",
+                    "LSB",
+                    "Landessportbund Sachsen",
+                    "--lead",
+                    "tobias.hein",
+                    "--customer-key",
+                    "LSB",
+                    "--dry-run",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        mock_client.tempo_account_add_account.assert_not_called()
+
+    def test_account_create_success_payload_shape(self):
+        mock_client = _make_mock_client()
+        mock_client.tempo_account_add_account.return_value = {"id": 42, "key": "LSB"}
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _tempo_mod.cli,
+                [
+                    "account",
+                    "create",
+                    "LSB",
+                    "Landessportbund Sachsen",
+                    "--lead",
+                    "tobias.hein",
+                    "--customer-key",
+                    "LSB",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_client.tempo_account_add_account.assert_called_once_with(
+            {
+                "key": "LSB",
+                "name": "Landessportbund Sachsen",
+                "lead": {"name": "tobias.hein"},
+                "customer": {"key": "LSB"},
+            }
+        )
+        assert "42" in result.output
+
+    def test_account_link_dry_run(self):
+        mock_client = _make_mock_client()
+        mock_client.project.return_value = {"id": 10101}
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_tempo_mod.cli, ["account", "link", "42", "LSB", "--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "DRY RUN" in result.output
+        mock_client.tempo_account_associate_with_jira_project.assert_not_called()
+
+    def test_account_link_success(self):
+        mock_client = _make_mock_client()
+        mock_client.project.return_value = {"id": 10101}
+        mock_client.tempo_account_associate_with_jira_project.return_value = {"id": 999}
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_tempo_mod.cli, ["account", "link", "42", "LSB", "--default"])
+        assert result.exit_code == 0, result.output
+        mock_client.tempo_account_associate_with_jira_project.assert_called_once_with(42, 10101, default_account=True)
+
+    def test_account_link_unresolvable_project_errors_out(self):
+        mock_client = _make_mock_client()
+        mock_client.project.side_effect = Exception("404 project not found")
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(_tempo_mod.cli, ["account", "link", "42", "DOES-NOT-EXIST"])
+        assert result.exit_code != 0
+        mock_client.tempo_account_associate_with_jira_project.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `jira-create.py project` — creates a Jira project via the shared-configuration mechanism (copies permission/notification/workflow schemes from an existing project), with an optional `--bootstrap-issues` flag for the XXX-1/2/3 convention (Config Hub / PM Epic / Deployment Epic).
- Add `tempo-account.py` (`customer create`, `account create`, `account link`) wrapping atlassian-python-api's existing Tempo Accounts helpers.
- Both reuse the existing Jira PAT — verified it already carries `ADMINISTER` and all four `GLOBAL_TEMPO_*_ADMINISTRATOR` permissions, so no new credential is introduced.
- Documents the new commands in SKILL.md (Scripts list + Basic Usage examples + admin-scope caveat).

## Test plan
- [x] `pytest tests/` — 782 passed (13 new: dry-run, success path, error handling, bootstrap-issues partial failure)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `bandit` — no findings
- [x] `markdownlint-cli2` on SKILL.md — clean
- [x] `scripts/verify-harness.sh` — Level 3 COMPLETE

NRFE-3971