### PR TITLE
fix(hook): list jira-create.py in the detected-issue reminder

### DIFF
--- a/scripts/detect_jira_issues.py
+++ b/scripts/detect_jira_issues.py
@@ -195,6 +195,7 @@ or run scripts directly via uv run (NOT python3):
 
 - Fetch issue details: uv run {scripts_dir}/core/jira-issue.py get KEY
 - Search issues: uv run {scripts_dir}/core/jira-search.py query "JQL"
+- Create an issue: uv run {scripts_dir}/workflow/jira-create.py issue PROJ "Summary" --type Task
 - Transition status: uv run {scripts_dir}/workflow/jira-transition.py do KEY "Status"
 - Add comments: uv run {scripts_dir}/workflow/jira-comment.py add KEY "text"
 - Log work: uv run {scripts_dir}/core/jira-worklog.py add KEY "2h"


### PR DESCRIPTION
The `UserPromptSubmit` reminder emitted by `scripts/detect_jira_issues.py` names five scripts — get, search, transition, comment, worklog — and omits creation. An agent that follows the reminder and then needs a new issue has to guess, and the obvious guess is `jira-issue.py create`, which does not exist:

```
Error: No such command 'create'.
```

That costs a `--help` round trip on the wrong script before `SKILL.md` gets consulted, where `jira-create.py issue PROJ "Summary" --type Task` is documented correctly. The hook is what most agents read first, so the list should carry it.

One line added, matching the existing format and the documented invocation. `pytest` (785 passed) and both ruff gates are green.
