### PR TITLE
chore(release): v3.25.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.25.1] - 2026-08-12
+
+### Fixed
+- List jira-create.py in the detected-issue reminder (hook)
+
 ## [3.25.0] - 2026-08-08
 
 ### Added
@@ -738,7 +743,9 @@ First stable release providing comprehensive Jira integration through Claude Cod
 - [Claude Code Marketplace](https://github.com/netresearch/claude-code-marketplace)
 - [Jira Wiki Markup Reference](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
 
-[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.23.1...HEAD
+[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.25.1...HEAD
+[3.25.1]: https://github.com/netresearch/jira-skill/compare/v3.25.0...v3.25.1
+[3.25.0]: https://github.com/netresearch/jira-skill/compare/v3.23.1...v3.25.0
 [3.23.1]: https://github.com/netresearch/jira-skill/compare/v3.23.0...v3.23.1
 [3.23.0]: https://github.com/netresearch/jira-skill/compare/v3.22.1...v3.23.0
 [3.22.1]: https://github.com/netresearch/jira-skill/compare/v3.22.0...v3.22.1

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "jira",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.25.0"
+  version: "3.25.1"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.25.0"
+  version: "3.25.1"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Version bump to 3.25.1 for release: rolls the changelog where present and updates every version surface. No content changes beyond the release metadata.