### PR TITLE
feat(worklog): add delete subcommand; report assignee and empty link sets in qa-gather

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -73,7 +73,7 @@ In tickets, comments and worklog notes, state what happened, not how good it is.
 - `references/issue-editing.md` — edit, delete, clear fields, `--fields-json`
 - `references/creation.md` — create, `--parent`, fields, admin-scope (`project`, `tempo-account.py`)
 - `references/comments.md` — edit, delete, lint, body via `-`
-- `references/worklog.md` — `--started`, ranges, `--tempo-account`
+- `references/worklog.md` — `--started`, ranges, `--tempo-account`, `delete`
 - `references/attachments.md` — upload, download
 - `references/links.md` — links
 - `references/agile.md` — sprints/boards

--- a/skills/jira-communication/references/qa-gather.md
+++ b/skills/jira-communication/references/qa-gather.md
@@ -31,9 +31,13 @@ Read-only. No `--dry-run` needed.
 Human-readable sections, in order:
 
 1. Issue key + summary
-2. Status, comment count, worklog count + total minutes
-3. Structured issue links (`<type> → <key>: <summary>` for outward, `←` for inward)
-4. Web/remote links (`title: url`)
+2. Status, **current assignee** (or `Unassigned`), comment count, worklog count + total minutes
+3. Structured issue links (`<type> → <key>: <summary>` for outward, `←` for inward), or `Issue links: none`
+4. Web/remote links (`title: url`), or `Web/remote links: none`
+
+Sections 3 and 4 always print, including when empty. "None" is a reviewable fact — a related ticket mentioned in prose but never linked, or a merged MR with no web link, is a finding in its own right — whereas an omitted section reads as "not checked" and invites the reader to assume the links exist.
+
+The assignee is section 2 because claiming a ticket off a team queue depends on it: unassigned means claimable, someone else means it is already in flight, and yourself means you may be about to review your own work.
 5. URLs extracted from prose, grouped by category: `merge_request`, `pull_request`, `pipeline`, `commit`, `tag`, `release`, `issue_link`
 6. Sibling tickets in the same project, sorted by `updated DESC`
 
@@ -46,6 +50,8 @@ Top-level keys (stable):
 - `comments` — list of comment dicts (extracted from the issue payload, no second API call)
 - `worklogs` — list of worklog dicts
 - `worklog_total_seconds` — int
+- `assignee` — string account name, or `null` when unassigned (`null` is meaningful: an unclaimed queue ticket)
+- `assignee_display` — string display name, or `null`
 - `issue_links` — list (raw `issuelinks` from the issue)
 - `web_links` — list (from `get_issue_remote_links`)
 - `extracted_urls` — `{category: [url, ...]}` deduplicated, order-preserved

--- a/skills/jira-communication/references/worklog.md
+++ b/skills/jira-communication/references/worklog.md
@@ -2,7 +2,13 @@
 
 ## When to load
 
-Load this reference whenever the user wants to log work with a custom start date/time, or query worklogs across multiple issues by date range, user, project, epic or sprint.
+Load this reference whenever the user wants to log work with a custom start date/time, undo a worklog, or query worklogs across multiple issues by date range, user, project, epic or sprint.
+
+## Before booking: is Jira the system of record?
+
+Check this once per team, before the first `add`. Where a separate time tracker syncs its entries into Jira, that tracker owns time and a direct `jira-worklog.py add` **double-books** — your entry plus the one the tracker syncs in later. The duplicate is easy to miss afterwards, because a synced entry is indistinguishable from a hand-written one on the issue.
+
+The team convention belongs in an `AGENTS.md` or a team runbook, not in this skill — it cannot know your setup. If Jira *is* the system of record, `add` is correct and the rest of this section applies.
 
 ## `jira-worklog.py add` — advanced flags
 
@@ -16,6 +22,24 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-worklog.py add PROJ-123 1h30m \
 ```
 
 Time strings accept `Nw Nd Nh Nm Ns` combinations (Jira semantics, 8h workday).
+
+## `jira-worklog.py delete` — undo a booking
+
+Every `add` prints the new `Worklog ID`, and `list` shows the id of each entry — that id is the handle for `delete`. Use it to undo a booking made against the wrong issue, the wrong duration, or the wrong system (see above).
+
+```bash
+# See which entries exist, with their ids
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-worklog.py list PROJ-123
+#   [2026-08-06] Jane Doe: 45m  (id 409062)
+
+# Preview — shows the entry that would go away, deletes nothing
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-worklog.py delete PROJ-123 409062 --dry-run
+
+# Delete it
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-worklog.py delete PROJ-123 409062
+```
+
+`delete` fetches the entry first and echoes its date, author and duration, so a mistyped id surfaces before anything is removed rather than after. Deleting your own worklog needs the "Delete Own Worklogs" permission; someone else's needs "Delete All Worklogs".
 
 ## `jira-worklog-query.py` — cross-cutting query
 
@@ -69,4 +93,3 @@ curl -sS -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" -H "Content-Type: appli
 uv run ${CLAUDE_SKILL_DIR}/scripts/utility/jira-worklog-query.py \
     --from "$(date -d 'monday last week' -I)" --to "$(date -I)"
 ```
-

--- a/skills/jira-communication/scripts/core/jira-worklog.py
+++ b/skills/jira-communication/scripts/core/jira-worklog.py
@@ -196,9 +196,10 @@ def list_worklogs(ctx, issue_key: str, limit: int, truncate: int | None):
                     author = wl.get("author", {}).get("displayName", "Unknown")
                     time_spent = wl.get("timeSpent", "N/A")
                     started = wl.get("started", "N/A")[:10] if wl.get("started") else "N/A"
+                    worklog_id = wl.get("id", "N/A")
                     comment = comment_to_text(wl.get("comment"))
 
-                    print(f"  [{started}] {author}: {time_spent}")
+                    print(f"  [{started}] {author}: {time_spent}  (id {worklog_id})")
                     if comment:
                         # Truncate if requested
                         if truncate and len(comment) > truncate:
@@ -209,6 +210,66 @@ def list_worklogs(ctx, issue_key: str, limit: int, truncate: int | None):
         if ctx.obj["debug"]:
             raise
         error(f"Failed to get worklogs for {issue_key}: {e}")
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument("issue_key")
+@click.argument("worklog_id")
+@click.option("--dry-run", is_flag=True, help="Show what would be deleted without deleting")
+@click.pass_context
+def delete(ctx, issue_key: str, worklog_id: str, dry_run: bool):
+    """Delete a worklog entry from an issue.
+
+    ISSUE_KEY: The Jira issue key (e.g., PROJ-123)
+
+    WORKLOG_ID: The numeric worklog id, as printed by `add` and `list`
+
+    Use this to undo a booking made against the wrong issue, the wrong
+    duration, or the wrong system — e.g. when the team's system of record is a
+    separate time tracker that syncs its own entries into Jira, and a direct
+    Jira worklog would double-book.
+
+    Deleting another user's worklog requires the "Delete All Worklogs"
+    permission; your own needs "Delete Own Worklogs".
+
+    Examples:
+
+      jira-worklog delete PROJ-123 409062 --dry-run
+
+      jira-worklog delete PROJ-123 409062
+    """
+    ctx.obj["client"].with_context(issue_key=issue_key)
+    client = ctx.obj["client"]
+
+    try:
+        # Fetch the entry first so the operator sees which booking is going
+        # away — a bare numeric id is easy to mistype and impossible to sanity
+        # check after the fact.
+        existing = client.get(f"rest/api/2/issue/{issue_key}/worklog/{worklog_id}") or {}
+        author = existing.get("author", {}).get("displayName", "Unknown")
+        time_spent = existing.get("timeSpent", "N/A")
+        started = existing.get("started", "N/A")[:10] if existing.get("started") else "N/A"
+
+        if dry_run:
+            print(f"Would delete worklog {worklog_id} from {issue_key}:")
+            print(f"  [{started}] {author}: {time_spent}")
+            return
+
+        client.delete(f"rest/api/2/issue/{issue_key}/worklog/{worklog_id}")
+
+        if ctx.obj["quiet"]:
+            print(worklog_id)
+        elif ctx.obj["json"]:
+            format_output({"deleted": worklog_id, "issue": issue_key}, as_json=True)
+        else:
+            success(f"Deleted worklog {worklog_id} from {issue_key}")
+            print(f"  [{started}] {author}: {time_spent}")
+
+    except Exception as e:
+        if ctx.obj["debug"]:
+            raise
+        error(f"Failed to delete worklog {worklog_id} from {issue_key}: {e}")
         sys.exit(1)
 
 

--- a/skills/jira-communication/scripts/utility/jira-qa-gather.py
+++ b/skills/jira-communication/scripts/utility/jira-qa-gather.py
@@ -207,6 +207,12 @@ def cli(
     summary = fields.get("summary", "") or ""
     project_key = (fields.get("project") or {}).get("key", "") or issue_key.split("-")[0]
     status = (fields.get("status") or {}).get("name", "")
+    # Reviewers decide whether to claim a QA ticket by comparing the current
+    # assignee against themselves, so the bundle has to carry it. `None` is a
+    # meaningful value here (unclaimed team queue), not a missing one.
+    assignee_field = fields.get("assignee") or {}
+    assignee_name = assignee_field.get("name") or assignee_field.get("accountId") or ""
+    assignee_display = assignee_field.get("displayName") or ""
     description = fields.get("description", "") or ""
     if isinstance(description, dict):
         description_text = extract_adf_text(description) or ""
@@ -229,6 +235,9 @@ def cli(
         warning(f"Failed to fetch worklog: {_safe_message(exc)}")
     bundle["worklogs"] = worklogs
     bundle["worklog_total_seconds"] = sum(int(w.get("timeSpentSeconds") or 0) for w in worklogs)
+
+    bundle["assignee"] = assignee_name or None
+    bundle["assignee_display"] = assignee_display or None
 
     # Structured issue links + web/remote links
     bundle["issue_links"] = fields.get("issuelinks", []) or []
@@ -276,12 +285,16 @@ def cli(
 
     # Human-readable summary
     print(f"{issue_key}: {summary}")
+    assignee_label = f"{assignee_display} ({assignee_name})" if assignee_name else "Unassigned"
     print(
-        f"Status: {status} | Comments: {len(comments)} | "
+        f"Status: {status} | Assignee: {assignee_label} | Comments: {len(comments)} | "
         f"Worklog entries: {len(worklogs)} "
         f"({bundle['worklog_total_seconds'] // 60} min total)"
     )
 
+    # Printed unconditionally: "none" is a finding (an unlinked related ticket
+    # is a QA check in its own right), whereas an omitted section reads as
+    # "not checked" and invites the reader to assume links exist.
     if bundle["issue_links"]:
         print(f"\nIssue links ({len(bundle['issue_links'])}):")
         for link in bundle["issue_links"]:
@@ -291,12 +304,16 @@ def cli(
             other_summary = ((other.get("fields") or {}).get("summary") or "").strip()
             direction = "→" if "outwardIssue" in link else "←"
             print(f"  {link_type} {direction} {other_key}: {other_summary}")
+    else:
+        print("\nIssue links: none")
 
     if web_links:
         print(f"\nWeb/remote links ({len(web_links)}):")
         for wl in web_links:
             obj = wl.get("object") or {}
             print(f"  - {obj.get('title', '?')}: {obj.get('url', '?')}")
+    else:
+        print("\nWeb/remote links: none")
 
     if extracted:
         print("\nURLs extracted from description + comments:")


### PR DESCRIPTION
## Summary

Adds `jira-worklog.py delete`, and makes `jira-qa-gather.py` report the current assignee and say "none" for empty link sets. Both came from running a Round-1 QA end-to-end and hitting the gaps.

## Came from

`/retro` session on 2026-08-06.
Findings: A1 (no recovery path for a wrong booking), B3 (single-call bundle missing the field its consumer needs).

- **Symptom 1:** a QA worklog was booked onto the wrong system of record. `jira-worklog.py` has `add` and `list` but no `delete`, so undoing it meant reconstructing the base URL and PAT from `lib.config` and issuing a `DELETE /rest/api/2/issue/<key>/worklog/<id>` by hand.
- **Symptom 2:** `peer-qa-review` Stage -1 decides whether to claim a ticket by comparing the current assignee against yourself. `jira-qa-gather.py` — the single call that exists to serve Stage 0 — never emitted `assignee` (the string does not appear in the file). The reviewer had to make a second `jira-issue.py --json` call and parse it.
- **Cause:** `add` was built without its inverse, and the QA bundle was assembled from the reviewer's *reading* needs without the *deciding* ones.
- **Required behavior:** a booking is reversible with the id the tool already prints; the QA bundle carries every field Stage -1 and F4a need.
- **Verification:** exercised against jira.netresearch.de — see Test plan.

## Change

**`jira-worklog.py`**

- New `delete ISSUE_KEY WORKLOG_ID` with `--dry-run`, matching the destructive-command convention in `skills/jira-communication/AGENTS.md`. It fetches the entry first and echoes date/author/duration, so a mistyped id surfaces *before* anything is removed. Supports `--json` and `--quiet` like its siblings.
- `list` now prints each entry's id — without it `delete` has no usable handle. Previously the id appeared only under `--json`/`--quiet`.

**`references/worklog.md`** — documents `delete`, plus a short note that Jira is not automatically the system of record for time. Where a separate tracker syncs entries into Jira, a direct `add` double-books, and the duplicate is hard to spot because a synced entry looks identical to a hand-written one. The note deliberately points at the team's own `AGENTS.md`/runbook rather than asserting a convention this skill cannot know.

**`jira-qa-gather.py`**

- Emits `assignee` and `assignee_display` in the JSON bundle (`null` when unassigned — a meaningful value, not a missing one) and shows the assignee in the summary line.
- The issue-links and web-links sections now print `none` instead of vanishing. For a reviewer auditing link hygiene the empty case *is* the finding; a section that silently disappears reads as "not checked" and invites the reader to assume links exist.

**`SKILL.md`** — `delete` added to the `references/worklog.md` router line (499/500 words, still under the cap).

## Test plan

- [x] `ruff@0.16.0 check .` and `format --check` (pinned versions from AGENTS.md) — pass
- [x] `pytest tests/ -q` — 785 passed
- [x] `validate-skill.sh` — 0 errors; SKILL.md 499/500 words
- [x] `qa-gather` against a live ticket: assignee line renders for both assigned and unassigned; `Issue links: none` / `Web/remote links: none` render on a ticket lacking them
- [x] `worklog list` renders ids; `delete --dry-run` echoes the target entry and mutates nothing; bad id exits 1 with a clear message
- [x] `client.delete()` wiring proven against the live endpoint with a non-existent id (server rejects the id, not the request), and the same REST path was separately confirmed to return 204 on a real worklog

Note: the destructive `delete` path was verified via the endpoint and a dry-run rather than by creating and removing a throwaway worklog on a real ticket, to avoid leaving a spurious billing entry if it failed.

## Related

`netresearch/peer-qa-review-skill#40` removes the hardcoded worklog command from its Stage 5 and points Stage -1 at the identity lookup. Neither PR depends on the other landing.
