### PR TITLE
feat(hooks): advertise jira-issue.py work in the issue-detection hint

### DIFF
--- a/scripts/detect_jira_issues.py
+++ b/scripts/detect_jira_issues.py
@@ -194,6 +194,7 @@ The jira-communication skill can help. Use the Skill tool to invoke it,
 or run scripts directly via uv run (NOT python3):
 
 - Fetch issue details: uv run {scripts_dir}/core/jira-issue.py get KEY
+- Full context (description + all comments): uv run {scripts_dir}/core/jira-issue.py work KEY
 - Search issues: uv run {scripts_dir}/core/jira-search.py query "JQL"
 - Create an issue: uv run {scripts_dir}/workflow/jira-create.py issue PROJ "Summary" --type Task
 - Transition status: uv run {scripts_dir}/workflow/jira-transition.py do KEY "Status"


### PR DESCRIPTION
The UserPromptSubmit hint lists get/query/create/transition/comment/worklog but not `jira-issue.py work KEY`, which fetches description and all comments in one call. Agents that only see the hint guess flags like `get --comments` (observed in a live session: one failed call, then two calls where one would do). One added line routes them to the single-call command.

Test plan: ruff check + format green, full pytest suite green (793 passed); hint text change only, no logic touched.

https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss