### PR TITLE
feat(jira-syntax): warn on flag-like tokens Jira strikes through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `jira-syntax`: `validate-jira-syntax.sh` warns on flag-like tokens (`--strict`) outside `{code}`/`{noformat}` blocks. Jira parses `-text-` as strikethrough, the opening dash needs only whitespace (or a `{{` monospace opener) before it, and text effects apply inside `{{...}}` monospace, so a pair of CLI flags in prose strikes through everything between them. Backslash-escaped dashes (`\-`) pass.
+
+### Documentation
+
+- `jira-syntax`: `references/jira-syntax-quick-reference.md` documents the dash-strikethrough trap for CLI flags and the escape — `{{\-\-strict}}` renders as literal `--strict`, each `\-` reaching the rendered HTML as a `&#45;` entity (verified against the Jira Server 9.12 wiki renderer).
+
 ## [3.25.1] - 2026-08-12
 
 ### Fixed

--- a/skills/jira-syntax/references/jira-syntax-quick-reference.md
+++ b/skills/jira-syntax/references/jira-syntax-quick-reference.md
@@ -261,7 +261,13 @@ Three ways to write the literal token safely, in order of preference:
 
 The backslash escape is the official Jira mechanism; the rephrase is editorial; the `{{monospace}}` wrap renders fine but is disliked by teams that reserve monospace for actual code spans rather than inline references.
 
-A quick sanity check before posting: run `skills/jira-syntax/scripts/validate-jira-syntax.sh <file>` on your draft (from the repo root). The script verifies that the six paired macros (`code`, `panel`, `color`, `noformat`, `quote`, `anchor`) are balanced — every opener matches a closer, even with a language tag like `{code:bash}` — and catches Markdown leakage (` ``` ` fences, `[text](url)` links, `` `code` `` spans), language declarations Jira Server does not recognise, and malformed table headers.
+### Common gotcha: CLI flags struck through by `-text-`
+
+`-text-` is strikethrough, and the opening `-` needs only whitespace before it and a non-space character after it. Prose that mentions CLI flags hands the parser exactly that shape: in `checked with --strict and --no-global`, the dash before `strict` opens the effect, a later dash (here inside `no-global`) closes it, and everything between renders struck through. Text effects apply *inside* `{{...}}` monospace too (verified against the Jira Server 9.12 wiki renderer), so `{{--strict}}` does **not** protect the dashes.
+
+Backslash-escape every dash of the flag, inside or outside monospace: `{{\-\-strict}}` and `\-\-strict` both render as literal `--strict` (each `\-` reaches the rendered HTML as a `&#45;` entity). Dashes inside `{code}` and `{noformat}` blocks render literally and must not be escaped.
+
+A quick sanity check before posting: run `skills/jira-syntax/scripts/validate-jira-syntax.sh <file>` on your draft (from the repo root). The script verifies that the six paired macros (`code`, `panel`, `color`, `noformat`, `quote`, `anchor`) are balanced — every opener matches a closer, even with a language tag like `{code:bash}` — and catches Markdown leakage (` ``` ` fences, `[text](url)` links, `` `code` `` spans), language declarations Jira Server does not recognise, malformed table headers, and unescaped flag-like tokens (`--strict`) outside code blocks that would render struck through.
 
 ## Checklist Markers
 

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -47,8 +47,8 @@ validate_file() {
         return
     fi
 
-    local content=$(cat "$file")
-    local line_num=0
+    local content
+    content=$(cat "$file")
 
     # Check for Markdown-style headings (## instead of h2.)
     if echo "$content" | grep -qE "^##+ "; then
@@ -105,6 +105,35 @@ validate_file() {
         warning "Found unescaped * inside {{...}} monospace block — renders as bold mid-token. Escape as \\* (e.g. {{jira-\\*backup-\\*}})."
         echo "   Lines with issue:"
         grep -nE "$star_re" <<< "$content" | head -3
+    fi
+
+    # Check for flag-like tokens (--strict, --no-global) that Jira renders as
+    # strikethrough. `-text-` is strikethrough; the opening `-` needs only
+    # whitespace (or a {{ monospace opener — text effects apply INSIDE {{...}}
+    # too) before it and a non-space after it, so a pair of CLI flags strikes
+    # through everything between them. Escape every dash: {{\-\-strict}}.
+    # Dashes inside {code}/{noformat} blocks render literally — skip those
+    # lines via open/close toggling. Markdown ``` fences are skipped the same
+    # way: they are flagged as an error by their own check above, and fenced
+    # content is code either way, so warning on it here would be noise on top.
+    # Escaped dashes (\-) are stripped first so they don't false-positive;
+    # `--` followed by a non-letter (em-dash typography `---`, `-- `) is not a
+    # flag and stays exempt.
+    local dash_hits
+    dash_hits=$(awk '
+        /^[[:space:]]*\{(code|noformat)(:[^}]*)?\}[[:space:]]*$/ { inblock = !inblock; next }
+        /^[[:space:]]*```/ { infence = !infence; next }
+        inblock || infence { next }
+        {
+            line = $0
+            gsub(/\\-/, "", line)
+            if (line ~ /(^|[[:space:]]|\{\{)--[A-Za-z]/)
+                printf "%d:%s\n", NR, $0
+        }' <<< "$content" | head -3)
+    if [ -n "$dash_hits" ]; then
+        warning "Found flag-like token (--foo) outside a code block — Jira strikes through -text- spans, even inside {{...}}. Escape every dash: \\-\\-foo (e.g. {{\\-\\-strict}})."
+        echo "   Lines with issue:"
+        echo "$dash_hits"
     fi
 
     # Check for Markdown-style links ([text](url) instead of [text|url])
@@ -197,7 +226,8 @@ validate_file() {
     fi
 
     # Check for unclosed {color} blocks
-    local color_count=$(echo "$content" | grep -o "{color" | wc -l)
+    local color_count
+    color_count=$(echo "$content" | grep -o "{color" | wc -l)
     if [ $((color_count % 2)) -ne 0 ]; then
         warning "Potential unclosed {color} tag (odd number of occurrences)"
     fi


### PR DESCRIPTION
## What

Jira wiki markup parses `-text-` as strikethrough. The opening `-` needs only whitespace before it and a non-space character after it, and text effects apply **inside** `{{...}}` monospace as well, so prose mentioning CLI flags — `checked with --strict and --no-global`, or `{{--strict}}` — renders with everything between the flags struck through. Verified against the Jira Server 9.12 wiki renderer: `{{\-\-strict}}` renders as literal `--strict` (each `\-` becomes a `&#45;` entity in the rendered HTML), the unescaped form renders struck.

## Changes

- `references/jira-syntax-quick-reference.md`: new "Common gotcha" section with the failure shape and the escape; the validator summary paragraph now lists the new check.
- `scripts/validate-jira-syntax.sh`: warns on flag-like tokens (`--foo`) outside `{code}`/`{noformat}` blocks. Escaped dashes (`\-`) are stripped before matching; em/en-dash typography (`---`, `--` followed by a non-letter) is exempt; Markdown ``` fences are skipped — their own check already errors on them, and fenced content is code either way. Also resolves the three pre-existing shellcheck findings (SC2155 ×2, SC2034) in the same file — the pre-commit shellcheck hook blocks any commit touching the file until they are fixed.
- `CHANGELOG.md`: Unreleased entries.

## Tests

- Positive control: `Checked with {{--strict}} and --no-global in prose.` → warning fires.
- Negative controls: escaped dashes, em/en-dash typography, flags inside `{code:bash}` → no warning, exit 0.
- Template regression: validator findings on `templates/*.md` are identical before/after this change.
- `bash -n`, `shellcheck` (via pre-commit), `markdownlint-cli2` on the touched files: clean.

## Deliberately not in this PR

- `SKILL.md`'s Common Mistakes table: it sits at 497 words against the 500-word limit; `references/jira-syntax-quick-reference.md` is the designated single source of truth for syntax detail.
- `templates/*.md` already exit 1 under the validator on `main` (Markdown `##` headings and ``` fences in the wrapper docs), including the exact command in `skills/jira-syntax/AGENTS.md` "Build & tests" — pre-existing, filed separately.
