### PR TITLE
docs(jira-communication): verify comment rendering via renderedBody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- `jira-communication`: `references/comments.md` documents how to verify a comment actually renders as intended — `GET .../comment/<id>?expand=renderedBody` and what to grep for (`<del>` = strikethrough trap fired, literal backslash = escape leaked, `&#45;` = correctly escaped dash). A 2xx on add/edit proves the write, not the rendering.
+
+### Documentation
+
 - `AGENTS.md`: the release workflow goes through a release PR now — `main` requires pull requests, so the old direct-push flow only worked via owner bypass. The steps also name all four version surfaces (`.claude-plugin/plugin.json`, `plugin.json`, both `SKILL.md`), require the signed annotated tag on the verified merge commit (the old step 7 showed a lightweight tag), and describe the actual release artifacts (zip + tar.gz per package, checksums with Sigstore signature, SLSA provenance).
 
 ## [3.26.0] - 2026-08-13

--- a/skills/jira-communication/references/comments.md
+++ b/skills/jira-communication/references/comments.md
@@ -59,6 +59,17 @@ Comments use Jira wiki markup — see the **jira-syntax** skill for formatting.
 
 `add` and `edit` lint the body before posting: inline block tags (`{code}`, `{noformat}`, `{quote}`, `{panel}` are block-level — a tag with other text on the same line opens a block mid-prose), unbalanced tag counts, and flag-like tokens (`--strict`) outside code blocks abort with an error — Jira parses `-text-` as strikethrough, even inside `{{...}}` monospace, so a pair of CLI flags strikes through everything between them; escape every dash (`{{\-\-strict}}`). Escape literal tag mentions as `\{code\}`. Override with `--force` (findings are then printed as warnings).
 
+## Verify rendering after posting
+
+A 2xx on `add`/`edit` proves the write landed, not that the markup renders as intended — Jira renders wiki markup server-side. The rendered HTML is the only proof:
+
+```bash
+curl -s -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
+  "$JIRA_URL/rest/api/2/issue/<KEY>/comment/<id>?expand=renderedBody" | jq -r '.renderedBody'
+```
+
+Grep it for what you fear: `<del>` means something parsed as strikethrough (the dash trap — see the lint above), a literal `\` means a backslash escape reached the reader, and `&#45;` is a correctly escaped dash. Run this after editing any markup-sensitive comment; verified against Jira Server 9.12.
+
 ## Comment verbosity: depth for the failing path only
 
 Working-path checks get ONE summary line at most; the non-working path gets the depth; obvious/derivable steps are cut entirely. A human reader cannot filter long tables that mostly say "this works" — verbose investigation comments cause overload and force the reader to re-derive what mattered.


### PR DESCRIPTION
Retro learning from the dash-strikethrough incident: the fix was only provable via the rendered HTML (`expand=renderedBody`), and the technique was undocumented. `references/comments.md` gains a "Verify rendering after posting" section — the one-liner curl and what to grep for (`<del>` = strikethrough fired, literal backslash = escape leaked, `&#45;` = correctly escaped dash). Verified against Jira Server 9.12 during the incident. Docs only.