### PR TITLE
fix(worklog): keep the UTC offset when --started carries fractional seconds

### DIFF
--- a/skills/jira-communication/scripts/core/jira-worklog.py
+++ b/skills/jira-communication/scripts/core/jira-worklog.py
@@ -27,6 +27,12 @@ from lib.client import LazyJiraClient
 from lib.output import comment_to_text, error, format_output, success
 from lib.users import check_mentions_cli, person_label
 
+# Trailing UTC offset in any ISO-8601 spelling: "Z", "+01:00" or "+0100".
+_TZ_SUFFIX_RE = re.compile(r"(?:(?P<utc>[Zz])|(?P<sign>[+-])(?P<hh>\d{2}):?(?P<mm>\d{2}))$")
+
+# Date and time to the second, with an optional fractional part of any length.
+_DATE_TIME_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d+))?$")
+
 
 def normalize_iso_timestamp(timestamp: str) -> str:
     """Normalize ISO timestamp to Jira's required format.
@@ -38,7 +44,12 @@ def normalize_iso_timestamp(timestamp: str) -> str:
       - 2025-01-15T09:00 (adds seconds and local timezone)
       - 2025-01-15 (adds time 00:00:00 and local timezone)
       - 2025-01-15T09:00:00+01:00 (converts timezone format)
+      - 2025-01-15T09:00:00.123456+01:00 (truncates to milliseconds, converts timezone)
+      - 2025-01-15T09:00:00Z (Z is +0000, a spelling Jira itself rejects)
       - 2025-01-15T09:00:00.000+0100 (pass through)
+
+    Anything else is returned exactly as the caller typed it, so an
+    unrecognised shape reaches Jira intact rather than half-rewritten.
     """
     # Already in Jira format (has milliseconds and compact timezone)
     if re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{4}$", timestamp):
@@ -51,23 +62,28 @@ def normalize_iso_timestamp(timestamp: str) -> str:
     if re.match(r"^\d{4}-\d{2}-\d{2}$", timestamp):
         return f"{timestamp}T00:00:00.000{local_tz}"
 
-    # Has timezone with colon: 2025-01-15T09:00:00+01:00
-    tz_match = re.search(r"([+-])(\d{2}):(\d{2})$", timestamp)
+    # Split the offset off the timestamp body; a bare body inherits local time.
+    tz_match = _TZ_SUFFIX_RE.search(timestamp)
     if tz_match:
-        tz_compact = f"{tz_match.group(1)}{tz_match.group(2)}{tz_match.group(3)}"
-        timestamp = timestamp[: tz_match.start()]
+        body = timestamp[: tz_match.start()]
+        if tz_match.group("utc"):
+            tz_compact = "+0000"
+        else:
+            tz_compact = f"{tz_match.group('sign')}{tz_match.group('hh')}{tz_match.group('mm')}"
     else:
-        tz_compact = local_tz
+        body, tz_compact = timestamp, local_tz
 
     # No seconds: 2025-01-15T09:00
-    if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$", timestamp):
-        timestamp = f"{timestamp}:00"
+    if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$", body):
+        body = f"{body}:00"
 
-    # Has seconds but no milliseconds: 2025-01-15T09:00:00
-    if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$", timestamp):
-        return f"{timestamp}.000{tz_compact}"
+    # Seconds, with or without a fractional part — Jira takes exactly 3 digits.
+    dt_match = _DATE_TIME_RE.match(body)
+    if dt_match:
+        millis = (dt_match.group(2) or "").ljust(3, "0")[:3]
+        return f"{dt_match.group(1)}.{millis}{tz_compact}"
 
-    # Fallback: return as-is (let Jira API handle/reject it)
+    # Fallback: the original input, offset included (let Jira handle/reject it)
     return timestamp
 
 

--- a/tests/test_worklog_timestamp.py
+++ b/tests/test_worklog_timestamp.py
@@ -1,0 +1,134 @@
+"""Tests for ``normalize_iso_timestamp`` in ``core/jira-worklog.py``.
+
+Jira's worklog API wants exactly ``YYYY-MM-DDTHH:MM:SS.sss+ZZZZ``; the helper
+exists so ``--started`` accepts the ISO spellings people and tools actually
+produce. These tests pin every accepted shape, and in particular that an
+offset the caller supplied is never silently dropped on the way to Jira.
+"""
+
+from datetime import datetime
+from unittest import mock
+
+import click.testing
+from conftest import load_script, make_mock_client
+
+_worklog_mod = load_script("jira-worklog", "core")
+normalize_iso_timestamp = _worklog_mod.normalize_iso_timestamp
+
+
+def _local_offset() -> str:
+    """The compact local UTC offset the helper falls back to (e.g. ``+0100``)."""
+    return datetime.now().astimezone().strftime("%z")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: shapes that already carry an offset
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestOffsetPreserved:
+    """A caller-supplied UTC offset must survive normalization."""
+
+    def test_jira_format_passes_through(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00:00.000+0100") == "2025-01-15T09:00:00.000+0100"
+
+    def test_colon_offset_is_compacted(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00:00+01:00") == "2025-01-15T09:00:00.000+0100"
+
+    def test_milliseconds_with_colon_offset_keeps_offset(self):
+        """Regression: the offset used to be stripped and never re-attached."""
+        assert normalize_iso_timestamp("2025-01-15T09:00:00.000+01:00") == "2025-01-15T09:00:00.000+0100"
+
+    def test_microseconds_truncated_to_milliseconds(self):
+        """datetime.isoformat() emits 6 fractional digits; Jira accepts 3."""
+        assert normalize_iso_timestamp("2025-01-15T09:00:00.123456+01:00") == "2025-01-15T09:00:00.123+0100"
+
+    def test_short_fraction_padded_to_milliseconds(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00:00.5+01:00") == "2025-01-15T09:00:00.500+0100"
+
+    def test_zulu_becomes_zero_offset(self):
+        """Z is ISO-8601 for +00:00, but Jira only accepts the numeric form."""
+        assert normalize_iso_timestamp("2025-01-15T09:00:00Z") == "2025-01-15T09:00:00.000+0000"
+
+    def test_zulu_with_milliseconds(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00:00.000Z") == "2025-01-15T09:00:00.000+0000"
+
+    def test_utc_colon_offset(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00:00.000+00:00") == "2025-01-15T09:00:00.000+0000"
+
+    def test_negative_offset(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00:00.000-05:00") == "2025-01-15T09:00:00.000-0500"
+
+    def test_compact_offset_without_milliseconds(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00:00+0100") == "2025-01-15T09:00:00.000+0100"
+
+    def test_minutes_only_with_offset(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00+01:00") == "2025-01-15T09:00:00.000+0100"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: shapes with no offset — local time is supplied
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestLocalTimezoneApplied:
+    """A timestamp without an offset is anchored to the local zone."""
+
+    def test_date_only(self):
+        assert normalize_iso_timestamp("2025-01-15") == f"2025-01-15T00:00:00.000{_local_offset()}"
+
+    def test_date_and_minutes(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00") == f"2025-01-15T09:00:00.000{_local_offset()}"
+
+    def test_date_and_seconds(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00:00") == f"2025-01-15T09:00:00.000{_local_offset()}"
+
+    def test_naive_with_milliseconds(self):
+        assert normalize_iso_timestamp("2025-01-15T09:00:00.000") == f"2025-01-15T09:00:00.000{_local_offset()}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: unrecognised input
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestUnrecognisedInput:
+    """An unparseable value reaches Jira untouched, never half-rewritten."""
+
+    def test_garbage_returned_verbatim(self):
+        assert normalize_iso_timestamp("yesterday") == "yesterday"
+
+    def test_partial_timestamp_returned_verbatim(self):
+        assert normalize_iso_timestamp("2025-01-15T09") == "2025-01-15T09"
+
+    def test_offset_never_stripped_without_being_reattached(self):
+        """Whatever the body looks like, the result still carries the offset."""
+        result = normalize_iso_timestamp("2025-01-15 09:00:00+01:00")
+        assert result.endswith("+01:00") or result.endswith("+0100"), result
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: the CLI actually sends the normalized value
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWorklogAddStarted:
+    """``jira-worklog add --started`` must POST a Jira-shaped, offset-bearing timestamp."""
+
+    def _add(self, started: str):
+        mock_client = make_mock_client()
+        mock_client.issue_add_json_worklog.return_value = {"id": "10001"}
+        runner = click.testing.CliRunner()
+        with mock.patch.object(_worklog_mod, "LazyJiraClient", return_value=mock_client):
+            result = runner.invoke(_worklog_mod.cli, ["add", "TEST-1", "2h", "--started", started])
+        assert result.exit_code == 0, result.output
+        return mock_client.issue_add_json_worklog.call_args[0][1]
+
+    def test_isoformat_with_microseconds_keeps_offset(self):
+        """Regression: ``datetime.now().astimezone().isoformat()`` lost its offset."""
+        payload = self._add("2025-01-15T09:00:00.123456+01:00")
+        assert payload["started"] == "2025-01-15T09:00:00.123+0100"
+
+    def test_zulu_timestamp_sent_in_numeric_form(self):
+        payload = self._add("2025-01-15T09:00:00.000Z")
+        assert payload["started"] == "2025-01-15T09:00:00.000+0000"


### PR DESCRIPTION
This PR proposes a fix for `normalize_iso_timestamp()` in `skills/jira-communication/scripts/core/jira-worklog.py`, which silently discards the UTC offset when `--started` is handed an ISO timestamp that carries fractional seconds. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/468. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`normalize_iso_timestamp()` splits a trailing `+HH:MM` offset off the timestamp and keeps it as a compact `+HHMM`, then only re-attaches it when the remaining body matches `YYYY-MM-DDTHH:MM:SS` exactly. A fractional part fails that match, so the function falls through to its `# Fallback: return as-is` branch — except by then the value is no longer as-is, because the offset has already been cut off the string. A trailing `Z` is not recognised as an offset at all and is forwarded to Jira, which does not accept that spelling in `started`.

Those are precisely the two shapes the most common ways of building an ISO timestamp produce: `datetime.now().astimezone().isoformat()` emits six fractional digits followed by `+HH:MM`, and JavaScript's `Date.prototype.toISOString()` emits `Z`. So `jira-worklog.py add --started` sends Jira a `started` with no timezone for exactly the values a caller is most likely to hand it, and the entry is recorded against the server's own zone instead of the one the caller asked for.

Reproduction on current `main` (b2454f5), from a clean checkout:

```console
$ uv run --with atlassian-python-api --with click --with requests python - <<'PY'
import importlib.util, sys
from pathlib import Path
p = Path("skills/jira-communication/scripts")
sys.path.insert(0, str(p))
spec = importlib.util.spec_from_file_location("jira_worklog", p / "core" / "jira-worklog.py")
m = importlib.util.module_from_spec(spec)
spec.loader.exec_module(m)
for s in ("2025-01-15T09:00:00.000+01:00", "2025-01-15T09:00:00.123456+01:00", "2025-01-15T09:00:00Z"):
    print(f"{s!r:36} -> {m.normalize_iso_timestamp(s)!r}")
PY
'2025-01-15T09:00:00.000+01:00'      -> '2025-01-15T09:00:00.000'
'2025-01-15T09:00:00.123456+01:00'   -> '2025-01-15T09:00:00.123456'
'2025-01-15T09:00:00Z'               -> '2025-01-15T09:00:00Z'
```

The same command on this branch:

```console
'2025-01-15T09:00:00.000+01:00'      -> '2025-01-15T09:00:00.000+0100'
'2025-01-15T09:00:00.123456+01:00'   -> '2025-01-15T09:00:00.123+0100'
'2025-01-15T09:00:00Z'               -> '2025-01-15T09:00:00.000+0000'
```

## The change

The offset is now matched in every ISO-8601 spelling (`Z`, `+HH:MM`, `+HHMM`) by one regex, the fractional part is normalised to the three digits Jira accepts (`.5` becomes `.500`, `.123456` becomes `.123`), and the fallback returns the **original** argument, so an unrecognised shape reaches Jira exactly as the caller typed it rather than half-rewritten. Every input that already worked returns a byte-identical string — the docstring's accepted-format list is extended, never revised — and nothing outside this one helper is touched, so there is no signature or output change for any existing caller.

## Verification

`tests/test_worklog_timestamp.py` is new and covers the helper across every accepted spelling, the offset-less shapes that inherit local time, unparseable input, and two CLI-level cases that drive `jira-worklog.py add --started` through `CliRunner` and assert the payload handed to `issue_add_json_worklog` — so the real consumer is exercised, not just the helper. Twelve of its twenty cases fail on `main` and pass here; the other eight are guards pinning the shapes that already worked.

The suite was run before and after the change with the same command your CI uses, on both ends of your matrix:

```console
# main
$ uv run --python 3.13 --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/ -q
821 passed in 1.85s

# this branch (3.10, 3.13 and 3.14)
$ uv run --python 3.13 --with pytest --with atlassian-python-api --with click --with requests python -m pytest tests/ -q
841 passed in 1.84s
```

No test changed state in either direction; the difference is the twenty new cases. `ruff check .`, `ruff format --check .` and `bandit -r skills/jira-communication/scripts/ scripts/ -c pyproject.toml --severity-level medium` are all clean on the branch.

## How this was managed

The board at https://eastagiletracker.com/projects/468 was imported from this repository's own issues and pull requests (191 stories, 12 labels), and this change was worked through it as a single story: https://eastagiletracker.com/projects/468/stories/419869.

![board](https://raw.githubusercontent.com/eastagiletracker/jira-skill/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
