### PR TITLE
chore(release): v3.29.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "jira",
-  "version": "3.28.0",
+  "version": "3.29.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
-  "repository": "https://github.com/netresearch/jira-skill",
-  "license": "(MIT AND CC-BY-SA-4.0)",
   "author": {
     "name": "Netresearch DTT GmbH",
     "url": "https://www.netresearch.de/"
   },
+  "repository": "https://github.com/netresearch/jira-skill",
+  "license": "(MIT AND CC-BY-SA-4.0)",
   "keywords": [
     "jira",
     "atlassian",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.29.0] - 2026-08-27
+
 ### Changed
 
 - `jira-qa-gather` prints the description and every comment (all pages, chronological, with author and date — the same rendering as `jira-issue work`) in its text output, so a QA reviewer no longer needs a second `jira-issue work KEY` call per ticket; `--no-body` restores the metadata-only shape, and `--json` gains a `description` key. The shared rendering moved to `lib/render.py`
@@ -794,7 +796,8 @@ First stable release providing comprehensive Jira integration through Claude Cod
 - [Claude Code Marketplace](https://github.com/netresearch/claude-code-marketplace)
 - [Jira Wiki Markup Reference](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
 
-[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.28.0...HEAD
+[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.29.0...HEAD
+[3.29.0]: https://github.com/netresearch/jira-skill/compare/v3.28.0...v3.29.0
 [3.28.0]: https://github.com/netresearch/jira-skill/compare/v3.27.1...v3.28.0
 [3.27.1]: https://github.com/netresearch/jira-skill/compare/v3.27.0...v3.27.1
 [3.25.1]: https://github.com/netresearch/jira-skill/compare/v3.25.0...v3.25.1

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "jira",
-  "version": "3.28.0",
+  "version": "3.29.0",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.28.0"
+  version: "3.29.0"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.28.0"
+  version: "3.29.0"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
qa-gather prints the description and all comments in the bundle. Docs: stdin example for --description -, jira-comment delete has no confirmation prompt. Fixes: jira-link names the fix in the missing --type usage error; shebang scripts are executable.