### PR TITLE
feat(jira-create): use Issue Number One type for the bootstrap ticket, drop epics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `jira-communication`: `jira-create.py project --bootstrap-issues` now creates only the XXX-1 config-hub issue, using this Jira instance's dedicated "Issue Number One" issue type (summary "Projektmanagement") instead of a plain Task — falls back to Task if a `--from-project` template's issue type scheme doesn't include it. No longer auto-creates a PM Epic or Deployment Epic (dropped as unnecessary bootstrap overhead — create them by hand if a project actually needs them).
+
 ## [3.22.1] - 2026-07-26
 
 ### Fixed

--- a/skills/jira-communication/scripts/workflow/jira-create.py
+++ b/skills/jira-communication/scripts/workflow/jira-create.py
@@ -344,20 +344,22 @@ def _create_bootstrap_issues(client, project_key: str, ctx_obj: dict) -> None:
     matters more than its exact type.
     """
     config_hub_description = "Mail-Handler-Adressen, Matrix-Webhook-URL und weitere Projekt-Einstellungen."
-    config_hub_fields = {
-        "project": {"key": project_key},
-        "summary": "Projektmanagement",
-        "issuetype": {"name": "Issue Number One"},
-        "description": config_hub_description,
-    }
+
+    def _config_hub_fields(issue_type: str) -> dict:
+        return {
+            "project": {"key": project_key},
+            "summary": "Projektmanagement",
+            "issuetype": {"name": issue_type},
+            "description": config_hub_description,
+        }
+
     try:
-        result = client.create_issue(fields=config_hub_fields)
+        result = client.create_issue(fields=_config_hub_fields("Issue Number One"))
         success(f"Created {result['key']}: Projektmanagement")
     except Exception as e:
         warning(f"'Issue Number One' type unavailable, falling back to Task: {e}")
-        config_hub_fields["issuetype"] = {"name": "Task"}
         try:
-            result = client.create_issue(fields=config_hub_fields)
+            result = client.create_issue(fields=_config_hub_fields("Task"))
             success(f"Created {result['key']}: Projektmanagement")
         except Exception as e2:
             warning(f"Could not create bootstrap issue 'Projektmanagement': {e2}")

--- a/skills/jira-communication/scripts/workflow/jira-create.py
+++ b/skills/jira-communication/scripts/workflow/jira-create.py
@@ -202,7 +202,7 @@ def issue(
 @click.option(
     "--bootstrap-issues",
     is_flag=True,
-    help="Create the XXX-1/2/3 config-hub/PM-epic/deployment-epic issues after project creation",
+    help="Create the XXX-1 config-hub issue ('Projektmanagement') after project creation",
 )
 @click.option(
     "--force",
@@ -278,9 +278,7 @@ def project(
         print(f"  Lead: {lead}")
         print(f"  Copying schemes from: {source_project} (id={source_id})")
         if bootstrap_issues:
-            print(
-                f"  Would create bootstrap issues: {key}-1 (Config Hub), {key}-2 (PM Epic), {key}-3 (Deployment Epic)"
-            )
+            print(f"  Would create bootstrap issue: {key}-1 (Projektmanagement, Issue Number One)")
         return
 
     try:
@@ -333,42 +331,36 @@ def _check_key_collision(client, key: str) -> str | None:
 
 
 def _create_bootstrap_issues(client, project_key: str, ctx_obj: dict) -> None:
-    """Create the XXX-1/2/3 convention issues (Config Hub, PM Epic, Deployment Epic).
+    """Create the XXX-1 convention issue (Config Hub / "Projektmanagement").
 
-    Matches the NR-wide "New project structure — first issues" convention
-    (netresearch-jira skill, references/_global/project-routing.md). Each
-    creation is independent — a failure on one (e.g. an unavailable "Epic"
-    issue type) only warns, it does not abort the other two or the project
-    creation that already succeeded.
+    Matches the NR-wide "New project structure — first issue" convention
+    (netresearch-jira skill, references/_global/project-routing.md).
 
-    Epic-type issues additionally require the "Epic Name" custom field
-    (customfield_10581 on this Jira instance) — Epic creation fails without
-    it even though it isn't part of the visible create-screen fields.
+    Uses this instance's dedicated "Issue Number One" issue type
+    (purpose-built for exactly this "config hub" role) rather than a plain
+    Task, with summary "Projektmanagement" per NR convention. Falls back to
+    Task if a --from-project template's issue type scheme doesn't include
+    it — issue type schemes vary per template and this issue existing at all
+    matters more than its exact type.
     """
-    EPIC_NAME_FIELD = "customfield_10581"
-    specs = [
-        (
-            "Task",
-            f"{project_key} — Project Config Hub",
-            "Mail-Handler-Adressen, Matrix-Webhook-URL und weitere Projekt-Einstellungen.",
-        ),
-        ("Epic", f"{project_key} — Project Management", "Sammel-Epic fuer Projektmanagement-Aufgaben."),
-        ("Epic", f"{project_key} — Deployment", "Sammel-Epic fuer Deployment-/Release-Aufgaben."),
-    ]
-    for issue_type, summary, description in specs:
-        fields = {
-            "project": {"key": project_key},
-            "summary": summary,
-            "issuetype": {"name": issue_type},
-            "description": description,
-        }
-        if issue_type == "Epic":
-            fields[EPIC_NAME_FIELD] = summary
+    config_hub_description = "Mail-Handler-Adressen, Matrix-Webhook-URL und weitere Projekt-Einstellungen."
+    config_hub_fields = {
+        "project": {"key": project_key},
+        "summary": "Projektmanagement",
+        "issuetype": {"name": "Issue Number One"},
+        "description": config_hub_description,
+    }
+    try:
+        result = client.create_issue(fields=config_hub_fields)
+        success(f"Created {result['key']}: Projektmanagement")
+    except Exception as e:
+        warning(f"'Issue Number One' type unavailable, falling back to Task: {e}")
+        config_hub_fields["issuetype"] = {"name": "Task"}
         try:
-            result = client.create_issue(fields=fields)
-            success(f"Created {result['key']}: {summary}")
-        except Exception as e:
-            warning(f"Could not create bootstrap issue '{summary}': {e}")
+            result = client.create_issue(fields=config_hub_fields)
+            success(f"Created {result['key']}: Projektmanagement")
+        except Exception as e2:
+            warning(f"Could not create bootstrap issue 'Projektmanagement': {e2}")
 
 
 if __name__ == "__main__":

--- a/tests/test_project_and_tempo_create.py
+++ b/tests/test_project_and_tempo_create.py
@@ -98,8 +98,6 @@ class TestProjectCreate:
         mock_client.create_project_from_shared_template.return_value = {"key": "LSB", "id": 20202}
         mock_client.create_issue.side_effect = [
             {"key": "LSB-1"},
-            {"key": "LSB-2"},
-            {"key": "LSB-3"},
         ]
         runner = click.testing.CliRunner()
         with mock.patch("lib.client.get_jira_client", return_value=mock_client):
@@ -117,20 +115,21 @@ class TestProjectCreate:
                 ],
             )
         assert result.exit_code == 0, result.output
-        assert mock_client.create_issue.call_count == 3
-        for call in mock_client.create_issue.call_args_list:
-            assert call.kwargs["fields"]["project"] == {"key": "LSB"}
+        assert mock_client.create_issue.call_count == 1
+        call = mock_client.create_issue.call_args_list[0]
+        assert call.kwargs["fields"]["project"] == {"key": "LSB"}
+        assert call.kwargs["fields"]["issuetype"] == {"name": "Issue Number One"}
+        assert call.kwargs["fields"]["summary"] == "Projektmanagement"
 
-    def test_project_create_bootstrap_issue_failure_does_not_abort(self):
-        """One failing bootstrap issue only warns — the project creation that
-        already succeeded, and the other two issues, are unaffected."""
+    def test_project_create_bootstrap_issue_falls_back_to_task(self):
+        """If 'Issue Number One' isn't in the --from-project template's issue
+        type scheme, retries once with Task rather than losing the issue."""
         mock_client = _make_mock_client()
         mock_client.project.return_value = {"id": 10101}
         mock_client.create_project_from_shared_template.return_value = {"key": "LSB", "id": 20202}
         mock_client.create_issue.side_effect = [
+            Exception("issue type Issue Number One not available"),
             {"key": "LSB-1"},
-            Exception("issue type Epic not available"),
-            {"key": "LSB-3"},
         ]
         runner = click.testing.CliRunner()
         with mock.patch("lib.client.get_jira_client", return_value=mock_client):
@@ -148,7 +147,39 @@ class TestProjectCreate:
                 ],
             )
         assert result.exit_code == 0, result.output
-        assert mock_client.create_issue.call_count == 3
+        assert mock_client.create_issue.call_count == 2
+        first_call, second_call = mock_client.create_issue.call_args_list
+        assert first_call.kwargs["fields"]["issuetype"] == {"name": "Issue Number One"}
+        assert second_call.kwargs["fields"]["issuetype"] == {"name": "Task"}
+        assert second_call.kwargs["fields"]["summary"] == "Projektmanagement"
+
+    def test_project_create_bootstrap_issue_failure_does_not_abort(self):
+        """Both attempts (Issue Number One, then Task fallback) failing only
+        warns — the project creation that already succeeded is unaffected."""
+        mock_client = _make_mock_client()
+        mock_client.project.return_value = {"id": 10101}
+        mock_client.create_project_from_shared_template.return_value = {"key": "LSB", "id": 20202}
+        mock_client.create_issue.side_effect = [
+            Exception("issue type Issue Number One not available"),
+            Exception("issue type Task not available either"),
+        ]
+        runner = click.testing.CliRunner()
+        with mock.patch("lib.client.get_jira_client", return_value=mock_client):
+            result = runner.invoke(
+                _create_mod.cli,
+                [
+                    "project",
+                    "LSB",
+                    "Landessportbund Sachsen",
+                    "--from-project",
+                    "OPSFX",
+                    "--lead",
+                    "tobias.hein",
+                    "--bootstrap-issues",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_client.create_issue.call_count == 2
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- `jira-create.py project --bootstrap-issues` now creates the config-hub ticket using this Jira instance's dedicated **"Issue Number One"** issue type (summary "Projektmanagement") instead of a plain Task summarized "KEY — Project Config Hub". Falls back to Task if a `--from-project` template's issue type scheme doesn't include it.
- Drops the PM Epic and Deployment Epic from the bootstrap flow entirely (per user request — unnecessary overhead). Create them by hand if a specific project actually needs them.
- Cross-repo doc updates in the same spirit: `netresearch-jira-skill`'s `project-routing.md` and `dxp-project-init`'s `phase0.md`/`phase1.md` updated to match (separate PRs).

## Test plan

- [x] Live-verified against jira.netresearch.de with a disposable test project (`ZZTEST99`, deleted after): `--dry-run` shows the single bootstrap issue correctly; real creation produces exactly one issue of type "Issue Number One" with summary "Projektmanagement"; project + issue cleaned up afterward
- [x] ruff format/check clean
- [x] markdownlint clean