### PR TITLE
feat(jira-communication): transitions declare their own rules, so show and obey them

### DIFF
--- a/skills/jira-communication/SKILL.md
+++ b/skills/jira-communication/SKILL.md
@@ -53,6 +53,8 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-worklog.py add PROJ-123 2h --commen
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-create.py issue PROJ "Summary" --type Task
 ```
 
+> **Transitions**: `list` shows each transition's id and what its screen requires; pass the **id** to `do` — a name or
+> a target status is not always unique, and an ambiguous one is refused rather than guessed.
 > **Terminal transitions**: pass `--resolution <value>` (`Done`, `Won't do`); if rejected ("cannot be set"),
 > retry without it — `references/intent-verbs.md`. **Versions**: read `references/versions.md` before `jira-version.py`.
 > **Mentions**: posting commands verify `[~username]` (miss → suggestions); `get`/`work` print usernames (`references/fields-and-users.md`).

--- a/skills/jira-communication/references/intent-verbs.md
+++ b/skills/jira-communication/references/intent-verbs.md
@@ -201,4 +201,4 @@ Returns: description + Sebastian's scope-setting handover comment + Björn's ful
 
 ## Transition names are exact strings
 
-`jira-transition.py do KEY "<name>"` matches the transition name verbatim — including emoji prefixes some instances configure (e.g. `✅ Resolve`, `❌ QA failed`). On mismatch the error lists the available names; copy the wanted one exactly as printed. `jira-issue.py act KEY` shows them up front.
+`jira-transition.py do KEY <selector>` takes a transition ID, a transition name, or a target status name. Prefer the ID from `jira-transition.py list`: names carry emoji prefixes on some instances (`✅ Resolve`, `❌ QA failed`), two transitions can share a name up to that emoji, and two can share a target status — an ambiguous selector is refused with its candidates rather than resolved to a guess. On mismatch the error lists the available transitions with their IDs. `jira-issue.py act KEY` shows them up front.

--- a/skills/jira-communication/references/troubleshooting.md
+++ b/skills/jira-communication/references/troubleshooting.md
@@ -179,19 +179,26 @@ uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py --json query "project = O
 uv run ${CLAUDE_SKILL_DIR}/scripts/core/jira-search.py --json query -f key,status -n 500 "project = OPS"
 ```
 
-### "Transition 'X' not available" (passing the transition ID)
+### "Transition 'X' not available"
 
-**Cause**: `jira-transition.py do` expects the **target status name**, not the numeric transition ID that `jira-transition.py list` prints in its leftmost column.
+**Cause**: the selector matched no transition offered from the issue's current status. `do` accepts a transition ID, a transition name, or a target status name — so this means none of the three matched, not that the wrong kind was passed.
 
-**Fix**: Pass the destination status, in quotes:
+**Fix**: list what the issue actually offers, then pass the ID from the leftmost column:
 ```bash
-# Wrong — 311 is the transition ID from `list`
+uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-transition.py list PROJ-123
 uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-transition.py do PROJ-123 311
-
-# Correct — the To-Status name
-uv run ${CLAUDE_SKILL_DIR}/scripts/workflow/jira-transition.py do PROJ-123 "Resolved"
 ```
-When two transitions share a name but differ by icon (e.g. "✅ QA" → Resolved vs "❌ QA" → Reopened), disambiguate by passing the **target status** ("Resolved" / "Reopened"), which is unique.
+
+### "Transition 'X' is ambiguous"
+
+**Cause**: the name or target status matched more than one transition, and they are not interchangeable.
+
+**Fix**: pass the ID. Neither a name nor a target status is a reliable handle:
+
+- two transitions can share a **name** up to an emoji — `✅ QA` → Resolved beside `❌ QA` → Reopened, opposite outcomes;
+- two can share a **target** — `✅ Done` → Closed beside `✖ Close` → Closed, where only the second demands a resolution.
+
+`list` shows the ID, the target, and what each transition's screen requires. The ID is the only selector that means exactly one thing.
 
 ### "Issue does not exist"
 

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -257,8 +257,10 @@ def find_matching_transition(transitions: list[dict], status_name: str) -> tuple
     transition listing is the only unambiguous handle, so accept it.
 
     Tier 1 collects *all* exact matches rather than returning the first. Silently
-    picking one of two transitions that lead to different places is how a ticket
-    ends up Reopened when the reviewer meant Resolved.
+    picking one of two is how a ticket ends up Reopened when the reviewer meant
+    Resolved — or Closed by the transition that asks for nothing, when the one
+    that demands a resolution was the point. Both failures are above; the second
+    leaves no trace in the status.
     """
     selector = (status_name or "").strip()
 
@@ -436,7 +438,15 @@ def do_transition(
             if ambiguous:
                 rows = ", ".join(f"{t.get('id')} {t.get('name')} → {_get_to_status(t)}" for t in ambiguous)
                 error(f"Transition '{status_name}' is ambiguous for {issue_key}")
-                print(f"\nMatches: {rows}\nThese lead to different places. Pass the transition ID, not the name.")
+                # Not "these lead to different places": the case that motivated
+                # this is two transitions with the SAME target that differ in
+                # what their screens require. Saying they diverge by destination
+                # sends the reader to compare the one column where they agree.
+                print(
+                    f"\nMatches: {rows}\n"
+                    "These are distinct transitions and may differ in what they require, "
+                    "even where they share a target. Pass the transition ID, not the name."
+                )
             else:
                 available = ", ".join(f"{t.get('id')} {t.get('name')}" for t in transitions)
                 error(f"Transition '{status_name}' not available for {issue_key}")

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -75,7 +75,11 @@ def fetch_transitions(client, issue_key: str) -> list[dict]:
             # transitions" -- not a reason to ask again. Retrying there turns a
             # legitimate empty result into an error whenever the second call
             # fails.
-            if isinstance(transitions, list):
+            #
+            # Entries still have to be dicts: every caller does t.get(...), so a
+            # malformed member would raise past the fallback instead of using
+            # it, which is the failure this whole function exists to avoid.
+            if isinstance(transitions, list) and all(isinstance(t, dict) for t in transitions):
                 return transitions
     except Exception:  # noqa: BLE001 - any API/library shape problem falls back
         pass
@@ -420,7 +424,7 @@ def do_transition(
         if comment:
             payload["update"] = {"comment": [{"add": {"body": comment}}]}
 
-        client.post(f"rest/api/2/issue/{issue_key}/transitions", json=payload)
+        client.post(f"rest/api/2/issue/{issue_key}/transitions", data=payload)
 
         if ctx.obj["quiet"]:
             print(issue_key)

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -613,7 +613,24 @@ def path_transition(
 
             fields = {"resolution": {"name": resolution}} if (resolution and is_final) else {}
             update = {"comment": [{"add": {"body": comment}}]} if (comment and is_final) else None
-            client.set_issue_status(issue_key, to_status, fields=fields or None, update=update)
+
+            # By id, for the same reason `do` is. set_issue_status() re-resolves
+            # the target through get_transition_id_to_status_name(), which
+            # returns the FIRST transition whose target matches the name -- so
+            # the walker's own choice is discarded wherever two transitions
+            # share a target, which is exactly where the choice mattered. It
+            # also returns None when nothing matches, posting a null id, and
+            # spends an extra round-trip re-fetching what `chosen` already holds.
+            #
+            # No id guard here, unlike `do`: these come from
+            # get_issue_transitions(), which builds every entry with
+            # int(transition["id"]) and so cannot hand out one without an id.
+            payload: dict = {"transition": {"id": str(chosen["id"])}}
+            if fields:
+                payload["fields"] = fields
+            if update:
+                payload["update"] = update
+            client.post(f"rest/api/2/issue/{issue_key}/transitions", data=payload)
 
             chain.append(to_status)
             visited.add(to_status.lower())

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -368,9 +368,14 @@ def do_transition(
                 print(f"\nAvailable transitions: {available}")
             sys.exit(1)
 
+        # Without the screen we do not know what this transition wants, and
+        # saying "-" would claim it wants nothing — the same conflation `list`
+        # avoids with `?`. Skip the pre-check and say so, rather than implying a
+        # check happened.
+        spec_known = "fields" in matching
         required = required_fields(matching)
         supplied = {"resolution"} if resolution else set()
-        missing = [f for f in required if f not in supplied]
+        missing = [f for f in required if f not in supplied] if spec_known else []
 
         # Dry run
         if dry_run:
@@ -378,7 +383,13 @@ def do_transition(
             print(f"\nWould transition {issue_key}:")
             print(f"  Transition: {matching['name']} (id {matching.get('id')})")
             print(f"  To status: {_get_to_status(matching)}")
-            print(f"  Requires: {', '.join(required) or '-'}")
+            print(f"  Requires: {(', '.join(required) or '-') if spec_known else '?'}")
+            if not spec_known:
+                print(
+                    "  The field spec was not returned, so required fields were "
+                    "NOT checked — `?` is not `-`. The transition may still be "
+                    "rejected for a field nothing here could see."
+                )
             if comment:
                 print(f"  Comment: {comment}")
             if resolution:

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -103,6 +103,29 @@ def _ambiguous_selectors(transitions: list[dict]) -> list[str]:
     return notes
 
 
+def _missing_hint(missing: list[str]) -> str:
+    """What to do about the fields this transition declares and we did not send.
+
+    Only `resolution` has a flag here. Naming --resolution for an unmet
+    `assignee` or a custom field would send the reader after an option that
+    cannot help them.
+    """
+    flagged = [f for f in missing if f == "resolution"]
+    other = [f for f in missing if f != "resolution"]
+    parts = ["This is the transition's own screen talking, not a convention."]
+    if flagged:
+        parts.append("Pass --resolution <name> for `resolution`.")
+    if other:
+        parts.append(
+            "No flag exists here for "
+            + ", ".join(f"`{f}`" for f in other)
+            + " — POST the transition yourself with those fields, or choose a "
+            "transition that does not ask for them."
+        )
+    parts.append("`list` shows the requirements per transition.")
+    return " ".join(parts)
+
+
 def required_fields(transition: dict) -> list[str]:
     """Field keys this transition's screen marks required.
 
@@ -248,18 +271,28 @@ def list_transitions(ctx, issue_key: str):
             else:
                 rows = []
                 for t in transitions:
-                    req = required_fields(t)
-                    optional = [f for f in settable_fields(t) if f not in req]
+                    # "-" would read as "requires nothing". Without the screen
+                    # we do not know, and that is a different statement -- the
+                    # exact confusion required_fields() warns about.
+                    if "fields" not in t:
+                        requires = accepts = "?"
+                    else:
+                        req = required_fields(t)
+                        optional = [f for f in settable_fields(t) if f not in req]
+                        requires = ", ".join(req) or "-"
+                        accepts = ", ".join(optional) or "-"
                     rows.append(
                         {
                             "ID": t.get("id", ""),
                             "Name": t.get("name", ""),
                             "To Status": _get_to_status(t),
-                            "Requires": ", ".join(req) or "-",
-                            "Also accepts": ", ".join(optional) or "-",
+                            "Requires": requires,
+                            "Also accepts": accepts,
                         }
                     )
                 print(format_table(rows, ["ID", "Name", "To Status", "Requires", "Also accepts"]))
+                if any("fields" not in t for t in transitions):
+                    print("\n`?` means the field spec was not returned, not that the transition requires nothing.")
                 dupes = _ambiguous_selectors(transitions)
                 if dupes:
                     print(
@@ -352,20 +385,13 @@ def do_transition(
                 print(f"  Resolution: {resolution}")
             if missing:
                 error("Missing required field(s) for this transition: " + ", ".join(missing))
-                print(
-                    "  The transition's own screen declares them. Supply them "
-                    "(e.g. --resolution) or pick a transition that does not ask."
-                )
+                print("  " + _missing_hint(missing))
                 sys.exit(1)
             return
 
         if missing:
             error(f"Transition '{matching['name']}' requires: {', '.join(missing)}")
-            print(
-                "\nThis is the transition's own screen talking, not a convention — "
-                "supply the field (e.g. --resolution Done), or choose a transition "
-                "that does not require it. `list` shows the requirements per transition."
-            )
+            print("\n" + _missing_hint(missing))
             sys.exit(1)
 
         # Build transition payload

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -75,7 +75,6 @@ def fetch_transitions(client, issue_key: str) -> list[dict]:
             # transitions" -- not a reason to ask again. Retrying there turns a
             # legitimate empty result into an error whenever the second call
             # fails.
-            #
             if isinstance(transitions, list) and all(_usable_transition(t) for t in transitions):
                 return transitions
     except Exception:  # noqa: BLE001 - any API/library shape problem falls back
@@ -358,7 +357,7 @@ def list_transitions(ctx, issue_key: str):
 
 @cli.command("do")
 @click.argument("issue_key")
-@click.argument("status_name")
+@click.argument("status_name", metavar="TRANSITION")
 @click.option("--comment", "-c", help="Comment to add during transition")
 @click.option("--resolution", "-r", help="Resolution name (for closing transitions)")
 @click.option("--no-verify-mentions", is_flag=True, help="Skip [~username] mention verification in --comment")
@@ -377,9 +376,16 @@ def do_transition(
 
     ISSUE_KEY: The Jira issue key (e.g., PROJ-123)
 
-    STATUS_NAME: Target status name (e.g., "In Progress", "Done")
+    TRANSITION: A transition id, a transition name, or a target status name.
+
+    Prefer the id from `list`. A name or a target is not always a unique
+    handle — one status can offer "✅ Done → Closed" beside "✖ Close →
+    Closed", which differ in what they require — and an ambiguous selector is
+    refused with its candidates rather than resolved to a guess.
 
     Examples:
+
+      jira-transition do PROJ-123 341
 
       jira-transition do PROJ-123 "In Progress"
 

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -54,28 +54,113 @@ def _normalize_transition_name(name: str) -> str:
     return re.sub(r"^\W+", "", name or "", flags=re.UNICODE).strip().casefold()
 
 
-def find_matching_transition(transitions: list[dict], status_name: str) -> tuple[dict | None, list[dict]]:
-    """Resolve a user-supplied name to a transition, tolerating emoji prefixes.
+def fetch_transitions(client, issue_key: str) -> list[dict]:
+    """Available transitions **with their screens**.
 
-    Tiers, first hit wins: (1) exact case-insensitive on transition name or
-    target status; (2) normalized equality (emoji/symbol prefix stripped);
-    (3) unique normalized-substring match. Returns (match, candidates): match is
-    the resolved transition or None; candidates lists the >1 transitions that an
-    ambiguous substring matched (empty otherwise), so the caller can report them.
+    The bare listing answers half the question: which transitions exist. The
+    other half — what each one requires — lives in the screen, and only
+    ``expand=transitions.fields`` returns it. Without the expansion a caller
+    cannot tell "requires nothing" from "nobody asked", which is exactly the
+    confusion that put twelve status changes into two tickets that needed two.
+
+    Falls back to the unexpanded listing if the instance or library version does
+    not support the expansion, so this degrades to the previous behaviour rather
+    than failing.
     """
-    target = status_name.casefold()
-    for t in transitions:
-        if t.get("name", "").casefold() == target or _get_to_status(t).casefold() == target:
-            return t, []
+    try:
+        raw = client.get_issue_transitions_full(issue_key, expand="transitions.fields")
+        transitions = raw.get("transitions") if isinstance(raw, dict) else None
+        if transitions:
+            return transitions
+    except Exception:  # noqa: BLE001 - any API/library shape problem falls back
+        pass
+    return client.get_issue_transitions(issue_key)
+
+
+def _ambiguous_selectors(transitions: list[dict]) -> list[str]:
+    """Human-readable notes for names or targets shared by >1 transition."""
+    notes = []
+    for key, label in (("name", "name"), ("to", "target")):
+        seen: dict[str, list[dict]] = {}
+        for t in transitions:
+            value = _normalize_transition_name(t.get("name", "")) if key == "name" else _get_to_status(t).casefold()
+            if value:
+                seen.setdefault(value, []).append(t)
+        for value, group in seen.items():
+            if len(group) > 1:
+                ids = ", ".join(f"{t.get('id')} ({t.get('name')})" for t in group)
+                notes.append(f"{label} {value!r} → {ids}")
+    return notes
+
+
+def required_fields(transition: dict) -> list[str]:
+    """Field keys this transition's screen marks required.
+
+    Present only when the transitions were fetched with
+    ``expand=transitions.fields``; an unexpanded transition yields ``[]``, which
+    is indistinguishable from "requires nothing" — so callers that care must ask
+    for the expansion rather than infer from a bare listing.
+    """
+    return sorted(k for k, v in (transition.get("fields") or {}).items() if v.get("required"))
+
+
+def settable_fields(transition: dict) -> list[str]:
+    """Every field key this transition's screen accepts, required or not."""
+    return sorted((transition.get("fields") or {}).keys())
+
+
+def find_matching_transition(transitions: list[dict], status_name: str) -> tuple[dict | None, list[dict]]:
+    """Resolve a user-supplied name or id to a transition, tolerating emoji prefixes.
+
+    Tiers, first hit wins: (0) exact transition **id**; (1) exact
+    case-insensitive on transition name or target status; (2) normalized
+    equality (emoji/symbol prefix stripped); (3) unique normalized-substring
+    match. Returns (match, candidates): match is the resolved transition or
+    None; candidates lists the >1 transitions an ambiguous selector matched
+    (empty otherwise), so the caller can report them.
+
+    Tier 0 exists because a name is not always a usable selector: two
+    transitions from one status can share a target (``✅ Done → Closed`` and
+    ``✖ Close → Closed``, which differ in whether they require a resolution),
+    and two can share a display name up to an emoji (``✅ QA → Resolved`` and
+    ``❌ QA → Reopened``, which are opposite outcomes). The id from the
+    transition listing is the only unambiguous handle, so accept it.
+
+    Tier 1 collects *all* exact matches rather than returning the first. Silently
+    picking one of two transitions that lead to different places is how a ticket
+    ends up Reopened when the reviewer meant Resolved.
+    """
+    selector = (status_name or "").strip()
+
+    by_id = [t for t in transitions if str(t.get("id", "")) == selector]
+    if by_id:
+        return by_id[0], []
+
+    target = selector.casefold()
+    exact = [t for t in transitions if t.get("name", "").casefold() == target or _get_to_status(t).casefold() == target]
+    if len(exact) == 1:
+        return exact[0], []
+    if len(exact) > 1:
+        return None, exact
 
     norm_target = _normalize_transition_name(status_name)
     if norm_target:
-        for t in transitions:
-            if norm_target in (
+        # Same rule one tier down: `QA` normalizes to the same string for both
+        # `✅ QA → Resolved` and `❌ QA → Reopened`, so collect and report rather
+        # than take the first.
+        norm_exact = [
+            t
+            for t in transitions
+            if norm_target
+            in (
                 _normalize_transition_name(t.get("name", "")),
                 _normalize_transition_name(_get_to_status(t)),
-            ):
-                return t, []
+            )
+        ]
+        if len(norm_exact) == 1:
+            return norm_exact[0], []
+        if len(norm_exact) > 1:
+            return None, norm_exact
 
         substring = [
             t
@@ -133,7 +218,7 @@ def list_transitions(ctx, issue_key: str):
     client = ctx.obj["client"]
 
     try:
-        transitions = client.get_issue_transitions(issue_key)
+        transitions = fetch_transitions(client, issue_key)
 
         if ctx.obj["json"]:
             format_output(transitions, as_json=True)
@@ -153,8 +238,26 @@ def list_transitions(ctx, issue_key: str):
             else:
                 rows = []
                 for t in transitions:
-                    rows.append({"ID": t.get("id", ""), "Name": t.get("name", ""), "To Status": _get_to_status(t)})
-                print(format_table(rows, ["ID", "Name", "To Status"]))
+                    req = required_fields(t)
+                    optional = [f for f in settable_fields(t) if f not in req]
+                    rows.append(
+                        {
+                            "ID": t.get("id", ""),
+                            "Name": t.get("name", ""),
+                            "To Status": _get_to_status(t),
+                            "Requires": ", ".join(req) or "-",
+                            "Also accepts": ", ".join(optional) or "-",
+                        }
+                    )
+                print(format_table(rows, ["ID", "Name", "To Status", "Requires", "Also accepts"]))
+                dupes = _ambiguous_selectors(transitions)
+                if dupes:
+                    print(
+                        "\nAmbiguous by name or target: "
+                        + "; ".join(dupes)
+                        + ".\nSelect those by ID — the label and the target status do not "
+                        "identify them."
+                    )
 
     except Exception as e:
         if ctx.obj["debug"]:
@@ -204,50 +307,73 @@ def do_transition(
         check_mentions_cli(client, comment, skip=no_verify_mentions)
 
     try:
-        # Get available transitions
-        transitions = client.get_issue_transitions(issue_key)
+        # With their screens: what each transition requires is half the answer,
+        # and a bare listing cannot express it.
+        transitions = fetch_transitions(client, issue_key)
 
-        # Find matching transition (exact → emoji-tolerant → unique substring)
+        # Find matching transition (id → exact → emoji-tolerant → unique substring)
         matching, ambiguous = find_matching_transition(transitions, status_name)
 
         if not matching:
             if ambiguous:
-                names = [t.get("name", "") for t in ambiguous]
+                rows = ", ".join(f"{t.get('id')} {t.get('name')} → {_get_to_status(t)}" for t in ambiguous)
                 error(f"Transition '{status_name}' is ambiguous for {issue_key}")
-                print(f"\nMatches: {', '.join(names)} — use the exact name")
+                print(f"\nMatches: {rows}\nThese lead to different places. Pass the transition ID, not the name.")
             else:
-                available = [t.get("name", "") for t in transitions]
+                available = ", ".join(f"{t.get('id')} {t.get('name')}" for t in transitions)
                 error(f"Transition '{status_name}' not available for {issue_key}")
-                print(f"\nAvailable transitions: {', '.join(available)}")
+                print(f"\nAvailable transitions: {available}")
             sys.exit(1)
+
+        required = required_fields(matching)
+        supplied = {"resolution"} if resolution else set()
+        missing = [f for f in required if f not in supplied]
 
         # Dry run
         if dry_run:
             warning("DRY RUN - No transition will be performed")
             print(f"\nWould transition {issue_key}:")
-            print(f"  Transition: {matching['name']}")
+            print(f"  Transition: {matching['name']} (id {matching.get('id')})")
             print(f"  To status: {_get_to_status(matching)}")
+            print(f"  Requires: {', '.join(required) or '-'}")
             if comment:
                 print(f"  Comment: {comment}")
             if resolution:
                 print(f"  Resolution: {resolution}")
+            if missing:
+                error("Missing required field(s) for this transition: " + ", ".join(missing))
+                print(
+                    "  The transition's own screen declares them. Supply them "
+                    "(e.g. --resolution) or pick a transition that does not ask."
+                )
+                sys.exit(1)
             return
+
+        if missing:
+            error(f"Transition '{matching['name']}' requires: {', '.join(missing)}")
+            print(
+                "\nThis is the transition's own screen talking, not a convention — "
+                "supply the field (e.g. --resolution Done), or choose a transition "
+                "that does not require it. `list` shows the requirements per transition."
+            )
+            sys.exit(1)
 
         # Build transition payload
         fields = {}
         if resolution:
             fields["resolution"] = {"name": resolution}
 
-        # Perform transition - API uses target status name (not transition name/ID)
-        # set_issue_status handles the transition ID lookup internally
-        target_status = _get_to_status(matching)
-
-        # Build update dict for comment if provided
-        update = None
+        # Post the transition by ID. Going via the target status name would let
+        # the API re-resolve it, and a target is not always unique: one ticket
+        # can offer `✅ Done → Closed` and `✖ Close → Closed`, which differ in
+        # what they require. The ID is the only handle that means one thing.
+        payload: dict = {"transition": {"id": str(matching.get("id"))}}
+        if fields:
+            payload["fields"] = fields
         if comment:
-            update = {"comment": [{"add": {"body": comment}}]}
+            payload["update"] = {"comment": [{"add": {"body": comment}}]}
 
-        client.set_issue_status(issue_key, target_status, fields=fields if fields else None, update=update)
+        client.post(f"rest/api/2/issue/{issue_key}/transitions", json=payload)
 
         if ctx.obj["quiet"]:
             print(issue_key)

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -69,9 +69,14 @@ def fetch_transitions(client, issue_key: str) -> list[dict]:
     """
     try:
         raw = client.get_issue_transitions_full(issue_key, expand="transitions.fields")
-        transitions = raw.get("transitions") if isinstance(raw, dict) else None
-        if transitions:
-            return transitions
+        if isinstance(raw, dict):
+            transitions = raw.get("transitions")
+            # An empty list is a successful answer -- "this issue offers no
+            # transitions" -- not a reason to ask again. Retrying there turns a
+            # legitimate empty result into an error whenever the second call
+            # fails.
+            if isinstance(transitions, list):
+                return transitions
     except Exception:  # noqa: BLE001 - any API/library shape problem falls back
         pass
     return client.get_issue_transitions(issue_key)
@@ -83,7 +88,12 @@ def _ambiguous_selectors(transitions: list[dict]) -> list[str]:
     for key, label in (("name", "name"), ("to", "target")):
         seen: dict[str, list[dict]] = {}
         for t in transitions:
-            value = _normalize_transition_name(t.get("name", "")) if key == "name" else _get_to_status(t).casefold()
+            # Normalize both sides the way find_matching_transition does.
+            # Case-folding the target only would let `✅ Closed` and `✖ Closed`
+            # be refused by `do` while `list` shows no ambiguity at all — the
+            # reader would then have no way to learn why.
+            raw_value = t.get("name", "") if key == "name" else _get_to_status(t)
+            value = _normalize_transition_name(raw_value)
             if value:
                 seen.setdefault(value, []).append(t)
         for value, group in seen.items():

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -159,6 +159,26 @@ def _transition_rows(transitions: list[dict]) -> list[dict]:
     return rows
 
 
+def _transition_footnotes(transitions: list[dict]) -> list[str]:
+    """Notes qualifying the table above them.
+
+    Both say the same kind of thing: read alone, the table looks more definite
+    than it is. `?` is not "requires nothing", and a name or target shared by
+    two transitions identifies neither.
+    """
+    notes = []
+    if any("fields" not in t for t in transitions):
+        notes.append("`?` means the field spec was not returned, not that the transition requires nothing.")
+    dupes = _ambiguous_selectors(transitions)
+    if dupes:
+        notes.append(
+            "Ambiguous by name or target: "
+            + "; ".join(dupes)
+            + ".\nSelect those by ID — the label and the target status do not identify them."
+        )
+    return notes
+
+
 def _ambiguous_selectors(transitions: list[dict]) -> list[str]:
     """Human-readable notes for names or targets shared by >1 transition."""
     notes = []
@@ -347,16 +367,8 @@ def list_transitions(ctx, issue_key: str):
                 print("No transitions available from this status")
             else:
                 print(format_table(_transition_rows(transitions), _TRANSITION_COLUMNS))
-                if any("fields" not in t for t in transitions):
-                    print("\n`?` means the field spec was not returned, not that the transition requires nothing.")
-                dupes = _ambiguous_selectors(transitions)
-                if dupes:
-                    print(
-                        "\nAmbiguous by name or target: "
-                        + "; ".join(dupes)
-                        + ".\nSelect those by ID — the label and the target status do not "
-                        "identify them."
-                    )
+                for note in _transition_footnotes(transitions):
+                    print("\n" + note)
 
     except Exception as e:
         if ctx.obj["debug"]:

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -453,6 +453,22 @@ def do_transition(
                 print(f"\nAvailable transitions: {available}")
             sys.exit(1)
 
+        # The id is what gets posted, so an entry without one cannot be acted on
+        # by either path. Formatting it anyway sends {"id": "None"} and the API
+        # answers with a rejection that says nothing about where the None came
+        # from -- and a dry run would print `(id None)` and exit 0, which is the
+        # worse of the two: it reports as safe something that cannot run.
+        # Checked before either branch, because putting it in one of them is how
+        # the contract and its caveat came to disagree earlier on this branch.
+        transition_id = matching.get("id")
+        if not transition_id:
+            error(f"Transition '{matching.get('name')}' for {issue_key} has no id")
+            print(
+                "\nThe id is the only handle a transition is posted with, and this entry "
+                "carried none. Run `list` to see what the server offers for this issue."
+            )
+            sys.exit(1)
+
         # Without the screen we do not know what this transition wants, and
         # saying "-" would claim it wants nothing — the same conflation `list`
         # avoids with `?`. Skip the pre-check and say so, rather than implying a
@@ -481,18 +497,6 @@ def do_transition(
         if missing:
             error(f"Transition '{matching['name']}' requires: {', '.join(missing)}")
             print("\n" + _missing_hint(missing))
-            sys.exit(1)
-
-        # The id is what gets posted, so an entry without one cannot be acted
-        # on. Formatting it anyway sends {"id": "None"} and the API answers with
-        # a rejection that says nothing about where the None came from.
-        transition_id = matching.get("id")
-        if not transition_id:
-            error(f"Transition '{matching.get('name')}' for {issue_key} has no id")
-            print(
-                "\nThe id is the only handle a transition is posted with, and this entry "
-                "carried none. Run `list` to see what the server offers for this issue."
-            )
             sys.exit(1)
 
         # The contract this resolved to, on the path that actually changes the

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -128,6 +128,37 @@ def _contract_lines(matching: dict, required: list[str], spec_known: bool) -> li
     return lines
 
 
+_TRANSITION_COLUMNS = ["ID", "Name", "To Status", "Requires", "Also accepts"]
+
+
+def _transition_rows(transitions: list[dict]) -> list[dict]:
+    """One table row per transition, with its screen's contract.
+
+    `-` would read as "requires nothing". Without the screen we do not know,
+    and that is a different statement — the exact confusion `required_fields`
+    warns about — so an unexpanded entry gets `?` in both columns.
+    """
+    rows = []
+    for t in transitions:
+        if "fields" in t:
+            req = required_fields(t)
+            optional = [f for f in settable_fields(t) if f not in req]
+            requires = ", ".join(req) or "-"
+            accepts = ", ".join(optional) or "-"
+        else:
+            requires = accepts = "?"
+        rows.append(
+            {
+                "ID": t.get("id", ""),
+                "Name": t.get("name", ""),
+                "To Status": _get_to_status(t),
+                "Requires": requires,
+                "Also accepts": accepts,
+            }
+        )
+    return rows
+
+
 def _ambiguous_selectors(transitions: list[dict]) -> list[str]:
     """Human-readable notes for names or targets shared by >1 transition."""
     notes = []
@@ -315,28 +346,7 @@ def list_transitions(ctx, issue_key: str):
             if not transitions:
                 print("No transitions available from this status")
             else:
-                rows = []
-                for t in transitions:
-                    # "-" would read as "requires nothing". Without the screen
-                    # we do not know, and that is a different statement -- the
-                    # exact confusion required_fields() warns about.
-                    if "fields" not in t:
-                        requires = accepts = "?"
-                    else:
-                        req = required_fields(t)
-                        optional = [f for f in settable_fields(t) if f not in req]
-                        requires = ", ".join(req) or "-"
-                        accepts = ", ".join(optional) or "-"
-                    rows.append(
-                        {
-                            "ID": t.get("id", ""),
-                            "Name": t.get("name", ""),
-                            "To Status": _get_to_status(t),
-                            "Requires": requires,
-                            "Also accepts": accepts,
-                        }
-                    )
-                print(format_table(rows, ["ID", "Name", "To Status", "Requires", "Also accepts"]))
+                print(format_table(_transition_rows(transitions), _TRANSITION_COLUMNS))
                 if any("fields" not in t for t in transitions):
                     print("\n`?` means the field spec was not returned, not that the transition requires nothing.")
                 dupes = _ambiguous_selectors(transitions)

--- a/skills/jira-communication/scripts/workflow/jira-transition.py
+++ b/skills/jira-communication/scripts/workflow/jira-transition.py
@@ -76,14 +76,57 @@ def fetch_transitions(client, issue_key: str) -> list[dict]:
             # legitimate empty result into an error whenever the second call
             # fails.
             #
-            # Entries still have to be dicts: every caller does t.get(...), so a
-            # malformed member would raise past the fallback instead of using
-            # it, which is the failure this whole function exists to avoid.
-            if isinstance(transitions, list) and all(isinstance(t, dict) for t in transitions):
+            if isinstance(transitions, list) and all(_usable_transition(t) for t in transitions):
                 return transitions
     except Exception:  # noqa: BLE001 - any API/library shape problem falls back
         pass
     return client.get_issue_transitions(issue_key)
+
+
+def _usable_transition(entry: object) -> bool:
+    """Whether an expanded transition entry can be consumed as-is.
+
+    Every caller does ``entry.get(...)`` and `required_fields` walks the field
+    spec, so a malformed member raises *past* the fallback instead of using it
+    — the failure this module's fetch exists to avoid.
+
+    An absent ``fields`` key stays valid on purpose: that is what an unexpanded
+    answer looks like, and callers already report it as `?`. Only a ``fields``
+    that is present and not a mapping of mappings is rejected.
+
+    The transition id is deliberately not checked here. Rejecting the response
+    over a missing id would fall back to ``get_issue_transitions``, which reads
+    the same endpoint and does ``int(transition["id"])`` — so the id would only
+    move the crash one layer down. `do` guards it where it is actually used.
+    """
+    if not isinstance(entry, dict):
+        return False
+    if "fields" not in entry:
+        return True
+    spec = entry["fields"]
+    return isinstance(spec, dict) and all(isinstance(v, dict) for v in spec.values())
+
+
+def _contract_lines(matching: dict, required: list[str], spec_known: bool) -> list[str]:
+    """What the selector resolved to, for whoever has to read the outcome.
+
+    Both `do` paths render this from here because they drifted once: the caveat
+    below was added to the dry run and not to the real one, so the run that
+    actually changes a ticket was the run that said least about what it was
+    doing.
+    """
+    lines = [
+        f"  Transition: {matching.get('name')} (id {matching.get('id')})",
+        f"  To status: {_get_to_status(matching)}",
+        f"  Requires: {(', '.join(required) or '-') if spec_known else '?'}",
+    ]
+    if not spec_known:
+        lines.append(
+            "  The field spec was not returned, so required fields were NOT "
+            "checked — `?` is not `-`. The transition may still be rejected "
+            "for a field nothing here could see."
+        )
+    return lines
 
 
 def _ambiguous_selectors(transitions: list[dict]) -> list[str]:
@@ -385,15 +428,8 @@ def do_transition(
         if dry_run:
             warning("DRY RUN - No transition will be performed")
             print(f"\nWould transition {issue_key}:")
-            print(f"  Transition: {matching['name']} (id {matching.get('id')})")
-            print(f"  To status: {_get_to_status(matching)}")
-            print(f"  Requires: {(', '.join(required) or '-') if spec_known else '?'}")
-            if not spec_known:
-                print(
-                    "  The field spec was not returned, so required fields were "
-                    "NOT checked — `?` is not `-`. The transition may still be "
-                    "rejected for a field nothing here could see."
-                )
+            for line in _contract_lines(matching, required, spec_known):
+                print(line)
             if comment:
                 print(f"  Comment: {comment}")
             if resolution:
@@ -409,6 +445,26 @@ def do_transition(
             print("\n" + _missing_hint(missing))
             sys.exit(1)
 
+        # The id is what gets posted, so an entry without one cannot be acted
+        # on. Formatting it anyway sends {"id": "None"} and the API answers with
+        # a rejection that says nothing about where the None came from.
+        transition_id = matching.get("id")
+        if not transition_id:
+            error(f"Transition '{matching.get('name')}' for {issue_key} has no id")
+            print(
+                "\nThe id is the only handle a transition is posted with, and this entry "
+                "carried none. Run `list` to see what the server offers for this issue."
+            )
+            sys.exit(1)
+
+        # The contract this resolved to, on the path that actually changes the
+        # ticket -- not only under --dry-run. When the POST is rejected for a
+        # field, this is what tells the reader whether it was even checked.
+        if not ctx.obj["quiet"] and not ctx.obj["json"]:
+            print(f"Transitioning {issue_key}:")
+            for line in _contract_lines(matching, required, spec_known):
+                print(line)
+
         # Build transition payload
         fields = {}
         if resolution:
@@ -418,7 +474,7 @@ def do_transition(
         # the API re-resolve it, and a target is not always unique: one ticket
         # can offer `✅ Done → Closed` and `✖ Close → Closed`, which differ in
         # what they require. The ID is the only handle that means one thing.
-        payload: dict = {"transition": {"id": str(matching.get("id"))}}
+        payload: dict = {"transition": {"id": str(transition_id)}}
         if fields:
             payload["fields"] = fields
         if comment:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -446,13 +446,21 @@ class TestMockedCommands:
     def test_transition_do_dry_run(self):
         """jira-transition do with --dry-run must not call API."""
         mock_client = self._make_mock_client()
-        mock_client.get_issue_transitions.return_value = [{"name": "In Progress", "to": {"name": "In Progress"}}]
+        # With an id, as get_issue_transitions always returns them: it builds
+        # every entry with int(transition["id"]), so an id-less transition is
+        # not a shape a real server can produce.
+        mock_client.get_issue_transitions.return_value = [
+            {"id": "11", "name": "In Progress", "to": {"name": "In Progress"}}
+        ]
         runner = click.testing.CliRunner()
         with mock.patch("lib.client.get_jira_client", return_value=mock_client):
             result = runner.invoke(_transition_mod.cli, ["do", "TEST-1", "In Progress", "--dry-run"])
         assert result.exit_code == 0, result.output
         assert "DRY RUN" in result.output
-        mock_client.set_issue_status.assert_not_called()
+        # The POST is what "must not call API" means here; set_issue_status is
+        # not on this command's path at all, so asserting it went uncalled
+        # asserted nothing.
+        mock_client.post.assert_not_called()
 
     def test_link_create_dry_run(self):
         """jira-link create with --dry-run must not call API."""

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -424,3 +424,35 @@ class TestDoHelpNamesTheIdSelector:
         """`path` genuinely walks toward a status -- its metavar stays."""
         usage = self._usage(["path", "--help"])
         assert usage.endswith("ISSUE_KEY TARGET_STATUS"), usage
+
+
+class TestTransitionRows:
+    """The `?` / `-` distinction, now reachable without going through the CLI.
+
+    It is the point of the change and it lived inside the `list` command body,
+    where only a rendered table could exercise it.
+    """
+
+    def test_an_unexpanded_entry_is_unknown_in_both_columns(self):
+        (row,) = _mod._transition_rows([{"id": "1", "name": "Go", "to": "Done"}])
+        assert row["Requires"] == "?"
+        assert row["Also accepts"] == "?"
+
+    def test_an_expanded_entry_with_an_empty_screen_requires_nothing(self):
+        (row,) = _mod._transition_rows([{"id": "1", "name": "Go", "to": "Done", "fields": {}}])
+        assert row["Requires"] == "-"
+        assert row["Also accepts"] == "-"
+
+    def test_required_and_optional_are_separated(self):
+        (row,) = _mod._transition_rows(
+            [
+                {
+                    "id": "341",
+                    "name": "Close",
+                    "to": "Closed",
+                    "fields": {"resolution": {"required": True}, "assignee": {"required": False}},
+                }
+            ]
+        )
+        assert row["Requires"] == "resolution"
+        assert row["Also accepts"] == "assignee"

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -206,3 +206,21 @@ class TestSecondRoundFindings:
     def test_missing_hint_covers_a_mixed_set(self):
         hint = _mod._missing_hint(["resolution", "assignee"])
         assert "--resolution" in hint and "assignee" in hint
+
+
+class TestUnknownSpecInDo:
+    """`do` must not claim a check it could not perform.
+
+    `list` renders `?` where the screen was not returned. `do` printed `-` and
+    silently skipped the required-field pre-check — the same conflation of
+    "requires nothing" with "nobody asked", one command over.
+    """
+
+    def test_required_fields_cannot_speak_for_an_unexpanded_transition(self):
+        unexpanded = {"id": "1", "name": "Go", "to": "Done"}
+        assert "fields" not in unexpanded
+        assert _mod.required_fields(unexpanded) == []
+
+    def test_an_expanded_transition_without_requirements_is_a_real_answer(self):
+        assert "fields" in _tf("2", "Done", "Closed")
+        assert _mod.required_fields(_tf("2", "Done", "Closed")) == []

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -566,19 +566,27 @@ class TestPathPostsTheChosenOneNotTheFirst:
         _, kwargs = client.post.call_args
         assert kwargs["data"]["transition"] == {"id": "341"}
 
-    def test_the_single_forward_step_is_not_the_first_entry(self):
+    def test_the_forward_branch_picks_the_forward_one_not_the_first(self):
         """The dangerous shape: `chosen` comes from forward[0], and index 0 is
-        the backward transition that filtering just excluded."""
-        client = self._client(
-            [
-                {"id": 999, "name": "Reopen", "to": "Reopened"},
-                {"id": 500, "name": "Pick up", "to": "Done"},
+        the backward transition that filtering just excluded.
+
+        The target must be unreachable in step 1, or the direct-match line above
+        the branch resolves first and this never enters it -- which is exactly
+        how the first version of this test managed to duplicate its sibling.
+        """
+        client = self._client([])
+        client.get_issue_transitions = mock.Mock(
+            side_effect=[
+                # "Done" is not offered yet: the walker must filter Reopen and
+                # take the single forward step, which is NOT transitions[0].
+                [{"id": 999, "name": "Reopen", "to": "Reopened"}, {"id": 500, "name": "Pick up", "to": "In Progress"}],
+                [{"id": 999, "name": "Reopen", "to": "Reopened"}, {"id": 600, "name": "Finish", "to": "Done"}],
             ]
         )
         result, _ = run_cli(_mod, ["path", "X-1", "Done"], client)
         assert result.exit_code == 0, result.output
         posted = [c.kwargs["data"]["transition"]["id"] for c in client.post.call_args_list]
-        assert posted == ["500"]
+        assert posted == ["500", "600"]
         assert "999" not in posted
 
 

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -456,3 +456,23 @@ class TestTransitionRows:
         )
         assert row["Requires"] == "resolution"
         assert row["Also accepts"] == "assignee"
+
+
+class TestTransitionFootnotes:
+    """The two qualifications under the table, reachable without rendering one."""
+
+    def test_no_notes_when_every_screen_is_known_and_unique(self):
+        ts = [_tf("1", "Go", "Done"), _tf("2", "Stop", "Closed")]
+        assert _mod._transition_footnotes(ts) == []
+
+    def test_an_unexpanded_entry_earns_the_question_mark_note(self):
+        ts = [{"id": "1", "name": "Go", "to": "Done"}]
+        (note,) = _mod._transition_footnotes(ts)
+        assert "not that the transition requires nothing" in note
+
+    def test_a_shared_target_earns_the_ambiguity_note(self):
+        ts = [_tf("381", "✅ Done", "Closed"), _tf("341", "✖ Close", "Closed")]
+        (note,) = _mod._transition_footnotes(ts)
+        assert "381" in note
+        assert "341" in note
+        assert "Select those by ID" in note

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -13,7 +13,9 @@ _mod = load_script("jira-transition", "workflow")
 
 
 def _t(name: str, to: str):
-    return {"id": name, "name": name, "to": to}
+    """The id is deliberately distinct from the name, so a test asserting one
+    cannot pass on the other."""
+    return {"id": f"id-{name}", "name": name, "to": to}
 
 
 class TestFindMatchingTransition:

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -389,3 +389,35 @@ class TestPathPostsById:
         _, kwargs = client.post.call_args
         assert kwargs["data"]["fields"] == {"resolution": {"name": "Fixed"}}
         assert kwargs["data"]["update"]["comment"][0]["add"]["body"] == "done here"
+
+
+class TestDoHelpNamesTheIdSelector:
+    """`do`'s help said "Target status name" while the id is the reliable handle.
+
+    The usage line is the first thing an operator reads, and STATUS_NAME there
+    said ids were not accepted -- in the command whose whole point is that a
+    name is not always a usable selector.
+
+    These assert the *usage line*, not the help text as a whole: a metavar and
+    the prose that explains it both mention the same words, so a whole-output
+    match passes on the prose while the usage line still says the wrong thing.
+    """
+
+    @staticmethod
+    def _usage(args):
+        result, _ = run_cli(_mod, args)
+        return next(ln for ln in result.output.splitlines() if ln.startswith("Usage:"))
+
+    def test_usage_line_offers_a_transition_not_a_status_name(self):
+        usage = self._usage(["do", "--help"])
+        assert usage.endswith("ISSUE_KEY TRANSITION"), usage
+
+    def test_help_says_an_id_is_accepted_and_preferred(self):
+        result, _ = run_cli(_mod, ["do", "--help"])
+        assert "transition id" in result.output
+        assert "Prefer the id" in result.output
+
+    def test_path_still_takes_a_target_status(self):
+        """`path` genuinely walks toward a status -- its metavar stays."""
+        usage = self._usage(["path", "--help"])
+        assert usage.endswith("ISSUE_KEY TARGET_STATUS"), usage

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -7,8 +7,7 @@ adds emoji-tolerant and unique-substring fallbacks on top of exact matching.
 
 from unittest import mock
 
-from click.testing import CliRunner
-from conftest import load_script, make_mock_client
+from conftest import load_script, make_mock_client, run_cli
 
 _mod = load_script("jira-transition", "workflow")
 
@@ -308,8 +307,7 @@ class TestDoCommandOutput:
 
     @staticmethod
     def _run(client, args):
-        with mock.patch.object(_mod, "LazyJiraClient", return_value=client):
-            return CliRunner().invoke(_mod.cli, args)
+        return run_cli(_mod, args, client)[0]
 
     _DONE = {"id": "41", "name": "✅ Done", "to": {"name": "Closed"}, "fields": {"resolution": {"required": True}}}
 
@@ -347,3 +345,47 @@ class TestDoCommandOutput:
         client = self._client([self._DONE])
         result = self._run(client, ["--quiet", "do", "X-1", "Done", "-r", "Fixed"])
         assert result.output.strip() == "X-1"
+
+
+class TestPathPostsById:
+    """`path` chose a transition and then discarded it.
+
+    It called `set_issue_status(key, to_status)`, whose
+    `get_transition_id_to_status_name` returns the FIRST transition matching the
+    target name -- so wherever two transitions share a target, which is the only
+    case where choosing mattered, the walker's choice was thrown away, and an
+    extra round-trip was spent re-resolving what it already held.
+
+    These use the shape `client.get_issue_transitions()` returns -- `to` is a
+    plain string there, not an object -- because that is what `path` reads.
+    """
+
+    @staticmethod
+    def _client(transitions):
+        client = make_mock_client()
+        client.issue = mock.Mock(return_value={"fields": {"status": {"name": "Open"}}})
+        client.get_issue_transitions = mock.Mock(return_value=transitions)
+        client.set_issue_status = mock.Mock(side_effect=AssertionError("must not resolve by name"))
+        client.post = mock.Mock(return_value={})
+        return client
+
+    def test_it_posts_the_chosen_id_where_two_transitions_share_a_target(self):
+        client = self._client(
+            [
+                {"id": 381, "name": "\u2705 Done", "to": "Closed"},
+                {"id": 341, "name": "\u2716 Close", "to": "Closed"},
+            ]
+        )
+        result, _ = run_cli(_mod, ["path", "X-1", "Closed"], client)
+        assert result.exit_code == 0, result.output
+        client.set_issue_status.assert_not_called()
+        _, kwargs = client.post.call_args
+        assert kwargs["data"]["transition"] == {"id": "381"}
+
+    def test_the_final_hop_carries_resolution_and_comment(self):
+        client = self._client([{"id": 341, "name": "\u2716 Close", "to": "Closed"}])
+        result, _ = run_cli(_mod, ["path", "X-1", "Closed", "-r", "Fixed", "-c", "done here"], client)
+        assert result.exit_code == 0, result.output
+        _, kwargs = client.post.call_args
+        assert kwargs["data"]["fields"] == {"resolution": {"name": "Fixed"}}
+        assert kwargs["data"]["update"]["comment"][0]["add"]["body"] == "done here"

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -224,3 +224,28 @@ class TestUnknownSpecInDo:
     def test_an_expanded_transition_without_requirements_is_a_real_answer(self):
         assert "fields" in _tf("2", "Done", "Closed")
         assert _mod.required_fields(_tf("2", "Done", "Closed")) == []
+
+
+class TestMalformedExpandedResponse:
+    def test_a_non_dict_entry_falls_back_instead_of_raising(self):
+        """Every caller does t.get(...), so a null member must not reach them."""
+
+        class Client:
+            def get_issue_transitions_full(self, key, expand=None):
+                return {"transitions": [None]}
+
+            def get_issue_transitions(self, key):
+                return [{"id": "1", "name": "Go", "to": "Done"}]
+
+        got = _mod.fetch_transitions(Client(), "X-1")
+        assert got == [{"id": "1", "name": "Go", "to": "Done"}]
+
+    def test_a_well_formed_list_is_still_returned_as_is(self):
+        class Client:
+            def get_issue_transitions_full(self, key, expand=None):
+                return {"transitions": [{"id": "9", "name": "Ok", "to": "Done"}]}
+
+            def get_issue_transitions(self, key):
+                raise AssertionError("must not fall back on a well-formed answer")
+
+        assert _mod.fetch_transitions(Client(), "X-1")[0]["id"] == "9"

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -73,3 +73,72 @@ class TestFindMatchingTransition:
         ts = [_t("Abschließen", "Done")]
         match, _ = _mod.find_matching_transition(ts, "ABSCHLIESSEN")
         assert match["name"] == "Abschließen"
+
+
+def _tf(tid: str, name: str, to: str, required=(), optional=()):
+    """A transition as the API returns it with ``expand=transitions.fields``."""
+    fields = {k: {"required": True} for k in required}
+    fields.update({k: {"required": False} for k in optional})
+    return {"id": tid, "name": name, "to": to, "fields": fields}
+
+
+class TestAmbiguousSelectors:
+    """Two transitions that a name or a target cannot tell apart.
+
+    Both shapes are real, from one Jira DC instance: `✅ QA → Resolved` beside
+    `❌ QA → Reopened` (same label up to an emoji, opposite outcomes), and
+    `✅ Done → Closed` beside `✖ Close → Closed` (same target, different
+    requirements). Returning the first match silently sent a ticket to the wrong
+    place; the resolver must refuse and hand back the candidates instead.
+    """
+
+    QA_PAIR = [
+        _tf("121", "✅ QA", "Resolved"),
+        _tf("281", "❌ QA", "Reopened"),
+    ]
+    CLOSED_PAIR = [
+        _tf("381", "✅ Done", "Closed"),
+        _tf("341", "✖ Close", "Closed", required=("resolution",)),
+    ]
+
+    def test_same_label_up_to_emoji_is_refused(self):
+        match, ambiguous = _mod.find_matching_transition(self.QA_PAIR, "QA")
+        assert match is None
+        assert {t["id"] for t in ambiguous} == {"121", "281"}
+
+    def test_shared_target_status_is_refused(self):
+        match, ambiguous = _mod.find_matching_transition(self.CLOSED_PAIR, "Closed")
+        assert match is None
+        assert {t["id"] for t in ambiguous} == {"381", "341"}
+
+    def test_id_selects_unambiguously(self):
+        match, ambiguous = _mod.find_matching_transition(self.QA_PAIR, "121")
+        assert match["name"] == "✅ QA"
+        assert ambiguous == []
+
+    def test_id_wins_over_a_name_that_would_be_ambiguous(self):
+        match, _ = _mod.find_matching_transition(self.CLOSED_PAIR, "341")
+        assert match["name"] == "✖ Close"
+
+    def test_unambiguous_name_still_resolves(self):
+        match, ambiguous = _mod.find_matching_transition(self.CLOSED_PAIR, "Done")
+        assert match["id"] == "381"
+        assert ambiguous == []
+
+
+class TestFieldSpec:
+    def test_required_fields_read_from_the_screen(self):
+        t = _tf("341", "✖ Close", "Closed", required=("resolution",), optional=("worklog",))
+        assert _mod.required_fields(t) == ["resolution"]
+        assert _mod.settable_fields(t) == ["resolution", "worklog"]
+
+    def test_a_transition_declaring_nothing_requires_nothing(self):
+        assert _mod.required_fields(_tf("381", "✅ Done", "Closed")) == []
+
+    def test_unexpanded_transition_reports_no_requirements(self):
+        """An unexpanded listing cannot express requiredness — it must not pretend to."""
+        assert _mod.required_fields({"id": "1", "name": "x", "to": "y"}) == []
+
+    def test_ambiguity_notes_name_both_candidates(self):
+        notes = _mod._ambiguous_selectors(TestAmbiguousSelectors.CLOSED_PAIR)
+        assert any("381" in n and "341" in n for n in notes)

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -184,3 +184,25 @@ class TestReviewFindings:
 
         notes = _mod._ambiguous_selectors(ts)
         assert any("381" in n and "341" in n for n in notes), "list must flag what do refuses"
+
+
+class TestSecondRoundFindings:
+    def test_unknown_requirements_are_not_reported_as_none(self):
+        """An unexpanded transition has no screen — that is not 'requires nothing'."""
+        unexpanded = {"id": "1", "name": "Go", "to": "Done"}
+        assert "fields" not in unexpanded
+        expanded = _tf("2", "Close", "Closed", required=("resolution",))
+        assert _mod.required_fields(expanded) == ["resolution"]
+
+    def test_missing_hint_offers_the_flag_only_for_resolution(self):
+        hint = _mod._missing_hint(["resolution"])
+        assert "--resolution" in hint
+
+    def test_missing_hint_does_not_point_at_a_flag_that_cannot_help(self):
+        hint = _mod._missing_hint(["assignee", "customfield_10881"])
+        assert "--resolution" not in hint
+        assert "assignee" in hint and "customfield_10881" in hint
+
+    def test_missing_hint_covers_a_mixed_set(self):
+        hint = _mod._missing_hint(["resolution", "assignee"])
+        assert "--resolution" in hint and "assignee" in hint

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -522,3 +522,100 @@ class TestAmbiguityMessageWording:
         assert "differ in what they require" in output
         assert "381" in output
         assert "341" in output
+
+
+class TestPathPostsTheChosenOneNotTheFirst:
+    """Every earlier `path` fixture put the chosen transition at index 0.
+
+    So "posts the chosen id" and "posts transitions[0]" were the same
+    assertion, and substituting one for the other left the whole suite green.
+    These place the choice elsewhere in the list, which is the only arrangement
+    that can tell the two apart.
+    """
+
+    @staticmethod
+    def _client(transitions, status="Open"):
+        client = make_mock_client()
+        client.issue = mock.Mock(return_value={"fields": {"status": {"name": status}}})
+        client.get_issue_transitions = mock.Mock(return_value=transitions)
+        client.set_issue_status = mock.Mock(side_effect=AssertionError("must not resolve by name"))
+        client.post = mock.Mock(return_value={})
+        return client
+
+    def test_a_direct_target_match_that_is_not_first(self):
+        client = self._client(
+            [
+                {"id": 999, "name": "Reopen", "to": "Reopened"},
+                {"id": 341, "name": "Close", "to": "Closed"},
+            ]
+        )
+        result, _ = run_cli(_mod, ["path", "X-1", "Closed"], client)
+        assert result.exit_code == 0, result.output
+        _, kwargs = client.post.call_args
+        assert kwargs["data"]["transition"] == {"id": "341"}
+
+    def test_the_single_forward_step_is_not_the_first_entry(self):
+        """The dangerous shape: `chosen` comes from forward[0], and index 0 is
+        the backward transition that filtering just excluded."""
+        client = self._client(
+            [
+                {"id": 999, "name": "Reopen", "to": "Reopened"},
+                {"id": 500, "name": "Pick up", "to": "Done"},
+            ]
+        )
+        result, _ = run_cli(_mod, ["path", "X-1", "Done"], client)
+        assert result.exit_code == 0, result.output
+        posted = [c.kwargs["data"]["transition"]["id"] for c in client.post.call_args_list]
+        assert posted == ["500"]
+        assert "999" not in posted
+
+
+class TestDoRefusesAMissingRequiredField:
+    """`do` checking required fields before posting is the headline of this
+    branch, and deleting the check outright left every test green: the cases
+    that reach the POST all supply `-r`, and the unexpanded case requires
+    nothing. Nothing drove the command into the refusal."""
+
+    @staticmethod
+    def _client():
+        client = make_mock_client()
+        client.get_issue_transitions_full = mock.Mock(
+            return_value={
+                "transitions": [
+                    {
+                        "id": "341",
+                        "name": "✖ Close",
+                        "to": {"name": "Closed"},
+                        "fields": {"resolution": {"required": True}},
+                    }
+                ]
+            }
+        )
+        client.post = mock.Mock(side_effect=AssertionError("must not post without the required field"))
+        return client
+
+    def test_it_refuses_and_does_not_post(self):
+        client = self._client()
+        result, _ = run_cli(_mod, ["do", "X-1", "341"], client)
+        assert result.exit_code == 1
+        assert "requires: resolution" in result.output
+        client.post.assert_not_called()
+
+    def test_it_says_the_requirement_comes_from_the_screen(self):
+        result, _ = run_cli(_mod, ["do", "X-1", "341"], self._client())
+        assert "transition's own screen" in result.output
+        assert "--resolution" in result.output
+
+    def test_the_dry_run_refuses_too(self):
+        client = self._client()
+        result, _ = run_cli(_mod, ["do", "X-1", "341", "--dry-run"], client)
+        assert result.exit_code == 1
+        assert "Missing required field(s)" in result.output
+
+    def test_supplying_it_clears_the_refusal(self):
+        client = self._client()
+        client.post = mock.Mock(return_value={})
+        result, _ = run_cli(_mod, ["do", "X-1", "341", "-r", "Done"], client)
+        assert result.exit_code == 0, result.output
+        _, kwargs = client.post.call_args
+        assert kwargs["data"]["fields"] == {"resolution": {"name": "Done"}}

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -476,3 +476,47 @@ class TestTransitionFootnotes:
         assert "381" in note
         assert "341" in note
         assert "Select those by ID" in note
+
+
+class TestAmbiguityMessageWording:
+    """The refusal must not claim the candidates differ by destination.
+
+    The case that motivated the branch is two transitions with the SAME target
+    -- `✅ Done → Closed` beside `✖ Close → Closed` -- differing in what their
+    screens require. Telling the reader they "lead to different places" points
+    at the one column where they agree.
+    """
+
+    @staticmethod
+    def _refuse_shared_target():
+        client = make_mock_client()
+        client.get_issue_transitions_full = mock.Mock(
+            return_value={
+                "transitions": [
+                    {"id": "381", "name": "✅ Done", "to": {"name": "Closed"}, "fields": {}},
+                    {
+                        "id": "341",
+                        "name": "✖ Close",
+                        "to": {"name": "Closed"},
+                        "fields": {"resolution": {"required": True}},
+                    },
+                ]
+            }
+        )
+        client.post = mock.Mock(side_effect=AssertionError("must not post an ambiguous selector"))
+        result, _ = run_cli(_mod, ["do", "X-1", "Closed"], client)
+        return result
+
+    def test_it_refuses_rather_than_guessing(self):
+        result = self._refuse_shared_target()
+        assert result.exit_code == 1
+        assert "ambiguous" in result.output
+
+    def test_it_does_not_claim_they_lead_elsewhere(self):
+        assert "different places" not in self._refuse_shared_target().output
+
+    def test_it_names_requirements_as_what_can_differ(self):
+        output = self._refuse_shared_target().output
+        assert "differ in what they require" in output
+        assert "381" in output
+        assert "341" in output

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -346,6 +346,18 @@ class TestDoCommandOutput:
         assert "has no id" in result.output
         client.post.assert_not_called()
 
+    def test_the_dry_run_refuses_a_missing_id_too(self):
+        """A dry run that prints `(id None)` and exits 0 reports as safe
+        something that cannot run -- the worse half of the same defect."""
+        client = self._client([{"name": "Go", "to": "Done", "fields": {}}])
+        result = self._run(client, ["do", "X-1", "Go", "--dry-run"])
+        assert result.exit_code == 1
+        assert "has no id" in result.output
+
+    def test_the_dry_run_never_shows_a_none_id(self):
+        client = self._client([{"name": "Go", "to": "Done", "fields": {}}])
+        assert "id None" not in self._run(client, ["do", "X-1", "Go", "--dry-run"]).output
+
     def test_quiet_prints_the_key_alone(self):
         client = self._client([self._DONE])
         result = self._run(client, ["--quiet", "do", "X-1", "Done", "-r", "Fixed"])

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -5,7 +5,10 @@ exact-equality matching forces the caller to reproduce the emoji. The resolver
 adds emoji-tolerant and unique-substring fallbacks on top of exact matching.
 """
 
-from conftest import load_script
+from unittest import mock
+
+from click.testing import CliRunner
+from conftest import load_script, make_mock_client
 
 _mod = load_script("jira-transition", "workflow")
 
@@ -249,3 +252,98 @@ class TestMalformedExpandedResponse:
                 raise AssertionError("must not fall back on a well-formed answer")
 
         assert _mod.fetch_transitions(Client(), "X-1")[0]["id"] == "9"
+
+
+class TestMalformedFieldSpec:
+    """`fields` shapes that raise inside required_fields() rather than falling back."""
+
+    @staticmethod
+    def _client(spec):
+        client = make_mock_client()
+        client.get_issue_transitions_full = mock.Mock(
+            return_value={"transitions": [{"id": "1", "name": "Go", "to": "Done", "fields": spec}]}
+        )
+        client.get_issue_transitions = mock.Mock(return_value=[{"id": "1", "name": "Go", "to": "Done"}])
+        return client
+
+    def test_a_non_mapping_spec_falls_back(self):
+        """`fields: [...]` -- .items() would raise past the fallback."""
+        client = self._client(["resolution"])
+        assert _mod.fetch_transitions(client, "X-1") == [{"id": "1", "name": "Go", "to": "Done"}]
+        client.get_issue_transitions.assert_called_once_with("X-1")
+
+    def test_a_null_field_specification_falls_back(self):
+        """`fields: {"resolution": null}` -- v.get() would raise past the fallback."""
+        client = self._client({"resolution": None})
+        assert _mod.fetch_transitions(client, "X-1") == [{"id": "1", "name": "Go", "to": "Done"}]
+        client.get_issue_transitions.assert_called_once_with("X-1")
+
+    def test_an_absent_fields_key_stays_valid(self):
+        """The unexpanded shape is a legitimate answer, reported as `?` -- not a refetch."""
+        client = make_mock_client()
+        client.get_issue_transitions_full = mock.Mock(
+            return_value={"transitions": [{"id": "1", "name": "Go", "to": "Done"}]}
+        )
+        client.get_issue_transitions = mock.Mock()
+        assert _mod.fetch_transitions(client, "X-1")[0]["id"] == "1"
+        client.get_issue_transitions.assert_not_called()
+
+
+class TestDoCommandOutput:
+    """`do` end to end. Until this class existed no test invoked the command at
+    all, which is how the request path shipped unexercised and how the
+    unknown-spec caveat came to sit in the dry-run branch only."""
+
+    @staticmethod
+    def _client(transitions, expanded=True):
+        client = make_mock_client()
+        if expanded:
+            client.get_issue_transitions_full = mock.Mock(return_value={"transitions": transitions})
+            client.get_issue_transitions = mock.Mock(side_effect=AssertionError("must not fall back"))
+        else:
+            client.get_issue_transitions_full = mock.Mock(return_value={"transitions": [None]})
+            client.get_issue_transitions = mock.Mock(return_value=transitions)
+        client.post = mock.Mock(return_value={})
+        return client
+
+    @staticmethod
+    def _run(client, args):
+        with mock.patch.object(_mod, "LazyJiraClient", return_value=client):
+            return CliRunner().invoke(_mod.cli, args)
+
+    _DONE = {"id": "41", "name": "✅ Done", "to": {"name": "Closed"}, "fields": {"resolution": {"required": True}}}
+
+    def test_the_real_run_prints_the_contract_it_resolved(self):
+        client = self._client([self._DONE])
+        result = self._run(client, ["do", "X-1", "Done", "-r", "Fixed"])
+        assert result.exit_code == 0, result.output
+        assert "Transitioning X-1:" in result.output
+        assert "(id 41)" in result.output
+        assert "Requires: resolution" in result.output
+
+    def test_the_real_run_reports_an_unchecked_spec_too(self):
+        """The drift regression: `?` and the caveat existed only under --dry-run."""
+        client = self._client([{"id": "7", "name": "Go", "to": "Done"}], expanded=False)
+        result = self._run(client, ["do", "X-1", "Go"])
+        assert result.exit_code == 0, result.output
+        assert "Requires: ?" in result.output
+        assert "NOT checked" in result.output
+
+    def test_it_posts_the_id_not_the_name(self):
+        client = self._client([self._DONE])
+        self._run(client, ["do", "X-1", "Done", "-r", "Fixed"])
+        _, kwargs = client.post.call_args
+        assert kwargs["data"]["transition"] == {"id": "41"}
+        assert kwargs["data"]["fields"] == {"resolution": {"name": "Fixed"}}
+
+    def test_an_entry_without_an_id_is_refused_before_posting(self):
+        client = self._client([{"name": "Go", "to": "Done", "fields": {}}])
+        result = self._run(client, ["do", "X-1", "Go"])
+        assert result.exit_code == 1
+        assert "has no id" in result.output
+        client.post.assert_not_called()
+
+    def test_quiet_prints_the_key_alone(self):
+        client = self._client([self._DONE])
+        result = self._run(client, ["--quiet", "do", "X-1", "Done", "-r", "Fixed"])
+        assert result.output.strip() == "X-1"

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -182,7 +182,8 @@ class TestReviewFindings:
             _tf("341", "Close", "✖ Closed", required=("resolution",)),
         ]
         match, ambiguous = _mod.find_matching_transition(ts, "Closed")
-        assert match is None and len(ambiguous) == 2
+        assert match is None
+        assert len(ambiguous) == 2
 
         notes = _mod._ambiguous_selectors(ts)
         assert any("381" in n and "341" in n for n in notes), "list must flag what do refuses"
@@ -203,11 +204,13 @@ class TestSecondRoundFindings:
     def test_missing_hint_does_not_point_at_a_flag_that_cannot_help(self):
         hint = _mod._missing_hint(["assignee", "customfield_10881"])
         assert "--resolution" not in hint
-        assert "assignee" in hint and "customfield_10881" in hint
+        assert "assignee" in hint
+        assert "customfield_10881" in hint
 
     def test_missing_hint_covers_a_mixed_set(self):
         hint = _mod._missing_hint(["resolution", "assignee"])
-        assert "--resolution" in hint and "assignee" in hint
+        assert "--resolution" in hint
+        assert "assignee" in hint
 
 
 class TestUnknownSpecInDo:

--- a/tests/test_transition_match.py
+++ b/tests/test_transition_match.py
@@ -142,3 +142,45 @@ class TestFieldSpec:
     def test_ambiguity_notes_name_both_candidates(self):
         notes = _mod._ambiguous_selectors(TestAmbiguousSelectors.CLOSED_PAIR)
         assert any("381" in n and "341" in n for n in notes)
+
+
+class TestReviewFindings:
+    """Two defects the review caught in the first version of this change."""
+
+    def test_an_empty_expanded_list_is_an_answer_not_a_miss(self):
+        """`{"transitions": []}` means the issue offers none — do not ask again."""
+        calls = {"full": 0, "legacy": 0}
+
+        class Client:
+            def get_issue_transitions_full(self, key, expand=None):
+                calls["full"] += 1
+                return {"transitions": []}
+
+            def get_issue_transitions(self, key):
+                calls["legacy"] += 1
+                raise AssertionError("must not fall back on a valid empty answer")
+
+        assert _mod.fetch_transitions(Client(), "X-1") == []
+        assert calls == {"full": 1, "legacy": 0}
+
+    def test_a_missing_transitions_key_still_falls_back(self):
+        class Client:
+            def get_issue_transitions_full(self, key, expand=None):
+                return {"expand": "transitions"}
+
+            def get_issue_transitions(self, key):
+                return [{"id": "1", "name": "Go", "to": "Done"}]
+
+        assert _mod.fetch_transitions(Client(), "X-1")[0]["id"] == "1"
+
+    def test_ambiguity_notes_normalize_the_target_like_the_matcher(self):
+        """`✅ Closed` and `✖ Closed`: `do` refuses them, so `list` must say why."""
+        ts = [
+            _tf("381", "Done", "✅ Closed"),
+            _tf("341", "Close", "✖ Closed", required=("resolution",)),
+        ]
+        match, ambiguous = _mod.find_matching_transition(ts, "Closed")
+        assert match is None and len(ambiguous) == 2
+
+        notes = _mod._ambiguous_selectors(ts)
+        assert any("381" in n and "341" in n for n in notes), "list must flag what do refuses"

--- a/tests/test_transition_path.py
+++ b/tests/test_transition_path.py
@@ -16,8 +16,13 @@ def _run(args, mock_client=None):
 
 
 def _t(name: str, to: str):
-    """A transition dict in Server/DC shape ({'to': 'Status'})."""
-    return {"id": name, "name": name, "to": to}
+    """A transition dict in Server/DC shape ({'to': 'Status'}).
+
+    The id is deliberately NOT the name. When they were equal, an assertion that
+    `path` posts the id passed just as happily when the implementation posted
+    the name -- it could not fail for the reason it existed.
+    """
+    return {"id": f"id-{name}", "name": name, "to": to}
 
 
 def _client_at(status: str):
@@ -48,7 +53,7 @@ class TestGreedyWalk:
         assert mc.post.call_count == 4
         # Posted by transition id, not by target status name -- `_t` sets id=name.
         final = mc.post.call_args_list[-1]
-        assert final.kwargs["data"]["transition"] == {"id": "Close"}
+        assert final.kwargs["data"]["transition"] == {"id": "id-Close"}
         assert final.kwargs["data"]["fields"] == {"resolution": {"name": "Done"}}
         # Intermediate steps must NOT set a resolution.
         assert "fields" not in mc.post.call_args_list[0].kwargs["data"]
@@ -106,7 +111,7 @@ class TestBackwardDetection:
         result, _ = _run(["path", "ABC-1", "In Progress"], mc)
         assert result.exit_code == 0, result.output
         posted = [c.kwargs["data"]["transition"]["id"] for c in mc.post.call_args_list]
-        assert posted == ["Send to Backlog", "Pick up"]
+        assert posted == ["id-Send to Backlog", "id-Pick up"]
 
 
 class TestMaxStepsValidation:

--- a/tests/test_transition_path.py
+++ b/tests/test_transition_path.py
@@ -51,7 +51,8 @@ class TestGreedyWalk:
 
         assert result.exit_code == 0, result.output
         assert mc.post.call_count == 4
-        # Posted by transition id, not by target status name -- `_t` sets id=name.
+        # Posted by transition id, not by target status name. `_t` keeps the two
+        # distinct, so this fails if the name is posted instead.
         final = mc.post.call_args_list[-1]
         assert final.kwargs["data"]["transition"] == {"id": "id-Close"}
         assert final.kwargs["data"]["fields"] == {"resolution": {"name": "Done"}}

--- a/tests/test_transition_path.py
+++ b/tests/test_transition_path.py
@@ -45,20 +45,20 @@ class TestGreedyWalk:
         result, _ = _run(["path", "NRSIQ-57", "Closed", "--resolution", "Done"], mc)
 
         assert result.exit_code == 0, result.output
-        assert mc.set_issue_status.call_count == 4
-        # Final transition lands on Closed and carries the resolution.
-        final = mc.set_issue_status.call_args_list[-1]
-        assert final.args[1] == "Closed"
-        assert final.kwargs["fields"] == {"resolution": {"name": "Done"}}
+        assert mc.post.call_count == 4
+        # Posted by transition id, not by target status name -- `_t` sets id=name.
+        final = mc.post.call_args_list[-1]
+        assert final.kwargs["data"]["transition"] == {"id": "Close"}
+        assert final.kwargs["data"]["fields"] == {"resolution": {"name": "Done"}}
         # Intermediate steps must NOT set a resolution.
-        assert mc.set_issue_status.call_args_list[0].kwargs["fields"] is None
+        assert "fields" not in mc.post.call_args_list[0].kwargs["data"]
         assert "UAT Stage -> Ready for deployment -> Resolved -> Closed" in result.output
 
     def test_already_at_target_is_noop(self):
         mc = _client_at("Closed")
         result, _ = _run(["path", "NRSIQ-57", "Closed"], mc)
         assert result.exit_code == 0, result.output
-        assert mc.set_issue_status.call_count == 0
+        assert mc.post.call_count == 0
         assert "already in status" in result.output
 
     def test_ambiguous_step_stops_and_lists_options(self):
@@ -69,7 +69,7 @@ class TestGreedyWalk:
         ]
         result, _ = _run(["path", "NRSIQ-57", "Closed"], mc)
         assert result.exit_code == 1, result.output
-        assert mc.set_issue_status.call_count == 0
+        assert mc.post.call_count == 0
         assert "ambiguous next step" in result.output
         assert "In Progress" in result.output and "On Hold" in result.output
 
@@ -78,7 +78,7 @@ class TestGreedyWalk:
         mc.get_issue_transitions.side_effect = _linear_chain()
         result, _ = _run(["path", "NRSIQ-57", "Closed", "--dry-run"], mc)
         assert result.exit_code == 0, result.output
-        assert mc.set_issue_status.call_count == 0
+        assert mc.post.call_count == 0
         assert "DRY RUN" in result.output
         assert "QA passed -> UAT Stage" in result.output
 
@@ -105,7 +105,8 @@ class TestBackwardDetection:
         ]
         result, _ = _run(["path", "ABC-1", "In Progress"], mc)
         assert result.exit_code == 0, result.output
-        assert [c.args[1] for c in mc.set_issue_status.call_args_list] == ["Backlog", "In Progress"]
+        posted = [c.kwargs["data"]["transition"]["id"] for c in mc.post.call_args_list]
+        assert posted == ["Send to Backlog", "Pick up"]
 
 
 class TestMaxStepsValidation:


### PR DESCRIPTION
Jira answers **per transition** what it requires, and this CLI hid all of it. A reviewer therefore had to carry per-project conventions in their head — and got them wrong: twelve status changes went into two tickets that needed two, because a resolution missing from one screen was read as a defect and chased across others.

From the [NRS-4609](https://jira.netresearch.de/browse/NRS-4609) retrospective (tracked as [NRS-4687](https://jira.netresearch.de/browse/NRS-4687)). The operator's own words: *the transitions state the resolution as mandatory when it is mandatory — obey the rules that are in the transitions, in their screens.*

**`list` shows the whole contract.** Fetches with `expand=transitions.fields`, adds Requires / Also-accepts, and names any selector more than one transition answers to. Live, on a real ticket:

```
ID  | Name      | To Status | Requires   | Also accepts
381 | ✅ Done    | Closed    | -          | -
341 | ✖ Close   | Closed    | resolution | assignee, customfield_10881, fixVersions, worklog

Ambiguous by name or target: target 'closed' → 381 (✅ Done), 341 (✖ Close).
Select those by ID — the label and the target status do not identify them.
```

**`do` accepts a transition id.** Neither a label nor a target status is a usable selector: one status can offer `✅ QA → Resolved` beside `❌ QA → Reopened` (differing only by emoji, opposite outcomes), and two transitions can share a target while differing in what they require.

**`do` refuses an ambiguous selector** instead of silently taking the first match, naming the candidates and their ids. This was a real wrong-outcome path, not a theoretical one.

**`do` checks required fields before posting**, in dry-run and for real, and says the requirement comes from the transition's own screen rather than from a convention:

```
$ jira-transition do NRT-4586 341 --dry-run
  Transition: ✖ Close (id 341)
  Requires: resolution
✗ Missing required field(s) for this transition: resolution
```

**Both write paths POST by id now.** They went through `set_issue_status()`, which re-resolves by target status name — so having picked the right transition did not mean issuing it. `get_transition_id_to_status_name()` returns the **first** transition whose target matches, and `None` when none does, so on a ticket offering `✅ Done → Closed` beside `✖ Close → Closed` the choice was a coin flip between two different outcomes.

`path` is included, which the description previously excluded. That exclusion was the problem: this claim was written as a general statement about the file while `path` still posted by name, and it is the same wrong-outcome path the branch exists to close. Its two existing tests asserted `set_issue_status` and are re-anchored on the POST rather than relaxed — then mutation-checked to confirm they still catch what they were written for.

**Verification.** Full suite 882 passed, both ruff gates and markdownlint clean.

Tests were seen red before being counted: three of the five original ambiguity cases against the previous matcher, and twenty-two mutation runs across the review rounds. Twenty-one turned a test red. The one that did not is the useful one — it renamed `path`'s metavar and left the test guarding that metavar green, because the assertion matched a word in the docstring prose rather than the usage line. It asserted nothing, and only a mutation could show that; the three help tests were rewritten against the parsed `Usage:` line and re-mutated.

Four of the runs exist because an earlier batch left three new tests untouched, and three confirm the re-anchored `path` assertions still catch the defects they were written for rather than having been relaxed into passing.

The request path was checked against the live instance, not only in tests, and that mattered: `--dry-run` returns before the POST, so until a reviewer questioned the `json=`/`data=` call, `do`'s actual write had never run in any verification of this branch.

**Output does change**, and that is the point: `list` gains `Requires` and `Also accepts` columns plus an ambiguity footer, and `do` prints the chosen transition's id and requirements — on the real run as well as under `--dry-run`, suppressed by `--quiet` and `--json`. Where the field spec is unavailable the columns show `?` rather than `-`, because "unknown" and "requires nothing" are different statements, and `do` says outright that the pre-check did not run.

**A malformed transition listing falls back instead of raising.** Entries that are not objects, and a `fields` that is present but not a mapping of mappings, would reach `required_fields()` and raise past the very fallback the fetch exists to provide. An absent `fields` key stays valid — that is the unexpanded answer, reported as `?`. A transition carrying no id is refused before the POST rather than at fetch time: falling back there does not recover, because `get_issue_transitions` reads the same endpoint and does `int(transition["id"])`.

**`do`'s help matched the old contract** and now names the id: the usage line offered `STATUS_NAME`, so `--help` alone implied ids were unsupported. `path` keeps `TARGET_STATUS` — it walks toward a status, not a transition — and a test pins that asymmetry. `SKILL.md` carries the same one-liner.

**SonarCloud's four findings on this branch's new code are addressed, not accepted.** Three composite assertions are split so a failure names which half broke. The fourth was `list_transitions` at cognitive complexity 27 against 15 allowed — growth this branch caused, 45 lines to 73 — and it took two passes: extracting `_transition_rows()` brought it to 17, still over, and extracting `_transition_footnotes()` brought it under. Both are pure functions of the transition list, and pulling them out makes the things this branch exists for testable directly rather than only through a rendered table: the `?`-versus-`-` distinction, and the two notes that stop the table from reading as more definite than it is.

The intermediate state is worth recording, because it was reported here as fixed before it was: 27 to 17 is progress and still a finding. The local measurement is `complexipy`, which scores differently from SonarCloud — it is a before/after gauge, and SonarCloud's own re-scan is what settles it. It has now run: **0 open issues on new code.**

**Two defects the suite could not see, found by sweeping for assertions that pass for the wrong reason.** Both were confirmed by injecting the defect and watching all 876 tests stay green, not by argument.

`path` posting `transitions[0]` instead of the transition the walker chose was invisible, because every fixture placed the chosen transition at index 0 — so "posts the chosen id" and "posts the first entry" were the same assertion. The shape that matters is the one where `chosen` comes from the `forward[0]` branch rather than a direct target match: index 0 is then the *backward* transition filtering had just excluded, so the walker would reopen a ticket it was asked to advance.

`do`'s required-field pre-check — the headline of this branch — could be deleted outright with nothing failing. Every case that reached the POST supplied `-r`, and the unexpanded case requires nothing, so no test drove the command into the refusal it exists for. Six tests close both gaps, and each mutation reddens the tests written for it.

**The reference docs taught the opposite and are corrected here.** `references/troubleshooting.md` blamed "passing the transition ID", said `do` expects a target status "not the numeric transition ID", marked `do PROJ-123 311` as `# Wrong`, and prescribed disambiguating by target status "which is unique" — the claim this branch exists to refute, on the page an operator reaches *after* `do` refuses their ambiguous selector. It also had no section for that refusal; it has one now. `references/intent-verbs.md` said the name matches "verbatim" and never mentioned the id.

**Bounded**: no change to the mention gate, to the greedy walk itself, or to the `--json` / `--quiet` shapes. The unexpanded listing remains a fallback if an instance or library version cannot expand.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_0147ZQG3cRLaUUgpYQPozexo)_










