### PR TITLE
refactor(jira-communication): declare the shipped scripts in allowed-tools, not the interpreter

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   author: Netresearch DTT GmbH
   version: "3.29.1"
   repository: https://github.com/netresearch/jira-skill
-allowed-tools: Bash(python:*) Bash(uv:*) Read Write
+allowed-tools: Bash(uv run ${CLAUDE_SKILL_DIR}/scripts/*) Bash(${CLAUDE_SKILL_DIR}/scripts/*) Read Write
 ---
 
 # Jira Communication

--- a/skills/jira-communication/references/multi-profile.md
+++ b/skills/jira-communication/references/multi-profile.md
@@ -23,8 +23,8 @@ If none of the above match, the script raises an error listing available profile
 All scripts accept `--profile` (or `-P`) to select a profile explicitly:
 
 ```bash
-uv run scripts/core/jira-issue.py --profile cloud get WEB-123
-uv run scripts/core/jira-search.py --profile server query "project = OPS"
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py --profile cloud get WEB-123
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py --profile server query "project = OPS"
 ```
 
 ## `~/.jira/profiles.json` Format

--- a/skills/jira-communication/references/troubleshooting.md
+++ b/skills/jira-communication/references/troubleshooting.md
@@ -8,7 +8,7 @@ Load this reference whenever any script returns a non-zero exit code related to 
 
 Always start with:
 ```bash
-uv run scripts/core/jira-validate.py --verbose
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-validate.py --verbose
 ```
 
 ### Exit Codes
@@ -131,10 +131,10 @@ A script's first invocation warms **its own** environment, so later calls to *th
 **Fix**: Move flags before subcommand:
 ```bash
 # Wrong
-uv run scripts/core/jira-issue.py get PROJ-123 --json
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py get PROJ-123 --json
 
 # Correct
-uv run scripts/core/jira-issue.py --json get PROJ-123
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py --json get PROJ-123
 ```
 
 ### "Cannot index array with string" (`--json` payload shape)
@@ -156,10 +156,10 @@ Shapes across the scripts (verify with `| jq -r 'type'` rather than assuming):
 
 ```bash
 # Wrong — exits 5 with: Cannot index array with string "issues"
-uv run scripts/core/jira-search.py --json query "project = OPS" | jq -r '.issues[].key'
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py --json query "project = OPS" | jq -r '.issues[].key'
 
 # Correct
-uv run scripts/core/jira-search.py --json query "project = OPS" | jq -r '.[].key'
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py --json query "project = OPS" | jq -r '.[].key'
 ```
 
 Confirm any shape you are unsure of with `… --json <cmd> | jq -r 'type'` before building the pipeline on top of it.
@@ -171,12 +171,12 @@ Confirm any shape you are unsure of with `… --json <cmd> | jq -r 'type'` befor
 **Fix**: Put query flags after the `query` subcommand:
 ```bash
 # Wrong — -f before the `query` subcommand → "Error: No such option: -f" (exit 2)
-uv run scripts/core/jira-search.py --json -f key,status query "project = OPS"
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py --json -f key,status query "project = OPS"
 
 # Correct — global flags before `query`; query flags after `query`,
 # either before or after the JQL both work
-uv run scripts/core/jira-search.py --json query "project = OPS" -f key,status -n 500
-uv run scripts/core/jira-search.py --json query -f key,status -n 500 "project = OPS"
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py --json query "project = OPS" -f key,status -n 500
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py --json query -f key,status -n 500 "project = OPS"
 ```
 
 ### "Transition 'X' not available" (passing the transition ID)
@@ -186,10 +186,10 @@ uv run scripts/core/jira-search.py --json query -f key,status -n 500 "project = 
 **Fix**: Pass the destination status, in quotes:
 ```bash
 # Wrong — 311 is the transition ID from `list`
-uv run scripts/workflow/jira-transition.py do PROJ-123 311
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-transition.py do PROJ-123 311
 
 # Correct — the To-Status name
-uv run scripts/workflow/jira-transition.py do PROJ-123 "Resolved"
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-transition.py do PROJ-123 "Resolved"
 ```
 When two transitions share a name but differ by icon (e.g. "✅ QA" → Resolved vs "❌ QA" → Reopened), disambiguate by passing the **target status** ("Resolved" / "Reopened"), which is unique.
 
@@ -217,7 +217,7 @@ When two transitions share a name but differ by icon (e.g. "✅ QA" → Resolved
 
 Add `--debug` for full stack traces:
 ```bash
-uv run scripts/core/jira-issue.py --debug get PROJ-123
+uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-issue.py --debug get PROJ-123
 ```
 
 ## Auth Mode Detection


### PR DESCRIPTION
Applies the rule from netresearch/skill-repo-skill#272: a skill that ships scripts declares the scripts, not the interpreter.

```yaml
- allowed-tools: Bash(python:*) Bash(uv:*) Read Write
+ allowed-tools: Bash(uv run ${CLAUDE_SKILL_DIR}/scripts/*) Bash(${CLAUDE_SKILL_DIR}/scripts/*) Read Write
```

This skill had already adopted the convention in its body: 140 of its 153 documented invocations read `uv run ${CLAUDE_SKILL_DIR}/scripts/…`. Only the frontmatter still granted the interpreters.

## `Bash(python:*)` was dead as written

The only direct interpreter call in the references is `python3 -c "import sys,json; …"`, and a rule keyed on `python` never matched the `python3` prefix — so that rule granted nothing to the one call it might have been meant for, while pre-approving every `python …` command the skill could otherwise issue. Removed rather than widened. That inline call now prompts, which is the right outcome for an interpreter invocation carrying arbitrary code.

The remaining 13 relative `uv run scripts/…` invocations are normalised to `${CLAUDE_SKILL_DIR}` in the same commit, because a rule that does not match the documented call is worse than the broad one it replaces — it produces a prompt per call that people click away.

`jira-syntax` needs no change: it already invokes its script via `${CLAUDE_SKILL_DIR}` and declares no `allowed-tools` at all.

## Verification

```
validate-skill.sh: 0 errors, 18 warnings — identical to main, no new ones
pre-commit run --files <changed>: all hooks pass
```

Not verified end to end: a session with permission prompts bypassed cannot show whether a pattern matches. #272 documents what the check can and cannot conclude.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01JYQciiXoiApXBfcJrFMnA9)_
