### PR TITLE
chore(release): v3.28.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.27.1",
+  "version": "3.28.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "repository": "https://github.com/netresearch/jira-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.28.0] - 2026-08-17
+
 ### Added
 
 - Every command that posts mention-capable wiki markup verifies `[~username]` mentions against Jira inside the posting call — `jira-comment add`/`edit`, `jira-transition do --comment`, `jira-worklog add --comment`, and the `--description` of `jira-create issue`/`jira-issue update`. An unknown username aborts with candidate suggestions in the form that actually notifies (`[~name]` on Server/DC, `[~accountid:...]` on Cloud, where a plain username mention can never notify and is always flagged); mentions inside `{code}`/`{noformat}` blocks and backslash-escaped literals are ignored; auth/transport failures surface as themselves, never as "unknown user". Skip with `--no-verify-mentions` (#199)
@@ -787,7 +789,8 @@ First stable release providing comprehensive Jira integration through Claude Cod
 - [Claude Code Marketplace](https://github.com/netresearch/claude-code-marketplace)
 - [Jira Wiki Markup Reference](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
 
-[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.27.1...HEAD
+[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.28.0...HEAD
+[3.28.0]: https://github.com/netresearch/jira-skill/compare/v3.27.1...v3.28.0
 [3.27.1]: https://github.com/netresearch/jira-skill/compare/v3.27.0...v3.27.1
 [3.25.1]: https://github.com/netresearch/jira-skill/compare/v3.25.0...v3.25.1
 [3.25.0]: https://github.com/netresearch/jira-skill/compare/v3.23.1...v3.25.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "jira",
-  "version": "3.27.1",
+  "version": "3.28.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.27.1"
+  version: "3.28.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.27.1"
+  version: "3.28.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Verifies `[~username]` mentions at post time and prints usernames in issue output, advertises `jira-issue.py` in the issue-detection hint, and breaks the client/users import cycle via `lib/errors.py`.