### PR TITLE
chore: release v3.23.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.23.1] - 2026-07-30
+
 ### Fixed
 
 - `jira-communication`: `jira-create.py project --bootstrap-issues` printed its `✓ Created KEY-1: Projektmanagement` line to stdout even under `--json` / `--quiet`, so the JSON payload failed to parse (`json.loads` → "Extra data") and `--quiet` emitted two lines instead of the project key. `_create_bootstrap_issues` accepted the context dict but never consulted it; it now suppresses the line in both modes. Covered by two regression tests.
@@ -726,7 +728,19 @@ First stable release providing comprehensive Jira integration through Claude Cod
 - [Claude Code Marketplace](https://github.com/netresearch/claude-code-marketplace)
 - [Jira Wiki Markup Reference](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
 
-[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.17.0...HEAD
+[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.23.1...HEAD
+[3.23.1]: https://github.com/netresearch/jira-skill/compare/v3.23.0...v3.23.1
+[3.23.0]: https://github.com/netresearch/jira-skill/compare/v3.22.1...v3.23.0
+[3.22.1]: https://github.com/netresearch/jira-skill/compare/v3.22.0...v3.22.1
+[3.22.0]: https://github.com/netresearch/jira-skill/compare/v3.21.1...v3.22.0
+[3.21.1]: https://github.com/netresearch/jira-skill/compare/v3.21.0...v3.21.1
+[3.21.0]: https://github.com/netresearch/jira-skill/compare/v3.20.0...v3.21.0
+[3.20.0]: https://github.com/netresearch/jira-skill/compare/v3.19.0...v3.20.0
+[3.19.0]: https://github.com/netresearch/jira-skill/compare/v3.18.3...v3.19.0
+[3.18.3]: https://github.com/netresearch/jira-skill/compare/v3.18.2...v3.18.3
+[3.18.2]: https://github.com/netresearch/jira-skill/compare/v3.18.1...v3.18.2
+[3.18.1]: https://github.com/netresearch/jira-skill/compare/v3.18.0...v3.18.1
+[3.18.0]: https://github.com/netresearch/jira-skill/compare/v3.17.0...v3.18.0
 [3.17.0]: https://github.com/netresearch/jira-skill/compare/v3.16.0...v3.17.0
 [3.16.0]: https://github.com/netresearch/jira-skill/compare/v3.15.0...v3.16.0
 [3.15.0]: https://github.com/netresearch/jira-skill/compare/v3.14.0...v3.15.0

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.23.0"
+  version: "3.23.1"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.23.0"
+  version: "3.23.1"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Patch release. Version bumped in the four files this repo's releases touch: `.claude-plugin/plugin.json` and both `skills/*/SKILL.md` (CI validates parity), plus the CHANGELOG.

## Contents

**Fixed**
- `jira-create.py project --bootstrap-issues` printed its `✓ Created KEY-1` line to stdout even under `--json` / `--quiet`, making the JSON payload unparseable (`json.loads` → "Extra data") and `--quiet` emit two lines. Covered by two mutation-checked regression tests.

**Documentation** — release-workflow gotchas for `jira-communication`: uv/jq stream pollution, `--json` payload shape (bare array, with a per-subcommand shape table), `--resolution` rejection on terminal transition screens, version-rename propagation, and array-field replace semantics. Plus the real pre-commit gates in `AGENTS.md`.

**Chore** — customer and staff identifiers replaced with placeholders across `--help` text, docs and the mocked test fixtures.

All of the above landed in #171.

## CHANGELOG housekeeping

Footer links for **3.18.0 through 3.23.0** were missing (drift since 3.18.0), and `[Unreleased]` still compared against `v3.17.0`. Both backfilled — `check-changelog-links.py` now exits 0 where it previously reported 11 missing links and a stale range.

## Deliberately not changed

`package.json` stays at `0.0.0-source`. The npm package takes its version from the git tag and no prior release bumped it, so `validate-pre-release.sh`'s "version files in sync" FAIL is a false positive against this repo's convention.

## Pre-existing issues found, not addressed here

- **17 of 61 tags are lightweight** (`1.0.0`, `v3.0.0`, `v3.3.0`, `v3.8.0`, …). `validate-pre-release.sh` flags this. Fixing it means retagging published history, so it needs a deliberate decision rather than a release-prep side effect. The v3.23.1 tag will be annotated and signed.
- Nine pre-existing `validate-skill.sh` warnings (README template sections, missing `checkpoints.yaml`).

## Verification

`validate-skill.sh` 0 errors · 785 tests pass · `ruff check` + `ruff format --check` clean · markdownlint clean · harness Level 3, 0 warnings.

## After merge

Tag is **not** created by this PR:

```bash
git checkout main && git pull
git tag -s v3.23.1 -m "v3.23.1"
git push origin v3.23.1
```