### PR TITLE
docs(changelog): record the unreleased entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
-- The quoted-content claim in the language guard corrected
+- Corrected the quoted-content claim in the language guard: the guard inspects
+  quoted content too, so a quoted German block is reported like any other
 
 ## [3.29.1] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `jira-markup`: a warning when German prose is posted to an English-only project
+
+### Changed
+
+- `jira-communication`: the shipped scripts are declared in `allowed-tools`, not the interpreter
+
+### Fixed
+
+- `jira-comment`: markup findings and language findings are labelled separately
+
+### Documentation
+
+- The quoted-content claim in the language guard corrected
+
 ## [3.29.1] - 2026-08-28
 
 ### Documentation


### PR DESCRIPTION
The `[Unreleased]` section was empty while the work it describes was already on `main`. The release roll needs it filled, so these entries are recorded ahead of the version bump.