### PR TITLE
chore(release): v3.29.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
-  "version": "3.29.0",
+  "version": "3.29.1",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.29.1] - 2026-08-28
+
 ### Documentation
 
 - `expand=transitions.fields` under-reports the `resolution` field: a transition that reports it absent may still accept `--resolution` and set it. Attempt the transition with `--resolution` and treat only the "cannot be set" error as a rejection (intent-verbs)
@@ -800,7 +802,8 @@ First stable release providing comprehensive Jira integration through Claude Cod
 - [Claude Code Marketplace](https://github.com/netresearch/claude-code-marketplace)
 - [Jira Wiki Markup Reference](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
 
-[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.29.0...HEAD
+[Unreleased]: https://github.com/netresearch/jira-skill/compare/v3.29.1...HEAD
+[3.29.1]: https://github.com/netresearch/jira-skill/compare/v3.29.0...v3.29.1
 [3.29.0]: https://github.com/netresearch/jira-skill/compare/v3.28.0...v3.29.0
 [3.28.0]: https://github.com/netresearch/jira-skill/compare/v3.27.1...v3.28.0
 [3.27.1]: https://github.com/netresearch/jira-skill/compare/v3.27.0...v3.27.1

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "jira",
-  "version": "3.29.0",
+  "version": "3.29.1",
   "description": "Comprehensive Jira integration with auto-detection of issue keys",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires python 3.10+, uv. Jira Server/DC or Cloud instance with API access."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.29.0"
+  version: "3.29.1"
   repository: https://github.com/netresearch/jira-skill
 allowed-tools: Bash(python:*) Bash(uv:*) Read Write
 ---

--- a/skills/jira-syntax/SKILL.md
+++ b/skills/jira-syntax/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when writing or formatting Jira descriptions, comments, or any
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.29.0"
+  version: "3.29.1"
   repository: https://github.com/netresearch/jira-skill
 ---
 


### PR DESCRIPTION
Documents that `expand=transitions.fields` under-reports the `resolution` field: a transition reporting it absent may still accept `--resolution` and set it, so only the "cannot be set" error counts as a rejection.