### PR TITLE
docs(jira-create): add stdin example for --description -

### DIFF
--- a/skills/jira-communication/scripts/workflow/jira-create.py
+++ b/skills/jira-communication/scripts/workflow/jira-create.py
@@ -95,6 +95,8 @@ def issue(
 
       jira-create issue PROJ "API documentation" --type Task -d "Update API docs" -l docs,api
 
+      cat body.txt | jira-create issue PROJ "Long description" --type Task -d -
+
       jira-create issue PROJ "Bug from QA" --type Bug --reporter jane.doe
 
       jira-create issue PROJ "Sprint goal" --type Epic


### PR DESCRIPTION
## Summary

Adds the missing stdin usage example to `jira-create.py issue`'s help text: `cat body.txt | jira-create issue PROJ "Long description" --type Task -d -`.

## Re-scoped 2026-08-18

The original PR ported the stdin-reading block (`--description -`) from `jira-issue.py update` into `jira-create.py issue`. That implementation landed on `main` independently via 39ed9ce (with the mention gate from cfbde92 integrated on top), so the port here became redundant — and merging it as-was would have dropped the `check_mentions_cli` call that `main`'s version runs on descriptions. The branch was reset onto `main` and reduced to the one part `main` doesn't have: the docstring example showing the stdin form.

## Came from

`/retro` session on 2026-08-13, TYPO3 buildbox modernization ticket (WSD-1336): `jira-create.py issue ... --description -` silently created an issue whose description was the literal one-character string `-`. The behavior fix is on `main` (39ed9ce); this PR keeps the discoverability half.

## Test plan

- [x] `uvx ruff@0.16.0 check` + `format --check` pass on the file
- [x] `uv run scripts/workflow/jira-create.py issue --help` renders the new example
