### PR TITLE
feat(manifest): add Agent Plugins 1.0.0 portable manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "3.24.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
-  "license": "MIT",
+  "license": "(MIT AND CC-BY-SA-4.0)",
   "author": {
     "name": "Netresearch DTT GmbH",
     "url": "https://www.netresearch.de/"

--- a/plugin.json
+++ b/plugin.json
@@ -8,7 +8,7 @@
     "url": "https://www.netresearch.de/"
   },
   "repository": "https://github.com/netresearch/jira-skill",
-  "license": "MIT",
+  "license": "(MIT AND CC-BY-SA-4.0)",
   "keywords": [
     "jira",
     "atlassian",

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "jira",
+  "version": "3.24.0",
+  "description": "Comprehensive Jira integration with auto-detection of issue keys",
+  "author": {
+    "name": "Netresearch DTT GmbH",
+    "url": "https://www.netresearch.de/"
+  },
+  "repository": "https://github.com/netresearch/jira-skill",
+  "license": "MIT",
+  "keywords": [
+    "jira",
+    "atlassian",
+    "issue-tracking",
+    "project-management",
+    "wiki-markup",
+    "syntax-validation",
+    "templates"
+  ]
+}


### PR DESCRIPTION
Adds the root `plugin.json` required by [Agent Plugins 1.0.0](https://agent-plugins.org/specification), so this plugin loads in conformant clients (Cursor, Copilot, …) and not only in Claude Code.

- Values are copied verbatim from `.claude-plugin/plugin.json` — nothing changes for Claude Code, which reads its own manifest and ignores this file.
- The portable schema is closed, so `skills`/`agents`/`support` stay in the Claude manifest.
- `skills/<name>/SKILL.md` already matches what Agent Plugins clients discover; no layout change.

From here on the root manifest is the source of truth for name, version, description, author, homepage, repository, license and keywords. `skill-repo-skill`'s `sync-plugin-manifest.sh` projects it into `.claude-plugin/plugin.json` and CI checks the parity — see [netresearch/skill-repo-skill#202](https://github.com/netresearch/skill-repo-skill/pull/202).