### PR TITLE
docs(changelog): record the transitions-expand finding under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- `expand=transitions.fields` under-reports the `resolution` field: a transition that reports it absent may still accept `--resolution` and set it. Attempt the transition with `--resolution` and treat only the "cannot be set" error as a rejection (intent-verbs)
+
 ## [3.29.0] - 2026-08-27
 
 ### Changed


### PR DESCRIPTION
Commit 6a561ff documented that `expand=transitions.fields` under-reports the `resolution` field but left `[Unreleased]` empty, so the release roll has no content to move under the new version heading. This adds the entry ahead of the v3.29.1 bump.