### PR TITLE
chore(release): v3.24.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.23.1",
+  "version": "3.24.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "MIT",

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.23.1"
+  version: "3.24.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.23.1"
+  version: "3.24.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Version bump 3.23.1 → 3.24.0.

Changes since v3.23.1:

- docs: sync the scanner wording from the template
- chore(zizmor): drop the local policy copy, the reusable supplies it
- feat(jira-link): resolve link types via verbs and unique substring
- docs: comment discipline, Server config read tiers, inline-task checkbox limitation

Surfaces bumped: `.claude-plugin/plugin.json`, SKILL.md frontmatter version.
