### PR TITLE
chore(release): v3.23.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.22.1",
+  "version": "3.23.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.23.0] - 2026-07-27
+
 ### Changed
 
 - `jira-communication`: `jira-create.py project --bootstrap-issues` now creates only the XXX-1 config-hub issue, using this Jira instance's dedicated "Issue Number One" issue type (summary "Projektmanagement") instead of a plain Task — falls back to Task if a `--from-project` template's issue type scheme doesn't include it. No longer auto-creates a PM Epic or Deployment Epic (dropped as unnecessary bootstrap overhead — create them by hand if a project actually needs them).

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.22.1"
+  version: "3.23.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.22.1"
+  version: "3.23.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Bumps plugin.json and both SKILL.md files from 3.22.1 to 3.23.0 (minor — behavior change). Moves the Unreleased changelog entry under `## [3.23.0] - 2026-07-27` for the Issue Number One bootstrap change from #169.