### PR TITLE
fix(jira-user): pass limit= to user_find_by_user_string

### DIFF
--- a/skills/jira-communication/scripts/utility/jira-user.py
+++ b/skills/jira-communication/scripts/utility/jira-user.py
@@ -224,7 +224,7 @@ def search(ctx, query: str, limit: int):
         # Fallback to Cloud user search
         if not users:
             try:
-                results = client.user_find_by_user_string(query=query, maxResults=limit)
+                results = client.user_find_by_user_string(query=query, limit=limit)
                 if results and isinstance(results, list):
                     for r in results:
                         if isinstance(r, dict):


### PR DESCRIPTION
`jira-user.py search` always failed with `got an unexpected keyword argument 'maxResults'` whenever the primary `user/search` API path returned nothing and the Cloud-search fallback took over. The fallback passed `maxResults=`, but `atlassian-python-api` names that parameter `limit=` — verified against the pinned `>=3.41,<4` range, where the signature is `user_find_by_user_string(username=None, query=None, account_id=None, property_key=None, start=0, limit=50, …)`. Because the error was collected into `api_errors`, it surfaced to the user as the unhelpful "User search failed — all API attempts errored". `jira-user.py get` was never affected: it calls the same method without the keyword.

Found while onboarding two customer accounts against jira.netresearch.de (Jira Server/DC 9.12) — `search` was the natural way to check whether the accounts existed yet, and it was unusable.

Verified: `jira-user.py search philipp.beck` now returns the match. Gates run locally — ruff 0.16.0 `check` and `format --check` both clean, 785 tests pass.

https://claude.ai/code/session_01RUeyrHBbDhYzBwWDusz7Ey