### PR TITLE
docs(agents): release flow via release PR, not direct main push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Claude Code plugin with two skills. See SKILL.md in each skill directory for usa
 
 - Keep PRs small (~300 net LOC)
 - Conventional Commits: `type(scope): subject`
-- Version managed ONLY in `.claude-plugin/plugin.json`
+- Version source of truth: `.claude-plugin/plugin.json`; `plugin.json` and both `skills/*/SKILL.md` `metadata.version` must match (parity enforced by pre-commit and CI)
 - Update SKILL.md when changing user-facing behavior
 
 ## Dependencies
@@ -47,7 +47,7 @@ than trusting this block if CI disagrees. Note `Skill Validation` can report
 
 ## Release workflow
 
-Releases are automated via GitHub Actions (`.github/workflows/release.yml`). On tag push, it creates 3 packages:
+Releases are automated via GitHub Actions (`.github/workflows/release.yml`). On tag push, it publishes three package families (zip + tar.gz each, plus `SHA256SUMS.txt` with a Sigstore signature and SLSA provenance):
 
 | Package | Description |
 |---------|-------------|
@@ -55,17 +55,17 @@ Releases are automated via GitHub Actions (`.github/workflows/release.yml`). On 
 | `jira-communication-skill-vX.X.X.zip` | Standalone skill (Claude Desktop compatible) |
 | `jira-syntax-skill-vX.X.X.zip` | Standalone skill (Claude Desktop compatible) |
 
-**Steps:**
+**Steps (release PR — `main` requires pull requests; do not push it directly, that only works via owner bypass and rings the ruleset alarm):**
 1. Check commits since last release: `git log --oneline v<last>..HEAD`
-2. Backfill any missing CHANGELOG entries
-3. Update CHANGELOG.md with new version entry
-4. Bump version in `.claude-plugin/plugin.json`
-5. Bump `metadata.version` in **both** `skills/*/SKILL.md` to match (CI validates consistency)
-6. Commit: `git commit -m "chore: release v<version>"`
-7. Tag: `git tag v<version>`
-8. Push: `git push origin main --tags`
+2. Backfill any missing CHANGELOG entries, rename `[Unreleased]` to `[<version>] - <today>`, add a fresh empty `[Unreleased]` above it
+3. Bump the version in `.claude-plugin/plugin.json` **and** `plugin.json`
+4. Bump `metadata.version` in **both** `skills/*/SKILL.md` to match (CI and the pre-commit parity hook validate consistency)
+5. Branch `release/v<version>`, commit `chore: release v<version>` (signed, as always), push, open a PR with the same title
+6. Merge the PR once CI is green — plain merge, no bypass
+7. Tag the merge commit: `git fetch origin main`, assert local HEAD equals the remote `main` tip, then `git tag -s v<version> -m "v<version>"` (signed annotated — never lightweight)
+8. Push the tag: `git push origin v<version>`
 
-The GitHub Action automatically creates the release with all 3 download packages.
+The GitHub Action on the tag push creates the release with all packages, checksums and SLSA provenance. Never `gh release create`. Write the narrative release notes before tagging and apply them with `gh release edit v<version> --notes-file …` once the Action has published.
 
 ## Index of scoped AGENTS.md
 
@@ -97,4 +97,3 @@ bash evals/run-evals.sh my-iteration --results-json evals/results/my-iteration.j
 ## When instructions conflict
 
 Nearest AGENTS.md wins. User prompts override files.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- `AGENTS.md`: the release workflow goes through a release PR now — `main` requires pull requests, so the old direct-push flow only worked via owner bypass. The steps also name all four version surfaces (`.claude-plugin/plugin.json`, `plugin.json`, both `SKILL.md`), require the signed annotated tag on the verified merge commit (the old step 7 showed a lightweight tag), and describe the actual release artifacts (zip + tar.gz per package, checksums with Sigstore signature, SLSA provenance).
+
 ## [3.26.0] - 2026-08-13
 
 ### Fixed


### PR DESCRIPTION
The v3.26.0 release push surfaced that the documented release flow (direct push to `main` + `--tags`) violates the repo's own ruleset — the push went through only via owner bypass, with the remote reporting "Bypassed rule violations: Changes must be made through a pull request; 10 of 10 required status checks are expected."

`AGENTS.md` now documents the release-PR flow: release branch → `chore: release v<version>` PR → plain merge on green CI → signed annotated tag on the verified merge commit → tag push triggers the release Action. While in there, three stale details are corrected: the step list omitted two of the four version surfaces (`plugin.json`, both `SKILL.md` — the parity hook checks them), step 7 showed a lightweight tag (`git tag v<version>`) where releases use signed annotated tags, and the artifact description said "3 packages" where the Action publishes zip + tar.gz per package plus checksums with Sigstore signature and SLSA provenance.

The "Version managed ONLY in `.claude-plugin/plugin.json`" global rule is reworded to name the parity across all four surfaces.

`CLAUDE.md` is a symlink to `AGENTS.md`, so both surfaces update together. `verify-harness.sh`: all levels pass.
