### PR TITLE
chore(release): v3.22.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.22.1] - 2026-07-26
+
 ### Fixed
 
 - `jira-communication`: `jira-create.py project --bootstrap-issues` failed to create both Epic-type issues ("Epic Name is required") — this Jira instance requires the Epic Name custom field, which wasn't being set. Now populated automatically from the issue summary.

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.22.0"
+  version: "3.22.1"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.22.0"
+  version: "3.22.1"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Bumps plugin.json and both SKILL.md files from 3.22.0 to 3.22.1 (patch — bugfix). Moves the Unreleased changelog entry under `## [3.22.1] - 2026-07-26` for the jira-create.py fixes from #167.