### PR TITLE
docs: comment discipline, Server config read tiers, inline-task checkbox limitation

### DIFF
--- a/skills/jira-communication/references/comments.md
+++ b/skills/jira-communication/references/comments.md
@@ -58,3 +58,11 @@ Comments use Jira wiki markup — see the **jira-syntax** skill for formatting.
 ## Markup lint
 
 `add` and `edit` lint the body before posting: inline block tags (`{code}`, `{noformat}`, `{quote}`, `{panel}` are block-level — a tag with other text on the same line opens a block mid-prose) and unbalanced tag counts abort with an error. Escape literal mentions as `\{code\}`. Override with `--force` (findings are then printed as warnings).
+
+## Comment verbosity: depth for the failing path only
+
+Working-path checks get ONE summary line at most; the non-working path gets the depth; obvious/derivable steps are cut entirely. A human reader cannot filter long tables that mostly say "this works" — verbose investigation comments cause overload and force the reader to re-derive what mattered.
+
+## Consolidate progress updates — edit, don't append
+
+When iterative work on one issue produces multiple status updates, edit the prior comment instead of adding a new one. Watchers and QA reviewers are notified per comment and must wade through progress chatter to find the current state. Reserve new comments for genuinely separate story beats that build on (not restate) earlier ones.

--- a/skills/jira-communication/references/fields-and-users.md
+++ b/skills/jira-communication/references/fields-and-users.md
@@ -68,3 +68,13 @@ Prints every issue type the project accepts, including sub-task types. Issue typ
 | UAT / Test instructions | text | QA hand-off notes |
 
 Always confirm the `id` with `jira-fields.py search` on the target instance — custom-field numbering is not portable.
+
+## Jira Server config reads: three access tiers — "no REST to SET" does not mean "no way to READ"
+
+For scheme assignments, mail handlers, components, categories on Jira Server, try in order:
+
+1. **REST with PAT** — workflow/notification/permission/issue-type schemes + associations, components, versions, watchers, role actors, category, lead (`/rest/api/2/project/<KEY>/<resource>`, `/rest/api/2/<scheme>/<id>/associations`).
+2. **Project-level admin HTML with PAT** — screen scheme, issue type screen scheme, anything on `/plugins/servlet/project-config/<KEY>/…`; scheme names are extractable from the returned HTML.
+3. **Site-level admin HTML** (`/secure/admin/…`) — WebSudo-gated: PAT alone gets a 200 with `<title>Administrator Access…</title>` and a password form. Genuinely needs a human. **Detection rule:** a body containing "Administrator Access" means you hit WebSudo, not the data — never trust byte count alone.
+
+Only declare "manual UI check needed" after tiers 1 AND 2 both failed.

--- a/skills/jira-communication/references/troubleshooting.md
+++ b/skills/jira-communication/references/troubleshooting.md
@@ -228,3 +228,7 @@ Scripts auto-detect auth mode:
 - URL containing `.atlassian.net` → Cloud mode
 
 Override with `JIRA_CLOUD=true` or `JIRA_CLOUD=false`.
+
+## `{task}` inline checkboxes cannot be ticked via API
+
+The `{task:id=NN}…{task}` checkboxes in Jira Server descriptions (maintenance tickets) store their state in a plugin database, not in the description text. The endpoint (`/rest/inline-tasks/1.0/task/<id>`) rejects PAT/Bearer auth — it redirects to `login.jsp` (session cookie required); PUT returns 405. When closing such a ticket, never leave the boxes silently unticked: hand the one-click UI step to the human explicitly ("please tick the checkboxes in the browser") as a fixed part of the closing checklist, alongside the worklog booking.


### PR DESCRIPTION
## What

Four promoted learnings (`/retro promote`, batch 7):

- **`comments.md`**: verbosity discipline (one line for working paths, depth for the failing path) and consolidation (edit the prior progress comment instead of appending — watchers are notified per comment).
- **`fields-and-users.md`**: the three access tiers for Jira Server config reads — REST with PAT, project-config HTML with PAT, WebSudo-gated site admin — with the "Administrator Access" detection rule; a snippet saying "not supported by API" for writes had been misread as covering reads, costing a wrongly-declared manual check.
- **`troubleshooting.md`**: `{task}` inline checkboxes are plugin-stored and session-gated (PAT redirects to login.jsp) — hand the tick explicitly to the human in the closing checklist.

The other batch notes were already covered (`links.md` documents the NR link types, `list-types`, and create-direction semantics) and are tombstoned.

Came from /retro: yes
