### PR TITLE
fix: dash-strikethrough lint on posting and hybrid-template validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `jira-syntax`: `validate-jira-syntax.sh` no longer fails wholesale on the hybrid template files (#190). Files containing Markdown code fences are wrappers around a Jira-markup payload: the untagged fences are now extracted and validated as Jira markup, while language-tagged fences (bash usage examples) and wrapper prose are skipped. Draft files without fences keep the full strict treatment, so `templates/*.md` validate their actual payload and the documented build check exits 0.
+
 ### Added
+
+- `jira-communication`: the pre-post markup lint (`lib/markup.py`, used by `jira-comment.py add`/`edit`) flags flag-like tokens (`--strict`) outside code blocks (#189) — Jira parses `-text-` as strikethrough, even inside `{{...}}` monospace, so a pair of CLI flags strikes through everything between them. Escaped dashes (`\-`) pass; em/en-dash typography and single-dash options stay out of scope. Same rule as the `jira-syntax` shell validator; `--force` semantics unchanged.
 
 - `jira-syntax`: `validate-jira-syntax.sh` warns on flag-like tokens (`--strict`) outside `{code}`/`{noformat}` blocks. Jira parses `-text-` as strikethrough, the opening dash needs only whitespace (or a `{{` monospace opener) before it, and text effects apply inside `{{...}}` monospace, so a pair of CLI flags in prose strikes through everything between them. Backslash-escaped dashes (`\-`) pass.
 

--- a/skills/jira-communication/references/comments.md
+++ b/skills/jira-communication/references/comments.md
@@ -57,7 +57,7 @@ Comments use Jira wiki markup — see the **jira-syntax** skill for formatting.
 
 ## Markup lint
 
-`add` and `edit` lint the body before posting: inline block tags (`{code}`, `{noformat}`, `{quote}`, `{panel}` are block-level — a tag with other text on the same line opens a block mid-prose) and unbalanced tag counts abort with an error. Escape literal mentions as `\{code\}`. Override with `--force` (findings are then printed as warnings).
+`add` and `edit` lint the body before posting: inline block tags (`{code}`, `{noformat}`, `{quote}`, `{panel}` are block-level — a tag with other text on the same line opens a block mid-prose), unbalanced tag counts, and flag-like tokens (`--strict`) outside code blocks abort with an error — Jira parses `-text-` as strikethrough, even inside `{{...}}` monospace, so a pair of CLI flags strikes through everything between them; escape every dash (`{{\-\-strict}}`). Escape literal tag mentions as `\{code\}`. Override with `--force` (findings are then printed as warnings).
 
 ## Comment verbosity: depth for the failing path only
 

--- a/skills/jira-communication/scripts/lib/markup.py
+++ b/skills/jira-communication/scripts/lib/markup.py
@@ -25,6 +25,13 @@ Catches the most damaging authoring mistakes before text is sent to Jira:
   Content inside ``{{monospace}}`` and ``[links]`` is ignored. Known blind spot:
   a bare trailing-underscore prefix (``tx_news_``) is flagged like broken
   emphasis - wrap identifiers in ``{{monospace}}`` to silence it.
+- Flag-like tokens (``--strict``) outside code blocks. Jira parses
+  ``-text-`` as strikethrough; the opening ``-`` needs only whitespace (or a
+  ``{{`` monospace opener - text effects apply INSIDE ``{{...}}``, verified
+  against Jira Server 9.12) before it and a non-space after it, so a pair of
+  CLI flags strikes through everything between them. Escaped dashes (``\\-``)
+  are literal and pass; em/en-dash typography (``---``, ``--`` before a
+  non-letter) never matches.
 
 Escaped tags (\\{code\\}), inline-monospace lookalikes ({{code}}) and
 *other* tags inside an open block are ignored. An occurrence of the
@@ -70,6 +77,13 @@ _MIDWORD_EMPHASIS_RES = {
     "_": re.compile(r"(?<=\w)_[^\s_]+_" + _EMPH_CLOSE),
     "*": re.compile(r"(?<=\w)\*[^\s*]+\*" + _EMPH_CLOSE),
 }
+
+# Flag-like token Jira strikes through. Scanned on the RAW line (not the
+# monospace-blanked copy): text effects apply INSIDE {{...}}, so {{--strict}}
+# is just as broken as bare --strict. The caller strips \- escapes before
+# matching (an escaped dash is a literal); requiring a letter after the second
+# dash keeps em/en-dash typography (---, `-- `) out of scope.
+_FLAG_DASH_RE = re.compile(r"(?:^|\s|\{\{)--[A-Za-z]")
 
 
 def lint_wiki_markup(text: str) -> list[str]:
@@ -121,6 +135,16 @@ def lint_wiki_markup(text: str) -> list[str]:
                     f"boundary (e.g. '{marker}Wort{marker}', not "
                     f"'Prefix{marker}Wort{marker}'): {stripped[:80]!r}"
                 )
+
+        # CLI flags render struck through, even inside {{monospace}} - scan the
+        # raw line with \- escapes removed (an escaped dash is a literal).
+        if _FLAG_DASH_RE.search(line.replace("\\-", "")):
+            findings.append(
+                f"line {lineno}: flag-like token (--foo) - Jira parses -text- as "
+                f"strikethrough, even inside {{{{...}}}} monospace, so a pair of "
+                f"flags strikes through everything between them; escape every "
+                f"dash as \\-\\-foo (e.g. {{{{\\-\\-strict}}}}): {stripped[:80]!r}"
+            )
 
         if not matches:
             continue

--- a/skills/jira-syntax/scripts/validate-jira-syntax.sh
+++ b/skills/jira-syntax/scripts/validate-jira-syntax.sh
@@ -47,8 +47,26 @@ validate_file() {
         return
     fi
 
+    # Hybrid template files (templates/*.md) are a Markdown wrapper carrying
+    # the Jira markup inside ``` fences. For those, validate the fenced
+    # payload: untagged ``` fences hold Jira markup to be copy-pasted;
+    # language-tagged fences (```bash) are foreign code and are skipped, as is
+    # the wrapper prose. Files without fences — drafts about to be posted —
+    # keep the full strict treatment.
     local content
-    content=$(cat "$file")
+    if grep -qE '^[[:space:]]*```' "$file"; then
+        echo "   (hybrid file: validating untagged \`\`\` fenced payload as Jira markup)"
+        content=$(awk '
+            /^[[:space:]]*```/ {
+                if (infence) { infence = 0 }
+                else { infence = 1; tagged = ($0 ~ /^[[:space:]]*```./) }
+                next
+            }
+            infence && !tagged { print }
+        ' "$file")
+    else
+        content=$(cat "$file")
+    fi
 
     # Check for Markdown-style headings (## instead of h2.)
     if echo "$content" | grep -qE "^##+ "; then

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -170,3 +170,36 @@ class TestInlineEmphasis:
         assert any("starts mid-word" in f for f in lint_wiki_markup('Das Label "Konzept_qualitaet_" ist falsch.'))
         german = "Im Feld " + chr(0x201E) + "Anmelden_jetzt_" + chr(0x201C) + " fehlt."
         assert any("starts mid-word" in f for f in lint_wiki_markup(german))
+
+
+class TestFlagDash:
+    """Flag-like tokens (--foo) render struck through outside code blocks."""
+
+    def test_flags_in_prose_flagged(self):
+        assert any("flag-like token" in f for f in lint_wiki_markup("checked with --strict and --no-global"))
+
+    def test_flag_inside_monospace_flagged(self):
+        # Text effects apply INSIDE {{...}} - {{--strict}} is just as broken.
+        assert any("flag-like token" in f for f in lint_wiki_markup("green under {{--strict}} today"))
+
+    def test_escaped_flag_is_clean(self):
+        assert lint_wiki_markup("green under {{\\-\\-strict}} and \\-\\-no-global today") == []
+
+    def test_dash_typography_is_clean(self):
+        # Em/en-dash typography: no letter after the second dash.
+        assert lint_wiki_markup("a --- b and c -- d stay prose") == []
+
+    def test_single_dash_flag_is_clean(self):
+        # Deliberately out of scope: `-v` needs a closing dash to strike; only
+        # the high-signal double-dash shape is flagged.
+        assert lint_wiki_markup("run it with -v for verbose output") == []
+
+    def test_flags_inside_code_block_clean(self):
+        assert lint_wiki_markup("{code:bash}\nvalidator --strict --no-global *.json\n{code}") == []
+
+    def test_flags_inside_noformat_block_clean(self):
+        assert lint_wiki_markup("{noformat}\ncmd --strict\n{noformat}") == []
+
+    def test_midword_double_dash_is_clean(self):
+        # No whitespace/{{ before the dashes: a mid-token -- is not a flag.
+        assert lint_wiki_markup("the range a--b stays prose") == []


### PR DESCRIPTION
Fixes the two defects from the dash-strikethrough family in one pass.

## Commit 1 — Closes #189

`lib/markup.py` (`lint_wiki_markup`, used by `jira-comment.py add`/`edit`): new finding for flag-like tokens (`--foo`) outside code blocks. Scans the raw line, not the monospace-blanked copy — text effects apply inside `{{...}}`, so `{{--strict}}` is just as broken as bare `--strict`. Escaped dashes (`\-`) pass; em/en-dash typography, mid-token `--`, and single-dash options stay out of scope. `--force` semantics unchanged. 8 new tests; `references/comments.md` lint section updated.

## Commit 2 — Closes #190

`validate-jira-syntax.sh`: hybrid template files (Markdown wrapper with the Jira payload in code fences) are now validated on their payload — untagged fences are extracted and checked as Jira markup, language-tagged fences (bash usage) and wrapper prose are skipped. Drafts without fences keep the full strict treatment. `templates/*.md` and the documented build check (`skills/jira-syntax/AGENTS.md`) now exit 0; a Markdown draft still exits 1. This lands option 2 from #190 rather than the option-1 lean in the issue: with the tagged/untagged distinction the strict path is untouched, and rewriting the templates would have destroyed their GitHub readability for no validation gain.

## Tests

- `pytest tests/` — 793 passed (8 new in `tests/test_markup.py`).
- Shell controls: both templates exit 0 with payload positively validated (headings/code-langs/mentions/links found); bad-draft fixture still flags; Markdown draft still exits 1.
- ruff check + format, markdownlint-cli2, shellcheck/pre-commit: clean.
