### PR TITLE
chore(release): v3.22.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.21.1",
+  "version": "3.22.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.22.0] - 2026-07-25
+
+### Added
+
+- `jira-communication`: `jira-create.py project` creates a new Jira project by copying the permission/notification/workflow schemes from an existing project, with an optional `--bootstrap-issues` flag for the XXX-1/2/3 (config hub, PM epic, deployment epic) convention ([#165](https://github.com/netresearch/jira-skill/pull/165)).
+- `jira-communication`: new `tempo-account.py` script (`customer create`, `account create`, `account link`) wrapping Tempo Accounts management ([#165](https://github.com/netresearch/jira-skill/pull/165)).
+
+### Documentation
+
+- `jira-syntax`: documented that validation gates the post — run it as its own step, never chained with the posting command ([#164](https://github.com/netresearch/jira-skill/pull/164)).
+- `jira-communication`: documented clearing a field via `--fields-json` with an explicit `null` (typed flags like `--assignee ""` are a no-op) ([#164](https://github.com/netresearch/jira-skill/pull/164)).
+
+## [3.21.1] - 2026-07-18
+
+### Documentation
+
+- `jira-communication`: `issue-editing.md`'s reference-index entry now points to `--fields-json` for custom-field updates, so it is found before guessing a non-existent `--field` flag ([#158](https://github.com/netresearch/jira-skill/pull/158)).
+
+## [3.21.0] - 2026-07-16
+
+### Added
+
+- `jira-communication`: wiki-markup lint flags inline emphasis (`*bold*`, `_italic_`) glued mid-word, where Jira does not render it ([#160](https://github.com/netresearch/jira-skill/pull/160)).
+
+### Documentation
+
+- `jira-communication`: documented that `jira-search.py` query-subcommand options (`-f`, `-n`, `--order-by`) must come after `query`, not before it ([#161](https://github.com/netresearch/jira-skill/pull/161)).
+
 ## [3.20.0] - 2026-07-13
 
 ### Added

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.21.1"
+  version: "3.22.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.21.1"
+  version: "3.22.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Prepare release v3.22.0 (minor: new project/Tempo account management since v3.21.1).

## Changes since v3.21.1
- #165 feat(workflow): add project creation and Tempo Accounts management
- #164 docs: validation is a gate; document clearing a field

## Release prep
- Backfilled missing 3.21.0 / 3.21.1 CHANGELOG entries
- Added 3.22.0 CHANGELOG entry
- Bumped version: `.claude-plugin/plugin.json`, both `SKILL.md` files (3 files, version only)